### PR TITLE
Added .idea in .gitignore and github.sha to build workflows

### DIFF
--- a/.github/workflows/build-gh.yml
+++ b/.github/workflows/build-gh.yml
@@ -1,4 +1,3 @@
-
 name: build
 on:
   push:

--- a/.github/workflows/build-gh.yml
+++ b/.github/workflows/build-gh.yml
@@ -51,6 +51,7 @@ jobs:
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
       INFRASTRUCTURE_FOLDER: "infrastructure"
       DOCKER_BUILD_INSTANCE: ${{ needs.set-vars.outputs.docker-build-instance }}
+      COMMIT_HASH: ${{ github.sha }}
     secrets:
       AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT}}
       AWS_GITHUBRUNNER_PAT_USER: ${{ secrets.AWS_GITHUBRUNNER_PAT_USER }}

--- a/.github/workflows/release-infra.yml
+++ b/.github/workflows/release-infra.yml
@@ -74,6 +74,7 @@ jobs:
       ENVIRONMENT: ${{ needs.set-vars.outputs.environment }}
       PUBLIC_INFRA_DEPLOYMENT: true
       INFRA_CONFIG_REPO: ${{ needs.set-vars.outputs.infra-config-repo }}
+      IMAGE_TAG: ${{ github.sha }}
     secrets:
       AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT }}
       AWS_GITHUBRUNNER_PAT_USER: ${{ secrets.AWS_GITHUBRUNNER_PAT_USER }}

--- a/.github/workflows/run_precommit.yml
+++ b/.github/workflows/run_precommit.yml
@@ -17,4 +17,3 @@ jobs:
       with:
         python-version-file: 'pyproject.toml'
     - uses: pre-commit/action@v3.0.1
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,5 +69,3 @@ jobs:
           DATABASE_URL: psql://pguser:pgpass@postgres:5432/consultations_test
           BATCH_JOB_QUEUE: dummy-queue
           BATCH_JOB_DEFINITION: dummy-definition
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -157,7 +157,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Frontend
 node_modules


### PR DESCRIPTION
## Context

My pycharm .idea files aren't ignored by the gitignore. The shared action build workflows will currently only build main, passing in github.sha will allow the branch that started the workflow to build (useful if you ever want to manually build a previous or future commit)

## Changes proposed in this pull request

- Changed gitignore
- Added github.sha to build workflows

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo