### PR TITLE
Feature/download pipeline

### DIFF
--- a/consultation_analyser/consultations/download_consultation.py
+++ b/consultation_analyser/consultations/download_consultation.py
@@ -16,7 +16,6 @@ def select_keys_from_model(model, keys):
 def consultation_to_json(consultation, processing_run=None):
     """
     Return the consultation in a format compliant with the public schema.
-    Default to latest processing_run if exists.
 
     Raises:
         pydantic.ValidationError: if the generated JSON is not compliant
@@ -25,8 +24,6 @@ def consultation_to_json(consultation, processing_run=None):
     attrs = {}
 
     themes = []
-    if not processing_run:
-        processing_run = consultation.latest_processing_run
 
     if processing_run:
         for theme in processing_run.themes:

--- a/consultation_analyser/consultations/management/commands/generate_themes.py
+++ b/consultation_analyser/consultations/management/commands/generate_themes.py
@@ -123,7 +123,7 @@ class Command(BaseCommand):
         return output_dir
 
     def __save_consultation_with_themes(self, output_dir: Path, consultation: models.Consultation):
-        json_with_themes = consultation_to_json(consultation)
+        json_with_themes = consultation_to_json(consultation, consultation.latest_processing_run)
         f = open(output_dir / "consultation_with_themes.json", "w")
         f.write(json_with_themes)
         f.close()

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -78,45 +78,45 @@
         Add users
       </a>
 
-      <h2 class="govuk-heading-m">All runs of theme generation</h2>
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Link</th>
-            <th scope="col" class="govuk-table__header">Run started at</th>
-            <th scope="col" class="govuk-table__header">Run finished at</th>
-            <th scope="col" class="govuk-table__header">Download</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-        {% for run in processing_runs %}
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <a href="{{ url('consultation_run', kwargs={'consultation_slug': consultation.slug, 'processing_run_slug': run.slug}) }}" class="govuk-link govuk-body govuk-link--no-visited-state">
-                View on frontend
-              </a>
-            </td>
-            <td class="govuk-table__cell">
-              {% if run.started_at %}
-                {{ datetime(run.started_at) }}
-              {% endif %}
-            </td>
-            <td class="govuk-table__cell">
-              {% if run.finished_at %}
-                {{ datetime(run.finished_at) }}
-              {% endif %}
-            </td>
-            <td class="govuk-table__cell">
-              {{ govukButton({
-                'text': "Download JSON",
-                'name': "download_json_" + run.slug
-              }) }}
-            </td>
-          </tr>
-        {% endfor %}
-      </table>
-
       <form method="post" novalidate>{{ csrf_input }}
+        <h2 class="govuk-heading-m">All runs of theme generation</h2>
+          <table class="govuk-table">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Link</th>
+                <th scope="col" class="govuk-table__header">Run started at</th>
+                <th scope="col" class="govuk-table__header">Run finished at</th>
+                <th scope="col" class="govuk-table__header">Download</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            {% for run in processing_runs %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                  <a href="{{ url('consultation_run', kwargs={'consultation_slug': consultation.slug, 'processing_run_slug': run.slug}) }}" class="govuk-link govuk-body govuk-link--no-visited-state">
+                    View on frontend
+                  </a>
+                </td>
+                <td class="govuk-table__cell">
+                  {% if run.started_at %}
+                    {{ datetime(run.started_at) }}
+                  {% endif %}
+                </td>
+                <td class="govuk-table__cell">
+                  {% if run.finished_at %}
+                    {{ datetime(run.finished_at) }}
+                  {% endif %}
+                </td>
+                <td class="govuk-table__cell">
+                  {{ govukButton({
+                    'text': "Download JSON",
+                    'name': "download_json_" + run.slug
+                  }) }}
+                </td>
+              </tr>
+            {% endfor %}
+          </table>
+
         <h2 class="govuk-heading-m">Generate themes</h2>
         <div>
           <p class="govuk-body">

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -132,20 +132,11 @@
         }) }}
 
         <h2 class="govuk-heading-m">Download JSON</h2>
-        <p class="govuk-body">This consultation can be downloaded without themes as a JSON in the <a class="govuk-link" href="/schema/consultation_with_responses_schema.json">ConsultationWithResponses</a> format.</p>
+        <p class="govuk-body">This consultation will be downloaded without themes as a JSON in the <a class="govuk-link" href="/schema/consultation_with_responses_schema.json">ConsultationWithResponses</a> format.</p>
         {{ govukButton({
           'text': "Download JSON (without themes)",
           'name': "download_json"
         }) }}
-
-        {% if total_themes %}
-          <p class="govuk-body">This consultation has themes, so the JSON can also be downloaded in the <a class="govuk-link" href="/schema/consultation_with_responses_and_themes_schema.json">ConsultationWithResponsesAndThemes</a> format. It will contain the themes generated most recently.</p>
-          {{ govukButton({
-            'text': "Download JSON (with themes)",
-            'name': "download_json_themes"
-          }) }}
-        {% endif %}
-
       </form>
     </div>
   </div>

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -132,15 +132,19 @@
         }) }}
 
         <h2 class="govuk-heading-m">Download JSON</h2>
-        {% if total_themes %}
-          <p class="govuk-body">This consultation has themes, so the JSON will be in the <a class="govuk-link" href="/schema/consultation_with_responses_and_themes_schema.json">ConsultationWithResponsesAndThemes</a> format. It will contain the themes generated most recently.</p>
-        {% else %}
-          <p class="govuk-body">This consultations has no themes, this JSON will be in the <a class="govuk-link" href="/schema/consultation_with_responses_schema.json">ConsultationWithResponses</a> format.</p>
-        {% endif %}
+        <p class="govuk-body">This consultation can be downloaded without themes as a JSON in the <a class="govuk-link" href="/schema/consultation_with_responses_schema.json">ConsultationWithResponses</a> format.</p>
         {{ govukButton({
-          'text': "Download JSON",
+          'text': "Download JSON (without themes)",
           'name': "download_json"
         }) }}
+
+        {% if total_themes %}
+          <p class="govuk-body">This consultation has themes, so the JSON can also be downloaded in the <a class="govuk-link" href="/schema/consultation_with_responses_and_themes_schema.json">ConsultationWithResponsesAndThemes</a> format. It will contain the themes generated most recently.</p>
+          {{ govukButton({
+            'text': "Download JSON (with themes)",
+            'name': "download_json_themes"
+          }) }}
+        {% endif %}
 
       </form>
     </div>

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -139,7 +139,7 @@
           <p class="govuk-body">This consultations has no themes, this JSON will be in the <a class="govuk-link" href="/schema/consultation_with_responses_schema.json">ConsultationWithResponses</a> format.</p>
         {% endif %}
         {{ govukButton({
-          'text': "Download latest JSON",
+          'text': "Download JSON",
           'name': "download_json"
         }) }}
 

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -85,6 +85,7 @@
             <th scope="col" class="govuk-table__header">Link</th>
             <th scope="col" class="govuk-table__header">Run started at</th>
             <th scope="col" class="govuk-table__header">Run finished at</th>
+            <th scope="col" class="govuk-table__header">Download</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -104,6 +105,12 @@
               {% if run.finished_at %}
                 {{ datetime(run.finished_at) }}
               {% endif %}
+            </td>
+            <td class="govuk-table__cell">
+              {{ govukButton({
+                'text': "Download JSON",
+                'name': "download_json_" + run.slug
+              }) }}
             </td>
           </tr>
         {% endfor %}
@@ -132,7 +139,7 @@
           <p class="govuk-body">This consultations has no themes, this JSON will be in the <a class="govuk-link" href="/schema/consultation_with_responses_schema.json">ConsultationWithResponses</a> format.</p>
         {% endif %}
         {{ govukButton({
-          'text': "Download JSON",
+          'text': "Download latest JSON",
           'name': "download_json"
         }) }}
 

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -108,10 +108,9 @@
                   {% endif %}
                 </td>
                 <td class="govuk-table__cell">
-                  {{ govukButton({
-                    'text': "Download JSON",
-                    'name': "download_json_" + run.slug
-                  }) }}
+                  <a href="{{ url('download_consultation', kwargs={'consultation_slug': consultation.slug, 'processing_run_slug': run.slug}) }}" class="govuk-link govuk-body govuk-link--no-visited-state">
+                    Download data as JSON
+                  </a>
                 </td>
               </tr>
             {% endfor %}

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -26,7 +26,9 @@ urlpatterns = [
         consultations_users.new,
         name="add_user",
     ),
-	path("download/consultations/<str:consultation_slug>/processing_run/<str:processing_run_slug>/",
-	    consultations.download, name="download_consultation")
-
+    path(
+        "download/consultations/<str:consultation_slug>/processing_run/<str:processing_run_slug>/",
+        consultations.download,
+        name="download_consultation",
+    ),
 ]

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -26,4 +26,7 @@ urlpatterns = [
         consultations_users.new,
         name="add_user",
     ),
+	path("download/consultations/<str:consultation_slug>/processing_run/<str:processing_run_slug>/",
+	    consultations.download, name="download_consultation")
+
 ]

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -81,6 +81,12 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
             response = HttpResponse(consultation_json, content_type="application/json")
             response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
             return response
+        elif "download_json_themes" in request.POST:
+            latest_processing_run = consultation.latest_processing_run
+            consultation_json = consultation_to_json(consultation, latest_processing_run)
+            response = HttpResponse(consultation_json, content_type="application/json")
+            response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
+            return response
 
     except RuntimeError as error:
         messages.error(request, error.args[0])

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -80,12 +80,6 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
             response = HttpResponse(consultation_json, content_type="application/json")
             response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
             return response
-        elif "download_json_themes" in request.POST:
-            latest_processing_run = consultation.latest_processing_run
-            consultation_json = consultation_to_json(consultation, latest_processing_run)
-            response = HttpResponse(consultation_json, content_type="application/json")
-            response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
-            return response
 
     except RuntimeError as error:
         messages.error(request, error.args[0])

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -63,7 +63,23 @@ def get_number_themes_for_processing_run(processing_run):
 @support_login_required
 def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
+    print(request.POST)
     try:
+        download_key = None
+        for key in request.POST:
+            if key.startswith("download_json"):
+                download_key = key
+        if download_key:
+            if download_key == "download_json":
+                consultation_json = consultation_to_json(consultation)
+            else:
+                processing_run_slug = download_key.replace("download_json_", "")
+                processing_run = models.ProcessingRun.objects.get(slug=processing_run_slug)
+                consultation_json = consultation_to_json(consultation, processing_run)
+            response = HttpResponse(consultation_json, content_type="application/json")
+            response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
+            return response
+
         if "generate_themes" in request.POST:
             run_processing_pipeline(consultation)
             messages.success(request, "Consultation data has been sent for processing")
@@ -75,13 +91,6 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
                 messages.success(
                     request, "(Re-)running LLM summarisation on the latest processing run"
                 )
-        elif "download_json" in request.POST:
-            consultation_json = consultation_to_json(consultation)
-            response = HttpResponse(consultation_json, content_type="application/json")
-            response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
-            return response
-        # TODO
-        # elif something with "download_json_" in request.POST, get the relevant processing run
 
     except RuntimeError as error:
         messages.error(request, error.args[0])

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -1,5 +1,4 @@
 from uuid import UUID
-from typing import Optional
 
 from django.contrib import messages
 from django.http import HttpRequest, HttpResponse
@@ -111,8 +110,12 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
 def download(request: HttpRequest, consultation_slug: str, processing_run_slug: str):
     # If no processing_run, defaults to latest if exists
     consultation = models.Consultation.objects.get(slug=consultation_slug)
-    processing_run = models.ProcessingRun.objects.get(consultation=consultation, slug=processing_run_slug)
-    consultation_json = consultation_to_json(consultation=consultation, processing_run=processing_run)
+    processing_run = models.ProcessingRun.objects.get(
+        consultation=consultation, slug=processing_run_slug
+    )
+    consultation_json = consultation_to_json(
+        consultation=consultation, processing_run=processing_run
+    )
     response = HttpResponse(consultation_json, content_type="application/json")
     response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
     return response

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -63,7 +63,6 @@ def get_number_themes_for_processing_run(processing_run):
 @support_login_required
 def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
-    print(request.POST)
     try:
         download_key = None
         for key in request.POST:

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -80,6 +80,8 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
             response = HttpResponse(consultation_json, content_type="application/json")
             response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
             return response
+        # TODO
+        # elif something with "download_json_" in request.POST, get the relevant processing run
 
     except RuntimeError as error:
         messages.error(request, error.args[0])

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from typing import Optional
 
 from django.contrib import messages
 from django.http import HttpRequest, HttpResponse
@@ -108,3 +109,14 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
         "total_with_summaries": total_with_summaries,
     }
     return render(request, "support_console/consultations/show.html", context=context)
+
+
+@support_login_required
+def download(request: HttpRequest, consultation_slug: str, processing_run_slug: str):
+    # If no processing_run, defaults to latest if exists
+    consultation = models.Consultation.objects.get(slug=consultation_slug)
+    processing_run = models.ProcessingRun.objects.get(consultation=consultation, slug=processing_run_slug)
+    consultation_json = consultation_to_json(consultation=consultation, processing_run=processing_run)
+    response = HttpResponse(consultation_json, content_type="application/json")
+    response["Content-Disposition"] = f"attachment; filename={consultation.slug}.json"
+    return response

--- a/tests/unit/test_download_consultation.py
+++ b/tests/unit/test_download_consultation.py
@@ -27,7 +27,9 @@ def test_consultation_to_json(django_app):
     consultation_no_themes_json = json.loads(consultation_to_json(consultation))
     assert "themes" not in consultation_no_themes_json.keys()
 
-    consultation_json = json.loads(consultation_to_json(consultation, processing_run=consultation.latest_processing_run))
+    consultation_json = json.loads(
+        consultation_to_json(consultation, processing_run=consultation.latest_processing_run)
+    )
 
     assert consultation_json["consultation"]["name"] == "My consultation"
 
@@ -49,9 +51,6 @@ def test_consultation_to_json(django_app):
     reuploaded = upload_consultation(file_to_reupload, user)
 
     assert reuploaded
-
-
-
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_download_consultation.py
+++ b/tests/unit/test_download_consultation.py
@@ -3,10 +3,10 @@ import json
 
 import pytest
 
-from consultation_analyser.consultations.download_consultation import consultation_to_json
-from consultation_analyser.consultations.upload_consultation import upload_consultation
 from consultation_analyser import factories
 from consultation_analyser.consultations import models
+from consultation_analyser.consultations.download_consultation import consultation_to_json
+from consultation_analyser.consultations.upload_consultation import upload_consultation
 from consultation_analyser.factories import ConsultationBuilder, UserFactory
 
 
@@ -54,8 +54,12 @@ def test_consultation_to_json_processing_runs(django_app):
     consultation = factories.ConsultationWithThemesFactory()
     first_processing_run = models.ProcessingRun.objects.all().order_by("created_at").first()
     second_processing_run = factories.ProcessingRunFactory(consultation=consultation)
-    made_up_theme = factories.ThemeFactory(processing_run=second_processing_run, short_description="This is my new theme")
-    question = models.Question.objects.filter(section__consultation=consultation, has_free_text=True).first()
+    made_up_theme = factories.ThemeFactory(
+        processing_run=second_processing_run, short_description="This is my new theme"
+    )
+    question = models.Question.objects.filter(
+        section__consultation=consultation, has_free_text=True
+    ).first()
     answer = models.Answer.objects.filter(question=question).first()
     answer.theme = made_up_theme
     answer.save()
@@ -65,5 +69,3 @@ def test_consultation_to_json_processing_runs(django_app):
     assert consultation1 != consultation2
     assert "This is my new theme" not in consultation1
     assert "This is my new theme" in consultation2
-
-

--- a/tests/unit/test_download_consultation.py
+++ b/tests/unit/test_download_consultation.py
@@ -24,7 +24,10 @@ def test_consultation_to_json(django_app):
     answer = consultation_builder.add_answer(question)
     consultation_builder.add_theme(answer)
 
-    consultation_json = json.loads(consultation_to_json(consultation))
+    consultation_no_themes_json = json.loads(consultation_to_json(consultation))
+    assert "themes" not in consultation_no_themes_json.keys()
+
+    consultation_json = json.loads(consultation_to_json(consultation, processing_run=consultation.latest_processing_run))
 
     assert consultation_json["consultation"]["name"] == "My consultation"
 
@@ -46,6 +49,9 @@ def test_consultation_to_json(django_app):
     reuploaded = upload_consultation(file_to_reupload, user)
 
     assert reuploaded
+
+
+
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Add the option to download the data for a given processing run and add this to the support view.

As before, this defaults to the latest processing run.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Download button has been added:
![image](https://github.com/user-attachments/assets/0903daac-a365-43b5-93c6-852aff1ba461)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
Partially answers: https://technologyprogramme.atlassian.net/browse/CON-370 (still outstanding task to make it easy for users to select different processing runs in frontend).

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A