### PR TITLE
remove references to out-of-date form

### DIFF
--- a/consultation_analyser/consultations/jinja2/base.html
+++ b/consultation_analyser/consultations/jinja2/base.html
@@ -58,10 +58,6 @@
         "text": "Privacy notice"
       },
       {
-        "href": "https://www.smartsurvey.co.uk/s/consultation-interest/",
-        "text": "Register your interest"
-      },
-      {
         "href": version.url(),
         "text": version.version_string()
       }

--- a/consultation_analyser/consultations/jinja2/static_pages/get_involved.html
+++ b/consultation_analyser/consultations/jinja2/static_pages/get_involved.html
@@ -9,7 +9,7 @@
 
     <h1 class="govuk-heading-l">Get involved</h1>
     <p class="govuk-body">As Consult is in the test and learn phase we need to learn how it compares to other methods you've used. How you can get involved depends on whether the consultation has already been analysed.</p>
-    <p class="govuk-body">If you would like to take part in one of the ways outlined below please <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/consultation-interest/">register your interest</a>.</p>
+    <p class="govuk-body">If you would like to take part in one of the ways outlined below please contact us at <a class="govuk-link" href="mailto:i-dot-ai-enquiries@cabinetoffice.gov.uk">i-dot-ai-enquiries@cabinetoffice.gov.uk</a>.</p>
 
     <h2 class="govuk-body-l govuk-!-padding-top-5">You have recently <strong>completed</strong> a consultation</h2>
     <p class="govuk-body">If you have recently completed an analysed a consultation the steps are:</p>

--- a/tests/integration/test_home_page.py
+++ b/tests/integration/test_home_page.py
@@ -13,4 +13,4 @@ def test_nav_links(django_app):
     assert "data sharing agreement" in data_sharing_page
 
     get_involved_page = data_sharing_page.click("Get involved", index=0)
-    assert "register your interest" in get_involved_page
+    assert "If you would like to take part" in get_involved_page


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Remove references to an out of date form.
Replace with link to email address.

Doesn't cover rewriting content, have just made sure that it isn't actively wrong.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above.

Before:
![image](https://github.com/user-attachments/assets/15fd119b-14c6-4a97-b029-c935223be268)


After:
![image](https://github.com/user-attachments/assets/1c1c2667-e088-4193-b780-0761b186b85c)

(The version doesn't appear locally, that hasn't been changed in this PR.)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Is this the right email address to use? (Yes, the consult specific one is just for the team.)
- Do you agree that the link should be removed? https://www.smartsurvey.co.uk/s/consultation-interest/ (Checked with Jude, it's fine.)

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A