### PR TITLE
only expose admin locally

### DIFF
--- a/consultation_analyser/support_console/decorators.py
+++ b/consultation_analyser/support_console/decorators.py
@@ -1,0 +1,8 @@
+from django.contrib.auth.decorators import staff_member_required
+
+
+def support_login_required(view_func=None):
+    actual_decorator = staff_member_required(login_url="/")
+    if view_func:
+        return actual_decorator(view_func)
+    return actual_decorator

--- a/consultation_analyser/support_console/decorators.py
+++ b/consultation_analyser/support_console/decorators.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.decorators import staff_member_required
+from django.contrib.admin.views.decorators import staff_member_required
 
 
 def support_login_required(view_func=None):

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -1,7 +1,6 @@
 from uuid import UUID
 
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 
@@ -13,9 +12,10 @@ from consultation_analyser.pipeline.backends.types import (
     NO_SUMMARY_STR,
 )
 from consultation_analyser.pipeline.processing import run_llm_summariser, run_processing_pipeline
+from consultation_analyser.support_console.decorators import support_login_required
 
 
-@staff_member_required
+@support_login_required
 def index(request: HttpRequest) -> HttpResponse:
     if request.POST:
         try:
@@ -30,7 +30,7 @@ def index(request: HttpRequest) -> HttpResponse:
     return render(request, "support_console/consultations/index.html", context=context)
 
 
-@staff_member_required
+@support_login_required
 def delete(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     context = {
@@ -60,7 +60,7 @@ def get_number_themes_for_processing_run(processing_run):
     return total_themes, total_with_summaries
 
 
-@staff_member_required
+@support_login_required
 def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     try:

--- a/consultation_analyser/support_console/views/consultations_users.py
+++ b/consultation_analyser/support_console/views/consultations_users.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
+
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -10,9 +10,10 @@ from consultation_analyser.consultations import models
 from consultation_analyser.support_console.forms.add_users_to_consultation_form import (
     AddUsersToConsultationForm,
 )
+from consultation_analyser.support_console.decorators import support_login_required
 
 
-@staff_member_required
+@support_login_required
 def new(request: HttpRequest, consultation_id: UUID):
     consultation = models.Consultation.objects.get(id=consultation_id)
     users = models.User.objects.exclude(id__in=[u.id for u in consultation.users.all()]).all()
@@ -35,7 +36,7 @@ def new(request: HttpRequest, consultation_id: UUID):
     return render(request, "support_console/consultations_users/new.html", context=context)
 
 
-@staff_member_required
+@support_login_required
 def delete(request: HttpRequest, consultation_id: UUID, user_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     user = models.User.objects.get(id=user_id)

--- a/consultation_analyser/support_console/views/consultations_users.py
+++ b/consultation_analyser/support_console/views/consultations_users.py
@@ -1,16 +1,15 @@
 from uuid import UUID
 
 from django.contrib import messages
-
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 
 from consultation_analyser.consultations import models
+from consultation_analyser.support_console.decorators import support_login_required
 from consultation_analyser.support_console.forms.add_users_to_consultation_form import (
     AddUsersToConsultationForm,
 )
-from consultation_analyser.support_console.decorators import support_login_required
 
 
 @support_login_required

--- a/consultation_analyser/support_console/views/pages.py
+++ b/consultation_analyser/support_console/views/pages.py
@@ -1,10 +1,11 @@
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import logout
 from django.http import HttpRequest
 from django.shortcuts import redirect
 
+from consultation_analyser.support_console.decorators import support_login_required
 
-@staff_member_required
+
+@support_login_required
 def sign_out(request: HttpRequest):
     logout(request)
     return redirect("/")

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -1,5 +1,4 @@
 from django.contrib import messages
-from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404, redirect, render
 
@@ -7,15 +6,16 @@ from consultation_analyser.authentication.models import User
 
 from ..forms.edit_user_form import EditUserForm
 from ..forms.new_user_form import NewUserForm
+from consultation_analyser.support_console.decorators import support_login_required
 
 
-@staff_member_required
+@support_login_required
 def index(request: HttpRequest):
     users = User.objects.all().order_by("-created_at")
     return render(request, "support_console/users/index.html", {"users": users})
 
 
-@staff_member_required
+@support_login_required
 def new(request: HttpRequest):
     if not request.POST:
         form = NewUserForm()
@@ -30,7 +30,7 @@ def new(request: HttpRequest):
     return render(request, "support_console/users/new.html", {"form": form})
 
 
-@staff_member_required
+@support_login_required
 def show(request: HttpRequest, user_id: int):
     user = get_object_or_404(User, pk=user_id)
     consultations = user.consultation_set.all()

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -3,10 +3,10 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404, redirect, render
 
 from consultation_analyser.authentication.models import User
+from consultation_analyser.support_console.decorators import support_login_required
 
 from ..forms.edit_user_form import EditUserForm
 from ..forms.new_user_form import NewUserForm
-from consultation_analyser.support_console.decorators import support_login_required
 
 
 @support_login_required

--- a/consultation_analyser/urls.py
+++ b/consultation_analyser/urls.py
@@ -20,13 +20,15 @@ from django.urls import include, path
 
 from consultation_analyser.consultations import urls
 from consultation_analyser.error_pages import views as error_views
-from consultation_analyser.support_console import urls as support_console_urls
 from consultation_analyser.hosting_environment import HostingEnvironment
+from consultation_analyser.support_console import urls as support_console_urls
 
 handler404 = error_views.error_404
 handler500 = error_views.error_500
 
-adminurlpatterns = [path("admin/", admin.site.urls),]
+adminurlpatterns = [
+    path("admin/", admin.site.urls),
+]
 
 urlpatterns = [
     path("", include(urls)),
@@ -34,4 +36,4 @@ urlpatterns = [
 ]
 
 if HostingEnvironment.is_local():
-	urlpatterns = urlpatterns + adminurlpatterns
+    urlpatterns = urlpatterns + adminurlpatterns

--- a/consultation_analyser/urls.py
+++ b/consultation_analyser/urls.py
@@ -21,12 +21,17 @@ from django.urls import include, path
 from consultation_analyser.consultations import urls
 from consultation_analyser.error_pages import views as error_views
 from consultation_analyser.support_console import urls as support_console_urls
+from consultation_analyser.hosting_environment import HostingEnvironment
 
 handler404 = error_views.error_404
 handler500 = error_views.error_500
 
+adminurlpatterns = [path("admin/", admin.site.urls),]
+
 urlpatterns = [
     path("", include(urls)),
-    path("admin/", admin.site.urls),
     path("support/", include(support_console_urls)),
 ]
+
+if HostingEnvironment.is_local():
+	urlpatterns = urlpatterns + adminurlpatterns


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
I don't think we should have admin in production. We're not using it (and people keep getting redirected to it erroneously).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
In addition to removing `admin` everywhere but local, I had to adapt the `staff_member_required` decorator (defaults to redirect to `admin`).

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check that you can see `/admin/` when running locally. Change your `ENVIRONMENT` env var locally to be "prod" and check you get a 404 when you go to `/admin/`.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A