### PR TITLE
Use versioned terraform modules

### DIFF
--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -3,7 +3,9 @@ locals {
 }
 
 module "batch_compute" {
-  source          = "../../i-ai-core-infrastructure/modules/batch/batch_compute_environment"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source          = "../../i-ai-core-infrastructure/modules/batch/batch_compute_environment"
+  source = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/batch-compute-environment?ref=v1.0.0-batch-compute-environment"
   account_id      = var.account_id
   name            = local.name
   region          = var.region
@@ -18,7 +20,9 @@ module "batch_compute" {
 }
 
 module "batch_job_definition" {
-  source                  = "../../i-ai-core-infrastructure/modules/batch/batch_job_definitons"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source                  = "../../i-ai-core-infrastructure/modules/batch/batch_job_definitons"
+  source = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/batch-job-definitions?ref=v1.0.0-batch-job-definitions"
   name                    = local.name
   compute_environment_arn = [module.batch_compute.ec2_compute_environment_arn]
   state_bucket            = var.state_bucket

--- a/infrastructure/elasticache.tf
+++ b/infrastructure/elasticache.tf
@@ -1,5 +1,7 @@
 module "elasticache" {
-  source          = "../../i-ai-core-infrastructure//modules/elasticache"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source          = "../../i-ai-core-infrastructure//modules/elasticache"
+  source = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/elasticache?ref=v1.0.0-elasticache"
   name            = local.name
   vpc_id          = data.terraform_remote_state.vpc.outputs.vpc_id
   private_subnets = data.terraform_remote_state.vpc.outputs.private_subnets

--- a/infrastructure/postgres/main.tf
+++ b/infrastructure/postgres/main.tf
@@ -2,7 +2,9 @@ locals {
   name = "${var.team_name}-${terraform.workspace}-${var.project_name}"
 }
 module "postgres" {
-  source              = "../../../i-ai-core-infrastructure//modules/postgres"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source              = "../../../i-ai-core-infrastructure//modules/postgres"
+  source = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/postgres?ref=v1.0.0-postgres"
   kms_secrets_arn     = data.terraform_remote_state.platform.outputs.kms_key_arn
   name                = local.name
   db_name             = "postgres"

--- a/infrastructure/universal/ecr.tf
+++ b/infrastructure/universal/ecr.tf
@@ -4,6 +4,8 @@ locals {
 }
 
 module "ecr" {
-  source = "../../../i-ai-core-infrastructure//modules/ecr"
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source = "../../../i-ai-core-infrastructure//modules/ecr"
+  source = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecr?ref=v1.0.0-ecr"
   name   = var.project_name
 }


### PR DESCRIPTION
Use versioned terraform modules for batch, elasticache, postgres and ecr.

## Context



## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo