### PR TITLE
Feature/404 lower case emails

### DIFF
--- a/consultation_analyser/consultations/views/sessions.py
+++ b/consultation_analyser/consultations/views/sessions.py
@@ -36,6 +36,7 @@ def new(request: HttpRequest):
         form = NewSessionForm(request.POST)
         if form.is_valid():
             email = form.cleaned_data["email"]
+            email = email.lower()
             send_magic_link_if_email_exists(request, email)
             return render(request, "magic_link/link_sent.html")
 

--- a/consultation_analyser/consultations/views/sessions.py
+++ b/consultation_analyser/consultations/views/sessions.py
@@ -14,6 +14,7 @@ from consultation_analyser.hosting_environment import HostingEnvironment
 
 def send_magic_link_if_email_exists(request: HttpRequest, email: str) -> None:
     try:
+        email = email.lower()
         user = User.objects.get(email=email)
         link = MagicLink.objects.create(user=user, redirect_to="/")
         magic_link = request.build_absolute_uri(link.get_absolute_url())
@@ -36,7 +37,6 @@ def new(request: HttpRequest):
         form = NewSessionForm(request.POST)
         if form.is_valid():
             email = form.cleaned_data["email"]
-            email = email.lower()
             send_magic_link_if_email_exists(request, email)
             return render(request, "magic_link/link_sent.html")
 

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -1,15 +1,17 @@
 from django.core import mail
+import pytest
 
 from consultation_analyser.email import send_magic_link_email
 
-
-def test_magic_link_email():
+@pytest.mark.parametrize("email", [("email@example.com",), ("EMAIL@Example.com",)])
+def test_magic_link_email(email):
     send_magic_link_email(
-        to="email@example.com",
+        to=email,
         magic_link="https://example.com",
     )
 
     sent_mail = mail.outbox[0]
     assert sent_mail.subject == "Sign in to Consult"
-    assert ["email@example.com"] == sent_mail.to
+    assert [email] == sent_mail.to
     assert "https://example.com" in sent_mail.body
+

--- a/tests/unit/test_emails.py
+++ b/tests/unit/test_emails.py
@@ -1,7 +1,8 @@
-from django.core import mail
 import pytest
+from django.core import mail
 
 from consultation_analyser.email import send_magic_link_email
+
 
 @pytest.mark.parametrize("email", [("email@example.com",), ("EMAIL@Example.com",)])
 def test_magic_link_email(email):
@@ -14,4 +15,3 @@ def test_magic_link_email(email):
     assert sent_mail.subject == "Sign in to Consult"
     assert [email] == sent_mail.to
     assert "https://example.com" in sent_mail.body
-


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Users couldn't login with emails like "Email@example.com" - expects lowercase (we lowercase emails in the User model).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Try logging in with emails in different cases (not just lower case) and check you can login.

Question - is this the right place to lower case the email? (It could also happen earlier in the view.)

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
https://technologyprogramme.atlassian.net/browse/CON-404

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A