### PR TITLE
Only show message when themes have been generated.

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/questions/show.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/show.html
@@ -190,7 +190,7 @@
               <h2 class="govuk-body-s govuk-!-display-block govuk-!-font-weight-bold govuk-!-margin-0">Prevalent themes</h2>
             {% endif %}
 
-            {% if blank_free_text_count and question.has_free_text %}
+            {% if blank_free_text_count and question.has_free_text and themes_exist %}
               {% if blank_free_text_count == 1 %}
                 <p class="govuk-body govuk-!-margin-top-5">There is {{ blank_free_text_count }} response with no free text and this has been excluded from the theme analysis.</p>
               {% else %}

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -58,6 +58,9 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
 
     # TODO - for now default to latest processing run
     processing_run = consultation.latest_processing_run
+    themes_exist = False
+    if processing_run:
+        themes_exist = models.Theme.objects.filter(processing_run=processing_run).exists()
 
     applied_filters = get_applied_filters(request)
     responses = get_filtered_responses(question, applied_filters)
@@ -99,5 +102,6 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
         "outliers_count": outliers_count,
         "outlier_theme_id": outlier_theme.id if outlier_theme else None,
         "scatter_plot_data": scatter_plot_data,
+        "themes_exist": themes_exist
     }
     return render(request, "consultations/questions/show.html", context)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Tidy up that didn't get finished with original change to exclude free text from topic modelling.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
This used to appear even when themes haven't been generated.
Don't display message when there no themes generated yet:
![image](https://github.com/user-attachments/assets/eb84b90b-bd58-4ec8-a234-9964b24b9624)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
https://technologyprogramme.atlassian.net/browse/CON-304

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A