### PR TITLE
Update rds module to explicitly use a postgres db

### DIFF
--- a/infrastructure/postgres.tf
+++ b/infrastructure/postgres.tf
@@ -12,7 +12,10 @@ module "rds" {
   service_sg_ids          = [module.ecs.ecs_sg_id]
   publicly_accessible     = var.publicly_accessible
   securelist_ips          = concat(var.developer_ips, var.internal_ips)
-  secret_tags = {
+  secret_tags             = {
     "platform:secret-purpose" : "general"
   }
+  engine         = "postgres"
+  engine_version = "16.3"
+  family         = "postgres16"
 }

--- a/infrastructure/postgres.tf
+++ b/infrastructure/postgres.tf
@@ -1,5 +1,7 @@
 module "rds" {
-  source                  = "../../i-ai-core-infrastructure//modules/rds"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+#  source = "../../../i-dot-ai-core-terraform-modules//modules/infrastructure/rds"  # For testing local changes
+  source                  = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/rds?ref=v1.0.0-rds"
   vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
   public_subnet_ids_list  = data.terraform_remote_state.vpc.outputs.public_subnets
   private_subnet_ids_list = data.terraform_remote_state.vpc.outputs.private_subnets
@@ -15,7 +17,4 @@ module "rds" {
   secret_tags             = {
     "platform:secret-purpose" : "general"
   }
-  engine         = "postgres"
-  engine_version = "16.3"
-  family         = "postgres16"
 }


### PR DESCRIPTION
## Context

- rds module in core infra has been updated, the rds module usage here needs to be updated to stay the same

## Changes proposed in this pull request

- Add explicit properties to build a postgres rds

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo