### PR TITLE
Feature/389 restrict users

### DIFF
--- a/consultation_analyser/consultations/middleware.py
+++ b/consultation_analyser/consultations/middleware.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
+
+
+class SupportAppStaffRequiredMiddleware:
+    """Require staff users only for support app."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if request.path.startswith("/support/"):
+            if isinstance(request.user, AnonymousUser):
+                return Http404
+            elif not request.user.is_staff:
+                return Http404
+        return None

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -4,12 +4,15 @@ from magic_link import urls as magic_link_urls
 from .views import consultations, pages, questions, responses, root, schema, sessions
 
 urlpatterns = [
-    path("", root.root),
-    path("how-it-works/", pages.how_it_works),
-    path("schema/", schema.show),
-    path("data-sharing/", pages.data_sharing),
-    path("get-involved/", pages.get_involved),
-    path("privacy/", pages.privacy),
+    # public urls
+    path("", root.root, name="root"),
+    path("how-it-works/", pages.how_it_works, name="how_it_works"),
+    path("schema/", schema.show, name="schema"),
+    path("data-sharing/", pages.data_sharing, name="data_sharing"),
+    path("get-involved/", pages.get_involved, name="get_involved"),
+    path("privacy/", pages.privacy, name="privacy"),
+    path("schema/<str:schema_name>.json", schema.raw_schema, name="raw_schema"),
+    # login required
     path("consultations/", consultations.index, name="consultations"),
     path("consultations/new/", consultations.new, name="new_consultation"),
     path("consultations/<str:consultation_slug>/", consultations.show, name="consultation"),
@@ -18,7 +21,6 @@ urlpatterns = [
         consultations.show,
         name="consultation_run",
     ),
-    path("schema/<str:schema_name>.json", schema.raw_schema),
     path(
         "consultations/<str:consultation_slug>/sections/<str:section_slug>/questions/<str:question_slug>/",
         questions.show,

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
         name="question_responses_runs",
     ),
     # authentication
-    path("sign-in/", sessions.new),
-    path("sign-out/", sessions.destroy),
-    path("magic-link/", include(magic_link_urls)),
+    path("sign-in/", sessions.new, name="sign_in"),
+    path("sign-out/", sessions.destroy, name="sign_out"),
+    path("magic-link/", include(magic_link_urls), name="magic_link"),
 ]

--- a/consultation_analyser/middleware.py
+++ b/consultation_analyser/middleware.py
@@ -9,13 +9,9 @@ class SupportAppStaffRequiredMiddleware:
 
     def __call__(self, request):
         response = self.get_response(request)
-        return response
-
-    def process_view(self, request, view_func, view_args, view_kwargs):
         if request.path.startswith("/support/"):
-            # if isinstance(request.user, AnonymousUser):
-            if not request.user:
+            if not request.user.is_authenticated:
                 return HttpResponseRedirect("/")
             elif not request.user.is_staff:
                 return HttpResponseRedirect("/")
-        return None
+        return response

--- a/consultation_analyser/middleware.py
+++ b/consultation_analyser/middleware.py
@@ -1,5 +1,4 @@
-from django.contrib.auth.models import AnonymousUser
-from django.http import Http404
+from django.http import HttpResponseRedirect
 
 
 class SupportAppStaffRequiredMiddleware:
@@ -14,8 +13,9 @@ class SupportAppStaffRequiredMiddleware:
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if request.path.startswith("/support/"):
-            if isinstance(request.user, AnonymousUser):
-                return Http404
+            # if isinstance(request.user, AnonymousUser):
+            if not request.user:
+                return HttpResponseRedirect("/")
             elif not request.user.is_staff:
-                return Http404
+                return HttpResponseRedirect("/")
         return None

--- a/consultation_analyser/middleware.py
+++ b/consultation_analyser/middleware.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseNotFound
 
 
 class SupportAppStaffRequiredMiddleware:
@@ -11,7 +11,7 @@ class SupportAppStaffRequiredMiddleware:
         response = self.get_response(request)
         if request.path.startswith("/support/"):
             if not request.user.is_authenticated:
-                return HttpResponseRedirect("/")
+                return HttpResponseNotFound()
             elif not request.user.is_staff:
-                return HttpResponseRedirect("/")
+                return HttpResponseNotFound()
         return response

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -17,8 +17,6 @@ from pathlib import Path
 
 import environ
 
-
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -69,7 +67,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "waffle.middleware.WaffleMiddleware",
-	"consultation_analyser.middleware.SupportAppStaffRequiredMiddleware"
+    "consultation_analyser.middleware.SupportAppStaffRequiredMiddleware",
 ]
 
 ROOT_URLCONF = "consultation_analyser.urls"

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -17,6 +17,9 @@ from pathlib import Path
 
 import environ
 
+from consultation_analyser.consultations.middleware import SupportAppStaffRequiredMiddleware
+
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -67,6 +70,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "waffle.middleware.WaffleMiddleware",
+	"SupportAppStaffRequiredMiddleware"
 ]
 
 ROOT_URLCONF = "consultation_analyser.urls"

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import environ
 
-from consultation_analyser.consultations.middleware import SupportAppStaffRequiredMiddleware
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -70,7 +69,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "waffle.middleware.WaffleMiddleware",
-	"SupportAppStaffRequiredMiddleware"
+	"consultation_analyser.middleware.SupportAppStaffRequiredMiddleware"
 ]
 
 ROOT_URLCONF = "consultation_analyser.urls"

--- a/consultation_analyser/support_console/decorators.py
+++ b/consultation_analyser/support_console/decorators.py
@@ -1,8 +1,0 @@
-from django.contrib.admin.views.decorators import staff_member_required
-
-
-def support_login_required(view_func=None):
-    actual_decorator = staff_member_required(login_url="/")
-    if view_func:
-        return actual_decorator(view_func)
-    return actual_decorator

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -4,12 +4,12 @@ from django.urls import path
 from .views import consultations, consultations_users, pages, users
 
 urlpatterns = [
-    path("", lambda request: redirect("/support/consultations/")),
-    path("sign-out/", pages.sign_out),
-    path("users/", users.index),
-    path("users/new/", users.new),
-    path("users/<int:user_id>/", users.show),
-    path("consultations/", consultations.index),
+    path("", lambda request: redirect("/support/consultations/"), name="support"),
+    path("sign-out/", pages.sign_out, name="support_sign_out"),
+    path("users/", users.index, name="users"),
+    path("users/new/", users.new, name="new_user"),
+    path("users/<int:user_id>/", users.show, name="user"),
+    path("consultations/", consultations.index, name="support_consultations"),
     path("consultations/<uuid:consultation_id>/", consultations.show, name="support_consultation"),
     path(
         "consultations/<uuid:consultation_id>/delete/",

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -15,7 +15,7 @@ from consultation_analyser.pipeline.processing import run_llm_summariser, run_pr
 from consultation_analyser.support_console.decorators import support_login_required
 
 
-@support_login_required
+# @support_login_required
 def index(request: HttpRequest) -> HttpResponse:
     if request.POST:
         try:
@@ -30,7 +30,7 @@ def index(request: HttpRequest) -> HttpResponse:
     return render(request, "support_console/consultations/index.html", context=context)
 
 
-@support_login_required
+# @support_login_required
 def delete(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     context = {

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -12,10 +12,8 @@ from consultation_analyser.pipeline.backends.types import (
     NO_SUMMARY_STR,
 )
 from consultation_analyser.pipeline.processing import run_llm_summariser, run_processing_pipeline
-from consultation_analyser.support_console.decorators import support_login_required
 
 
-# @support_login_required
 def index(request: HttpRequest) -> HttpResponse:
     if request.POST:
         try:
@@ -30,7 +28,6 @@ def index(request: HttpRequest) -> HttpResponse:
     return render(request, "support_console/consultations/index.html", context=context)
 
 
-# @support_login_required
 def delete(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     context = {
@@ -60,7 +57,6 @@ def get_number_themes_for_processing_run(processing_run):
     return total_themes, total_with_summaries
 
 
-@support_login_required
 def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     try:
@@ -100,7 +96,6 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     return render(request, "support_console/consultations/show.html", context=context)
 
 
-@support_login_required
 def download(request: HttpRequest, consultation_slug: str, processing_run_slug: str):
     # If no processing_run, defaults to latest if exists
     consultation = models.Consultation.objects.get(slug=consultation_slug)

--- a/consultation_analyser/support_console/views/consultations_users.py
+++ b/consultation_analyser/support_console/views/consultations_users.py
@@ -11,7 +11,6 @@ from consultation_analyser.support_console.forms.add_users_to_consultation_form 
 )
 
 
-# @support_login_required
 def new(request: HttpRequest, consultation_id: UUID):
     consultation = models.Consultation.objects.get(id=consultation_id)
     users = models.User.objects.exclude(id__in=[u.id for u in consultation.users.all()]).all()
@@ -34,7 +33,6 @@ def new(request: HttpRequest, consultation_id: UUID):
     return render(request, "support_console/consultations_users/new.html", context=context)
 
 
-# @support_login_required
 def delete(request: HttpRequest, consultation_id: UUID, user_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     user = models.User.objects.get(id=user_id)

--- a/consultation_analyser/support_console/views/consultations_users.py
+++ b/consultation_analyser/support_console/views/consultations_users.py
@@ -12,7 +12,7 @@ from consultation_analyser.support_console.forms.add_users_to_consultation_form 
 )
 
 
-@support_login_required
+# @support_login_required
 def new(request: HttpRequest, consultation_id: UUID):
     consultation = models.Consultation.objects.get(id=consultation_id)
     users = models.User.objects.exclude(id__in=[u.id for u in consultation.users.all()]).all()
@@ -35,7 +35,7 @@ def new(request: HttpRequest, consultation_id: UUID):
     return render(request, "support_console/consultations_users/new.html", context=context)
 
 
-@support_login_required
+# @support_login_required
 def delete(request: HttpRequest, consultation_id: UUID, user_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
     user = models.User.objects.get(id=user_id)

--- a/consultation_analyser/support_console/views/consultations_users.py
+++ b/consultation_analyser/support_console/views/consultations_users.py
@@ -6,7 +6,6 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 
 from consultation_analyser.consultations import models
-from consultation_analyser.support_console.decorators import support_login_required
 from consultation_analyser.support_console.forms.add_users_to_consultation_form import (
     AddUsersToConsultationForm,
 )

--- a/consultation_analyser/support_console/views/pages.py
+++ b/consultation_analyser/support_console/views/pages.py
@@ -2,8 +2,6 @@ from django.contrib.auth import logout
 from django.http import HttpRequest
 from django.shortcuts import redirect
 
-from consultation_analyser.support_console.decorators import support_login_required
-
 
 # @support_login_required
 def sign_out(request: HttpRequest):

--- a/consultation_analyser/support_console/views/pages.py
+++ b/consultation_analyser/support_console/views/pages.py
@@ -3,7 +3,6 @@ from django.http import HttpRequest
 from django.shortcuts import redirect
 
 
-# @support_login_required
 def sign_out(request: HttpRequest):
     logout(request)
     return redirect("/")

--- a/consultation_analyser/support_console/views/pages.py
+++ b/consultation_analyser/support_console/views/pages.py
@@ -5,7 +5,7 @@ from django.shortcuts import redirect
 from consultation_analyser.support_console.decorators import support_login_required
 
 
-@support_login_required
+# @support_login_required
 def sign_out(request: HttpRequest):
     logout(request)
     return redirect("/")

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -9,13 +9,13 @@ from ..forms.edit_user_form import EditUserForm
 from ..forms.new_user_form import NewUserForm
 
 
-@support_login_required
+# @support_login_required
 def index(request: HttpRequest):
     users = User.objects.all().order_by("-created_at")
     return render(request, "support_console/users/index.html", {"users": users})
 
 
-@support_login_required
+# @support_login_required
 def new(request: HttpRequest):
     if not request.POST:
         form = NewUserForm()
@@ -30,7 +30,7 @@ def new(request: HttpRequest):
     return render(request, "support_console/users/new.html", {"form": form})
 
 
-@support_login_required
+# @support_login_required
 def show(request: HttpRequest, user_id: int):
     user = get_object_or_404(User, pk=user_id)
     consultations = user.consultation_set.all()

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -8,13 +8,11 @@ from ..forms.edit_user_form import EditUserForm
 from ..forms.new_user_form import NewUserForm
 
 
-# @support_login_required
 def index(request: HttpRequest):
     users = User.objects.all().order_by("-created_at")
     return render(request, "support_console/users/index.html", {"users": users})
 
 
-# @support_login_required
 def new(request: HttpRequest):
     if not request.POST:
         form = NewUserForm()
@@ -29,7 +27,6 @@ def new(request: HttpRequest):
     return render(request, "support_console/users/new.html", {"form": form})
 
 
-# @support_login_required
 def show(request: HttpRequest, user_id: int):
     user = get_object_or_404(User, pk=user_id)
     consultations = user.consultation_set.all()

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -3,7 +3,6 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404, redirect, render
 
 from consultation_analyser.authentication.models import User
-from consultation_analyser.support_console.decorators import support_login_required
 
 from ..forms.edit_user_form import EditUserForm
 from ..forms.new_user_form import NewUserForm

--- a/tests/request/test_support_pages.py
+++ b/tests/request/test_support_pages.py
@@ -15,4 +15,4 @@ def test_no_login_support_pages(client):
     for url in support_urls:
         full_url = f"/support/{url}"
         response = client.get(full_url)
-        assert response.status_code == 302  # No access, redirect to admin login
+        assert response.status_code == 404  # No access - 404

--- a/tests/views/test_login_required.py
+++ b/tests/views/test_login_required.py
@@ -1,6 +1,8 @@
 import pytest
 from django.urls import reverse
 
+from consultation_analyser import factories
+from consultation_analyser.consultations.urls import urlpatterns
 
 PUBLIC_URL_NAMES = [
     "root",
@@ -10,6 +12,20 @@ PUBLIC_URL_NAMES = [
     "get_involved",
     "privacy",
 ]
+RAW_SCHEMA_URL_NAMES = ["raw_schema"]
+GENERIC_CONSULTATION_URL_NAMES = ["consultations", "new_consultation"]
+AUTHENTICATION_URL_NAMES = [
+    "sign_in",
+    "sign_out",
+    "magic_link",
+]  # No tests - tested elsewhere, all public
+
+URL_NAMES_TO_EXCLUDE = (
+    PUBLIC_URL_NAMES
+    + RAW_SCHEMA_URL_NAMES
+    + GENERIC_CONSULTATION_URL_NAMES
+    + AUTHENTICATION_URL_NAMES
+)
 
 
 @pytest.mark.django_db
@@ -18,3 +34,102 @@ def test_access_public_urls_no_login(client):
         url = reverse(url_name)
         response = client.get(url)
         assert response.status_code == 200
+    # There are more schema names, won't include them all
+    for schema_name in ["consultation_with_responses_schema", "consultation_schema"]:
+        url = reverse("raw_schema", kwargs={"schema_name": schema_name})
+        response = client.get(url, format="json")
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_access_generic_consultation_urls(client):
+    for url_name in GENERIC_CONSULTATION_URL_NAMES:
+        url = reverse(url_name)
+        # No login should redirect
+        response = client.get(url)
+        assert response.status_code == 302
+        # Any logged in user should be able to access pages
+        user = factories.UserFactory()
+        client.force_login(user)
+        response = client.get(url)
+        assert response.status_code == 200
+        client.logout()
+
+
+def set_up_consultation(user):
+    question = factories.QuestionFactory()
+    section = question.section
+    consultation = section.consultation
+    processing_run = factories.ProcessingRunFactory(consultation=consultation)
+    consultation.users.add(user)
+    consultation.save()
+    possible_args = {
+        "consultation_slug": consultation.slug,
+        "processing_run_slug": processing_run.slug,
+        "section_slug": section.slug,
+        "question_slug": question.slug,
+    }
+    return possible_args
+
+
+def check_expected_status_code(client, url, expected_status_code):
+    response = client.get(url)
+    assert response.status_code == expected_status_code
+
+
+def get_url_for_pattern(url_pattern, possible_args):
+    # Get a dictionary of any args that might occur
+    url_str = str(url_pattern)
+    kwargs = {}
+    for key in possible_args:
+        if key in url_str:
+            kwargs[key] = possible_args[key]
+    url = reverse(url_pattern.name, kwargs=kwargs)
+    return url
+
+
+@pytest.mark.django_db
+def test_consultations_urls_login_required(client):
+    """
+    This tests all URLs by default unless deliberately excluded (special cases).
+
+    This tests that login is required AND that only users who can see the consultation
+    can access pages.
+
+    If you have added a new URL and this test is failing either:
+        (1) it should pass and your view is wrong or
+        (2) add it as a special case to be excluded and write a separate test.
+    """
+
+    user = factories.UserFactory()
+    non_consultation_user = factories.UserFactory()
+    possible_args = set_up_consultation(user)
+
+    # Get all URLs that haven't explicitly been excluded.
+    # Exclude magic links in separate step as potentially more than one.
+    url_patterns_excluding_magic_link = [
+        url_pattern
+        for url_pattern in urlpatterns
+        if not str(url_pattern.pattern).startswith("magic-link")
+    ]
+    url_patterns_to_test = [
+        url_pattern
+        for url_pattern in url_patterns_excluding_magic_link
+        if url_pattern.name not in URL_NAMES_TO_EXCLUDE
+    ]
+
+    for url_pattern in url_patterns_to_test:
+        url = get_url_for_pattern(url_pattern, possible_args)
+
+        # Not logged in - should 404
+        check_expected_status_code(client, url, expected_status_code=404)
+
+        # Logged in with a user for this consultation - 200
+        client.force_login(user)
+        check_expected_status_code(client, url, 200)
+        client.logout()
+
+        # Logged in with a different user - 404
+        client.force_login(non_consultation_user)
+        check_expected_status_code(client, url, 404)
+        client.logout()

--- a/tests/views/test_login_required.py
+++ b/tests/views/test_login_required.py
@@ -1,0 +1,20 @@
+import pytest
+from django.urls import reverse
+
+
+PUBLIC_URL_NAMES = [
+    "root",
+    "how_it_works",
+    "schema",
+    "data_sharing",
+    "get_involved",
+    "privacy",
+]
+
+
+@pytest.mark.django_db
+def test_access_public_urls_no_login(client):
+    for url_name in PUBLIC_URL_NAMES:
+        url = reverse(url_name)
+        response = client.get(url)
+        assert response.status_code == 200

--- a/tests/views/test_support_urls.py
+++ b/tests/views/test_support_urls.py
@@ -1,0 +1,26 @@
+import pytest
+from django.urls import reverse
+
+from consultation_analyser import factories
+
+
+@pytest.mark.django_db
+def test_support_url_access(client):
+    url = reverse("users")
+    # Check anonymous user
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == "/"  # redirect to home
+
+    # Check normal non-staff user can't access
+    user = factories.UserFactory()
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == "/"
+
+    # Check staff user can access
+    user = factories.UserFactory(is_staff=True)
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 200

--- a/tests/views/test_support_urls.py
+++ b/tests/views/test_support_urls.py
@@ -10,14 +10,12 @@ def test_support_url_access(client):
     # Check anonymous user
     response = client.get(url)
     assert response.status_code == 404
-    assert response.url == "/"  # redirect to home
 
     # Check normal non-staff user can't access
     user = factories.UserFactory()
     client.force_login(user)
     response = client.get(url)
     assert response.status_code == 404
-    assert response.url == "/"
 
     # Check staff user can access
     user = factories.UserFactory(is_staff=True)

--- a/tests/views/test_support_urls.py
+++ b/tests/views/test_support_urls.py
@@ -9,14 +9,14 @@ def test_support_url_access(client):
     url = reverse("users")
     # Check anonymous user
     response = client.get(url)
-    assert response.status_code == 302
+    assert response.status_code == 404
     assert response.url == "/"  # redirect to home
 
     # Check normal non-staff user can't access
     user = factories.UserFactory()
     client.force_login(user)
     response = client.get(url)
-    assert response.status_code == 302
+    assert response.status_code == 404
     assert response.url == "/"
 
     # Check staff user can access


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Currently relying on decorators to restrict access to views is fragile. Make this more robust.

There are 2 cases to consider:
1. Making sure only "staff" users can access pages in support.
2. Making pages "login required" by default.

This PR only addresses (1).

(2) can be addressed by these changes in Django 5.1 which is coming imminently: https://docs.djangoproject.com/en/5.1/releases/5.1/#middleware-to-require-authentication-by-default.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
1. Add middleware for support app to check that a user is a staff user before giving them access to a view. 
2. Add tests to check login_required for all consultation URLs - these tests should pick up any new URLs too.

I think the actual improvement for `login_required` is to use this middleware when Django 5.1 is released imminently: https://docs.djangoproject.com/en/5.1/releases/5.1/#middleware-to-require-authentication-by-default. There are existing packages, but they are out of date (pre v5 Django/old versions of Python).

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check you can access the support pages if you're a staff user, and you can't if you're not logged in or a normal user.

- Does it make sense to restrict the middleware to the support app only?
- For the `login_required` restriction, should we just wait to upgrade to Django 5.1 and use: https://docs.djangoproject.com/en/5.1/releases/5.1/#middleware-to-require-authentication-by-default?
- Any ideas what we can do to ensure users can only see consultations they are assigned to? (New test should catch these?)


## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
Partially answers: https://technologyprogramme.atlassian.net/browse/CON-389

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A