### PR TITLE
remove dev_admin_user command from readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,7 +170,7 @@ frontend/django_extensions
 # Other
 .env
 .DS_Store
-
+.vscode
 
 # Local .terraform directories
 **/.terraform/*

--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ make dev_environment
 
 This will set up dev and test databases with dummy data. See the definition of that make task for the various steps.
 
-```
-make dev_admin_user
-```
-This will set up the admin account to dev environment.
+It will also set up the admin account to dev environment.
 
 You will have an staff user (i.e. one that can access the admin) created with the username `email@example.com` and the password `admin`.
 


### PR DESCRIPTION
## Context

When I ran the make commands in the README, I got a warning when running `make dev_admin_user` that said the new user already existed.

It looks like `dev_admin_user` is run as part of the previous command `dev_environment`. (See Makefile line 78)

## Changes proposed in this pull request

Remove the line from the PR suggesting users run `make dev_admin_user`.

## Guidance to review

Have I read the Makefile correctly? Does the new order of commands work?

## Link to Trello ticket

_No ticket - this was an adhoc change after I ran the README instructions for the first time_

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo