### PR TITLE
Feature/question overview

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
@@ -8,15 +8,16 @@
   <h1 class="govuk-heading-l">{{ page_title }}</h1>
 
   {% if consultations %}
-    <ul class="govuk-list">
-      {% for consultation in consultations %}
-        <li class="govuk-!-margin-top-2">
-          <a href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-body-l govuk-link govuk-link--no-visited-state">
-            {{ consultation.title }}
-          </a>
-        </li>
-      {% endfor %}
-    </ul>
+    <p class="govuk-body">Click to review themes for your consultations</p>
+      <ul class="govuk-list">
+        {% for consultation in consultations %}
+          <li class="govuk-!-margin-top-2">
+            <a href="{{ url('review_free_text_questions', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-body-l govuk-link govuk-link--no-visited-state">
+              {{ consultation.title }}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
   {% else %}
     <p class="govuk-body">You do not have any consultations</p>
   {% endif %}

--- a/consultation_analyser/consultations/jinja2/consultations/questions/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/index.html
@@ -25,18 +25,16 @@
         <ul class="govuk-body govuk-!-padding-0">
           {% for part in question_parts %}
             <li class="con-question-list__item iai-display-flex govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-left-7 govuk-!-padding-right-7">
-              <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">{{ part.question.text }}</p>
-              <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">{{ part.text }}</p>
+              <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">{{ part.question.text }} {{ part.text }}</p>
               <div class="con-question-list__button-group iai-display-flex govuk-!-margin-left-3">
+                <p class="govuk-body">{{ (part.proportion_of_audited_answers * 100) | round }}% reviewed</p>
                 <a class="iai-icon-button iai-icon-button--with-circle govuk-!-margin-left-5" href="{{ url('show_next_response', kwargs={'consultation_slug': consultation.slug, 'question_slug': part.question.slug}) }}">
                   <svg width="18" height="13" viewBox="0 0 18 13" fill="none" focusable="false" aria-hidden="true">
                     <path d="M1 6.71429C1 6.71429 3.90857 1 9 1C14.0903 1 17 6.71429 17 6.71429C17 6.71429 14.0903 12.4286 9 12.4286C3.90857 12.4286 1 6.71429 1 6.71429Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M9.00003 7.85713C9.30314 7.85713 9.59383 7.73672 9.80816 7.52239C10.0225 7.30806 10.1429 7.01737 10.1429 6.71427C10.1429 6.41116 10.0225 6.12047 9.80816 5.90615C9.59383 5.69182 9.30314 5.57141 9.00003 5.57141C8.69693 5.57141 8.40624 5.69182 8.19191 5.90615C7.97759 6.12047 7.85718 6.41116 7.85718 6.71427C7.85718 7.01737 7.97759 7.30806 8.19191 7.52239C8.40624 7.73672 8.69693 7.85713 9.00003 7.85713Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                   Show next
-                  <span class="govuk-visually-hidden"> - {{ part.text }}</span>
                 </a>
-                <p>Reviewed {{ part.proportion_of_audited_answers * 100 | round(0) }}%
               </div>
             </li>
           {% endfor %}

--- a/consultation_analyser/consultations/jinja2/consultations/questions/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/index.html
@@ -42,12 +42,12 @@
                   <span class="govuk-visually-hidden"> - {{ part.text }}</span>
                 </a>
 
-
+                <a class="iai-icon-button iai-icon-button--with-circle govuk-!-margin-left-5" href="{{ url('show_next_response', kwargs={'consultation_slug': consultation.slug, 'question_slug': part.question.slug}) }}">
                   <svg width="18" height="13" viewBox="0 0 18 13" fill="none" focusable="false" aria-hidden="true">
                     <path d="M1 6.71429C1 6.71429 3.90857 1 9 1C14.0903 1 17 6.71429 17 6.71429C17 6.71429 14.0903 12.4286 9 12.4286C3.90857 12.4286 1 6.71429 1 6.71429Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
                     <path d="M9.00003 7.85713C9.30314 7.85713 9.59383 7.73672 9.80816 7.52239C10.0225 7.30806 10.1429 7.01737 10.1429 6.71427C10.1429 6.41116 10.0225 6.12047 9.80816 5.90615C9.59383 5.69182 9.30314 5.57141 9.00003 5.57141C8.69693 5.57141 8.40624 5.69182 8.19191 5.90615C7.97759 6.12047 7.85718 6.41116 7.85718 6.71427C7.85718 7.01737 7.97759 7.30806 8.19191 7.52239C8.40624 7.73672 8.69693 7.85713 9.00003 7.85713Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
-                  Explore responses
+                  Show next
                   <span class="govuk-visually-hidden"> - {{ part.text }}</span>
                 </a>
               </div>

--- a/consultation_analyser/consultations/jinja2/consultations/questions/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/index.html
@@ -28,20 +28,6 @@
               <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">{{ part.question.text }}</p>
               <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">{{ part.text }}</p>
               <div class="con-question-list__button-group iai-display-flex govuk-!-margin-left-3">
-
-
-                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" focusable="false" aria-hidden="true">
-                    <path d="M15 2H9C8.44772 2 8 2.44772 8 3V5C8 5.55228 8.44772 6 9 6H15C15.5523 6 16 5.55228 16 5V3C16 2.44772 15.5523 2 15 2Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M16 4H18C18.5304 4 19.0391 4.21071 19.4142 4.58579C19.7893 4.96086 20 5.46957 20 6V20C20 20.5304 19.7893 21.0391 19.4142 21.4142C19.0391 21.7893 18.5304 22 18 22H6C5.46957 22 4.96086 21.7893 4.58579 21.4142C4.21071 21.0391 4 20.5304 4 20V6C4 5.46957 4.21071 4.96086 4.58579 4.58579C4.96086 4.21071 5.46957 4 6 4H8" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M12 11H16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M12 16H16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M8 11H8.01" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M8 16H8.01" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                  Question summary
-                  <span class="govuk-visually-hidden"> - {{ part.text }}</span>
-                </a>
-
                 <a class="iai-icon-button iai-icon-button--with-circle govuk-!-margin-left-5" href="{{ url('show_next_response', kwargs={'consultation_slug': consultation.slug, 'question_slug': part.question.slug}) }}">
                   <svg width="18" height="13" viewBox="0 0 18 13" fill="none" focusable="false" aria-hidden="true">
                     <path d="M1 6.71429C1 6.71429 3.90857 1 9 1C14.0903 1 17 6.71429 17 6.71429C17 6.71429 14.0903 12.4286 9 12.4286C3.90857 12.4286 1 6.71429 1 6.71429Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
@@ -50,6 +36,7 @@
                   Show next
                   <span class="govuk-visually-hidden"> - {{ part.text }}</span>
                 </a>
+                Reviewed {{ part.proportion_of_auditted_answers * 100 | round(0) }}%
               </div>
             </li>
           {% endfor %}

--- a/consultation_analyser/consultations/jinja2/consultations/questions/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/index.html
@@ -21,7 +21,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <div class="con-question-list">
-        <h2 class="govuk-body govuk-!-font-weight-bold govuk-!-padding-bottom-1 govuk-!-padding-top-5 govuk-!-padding-left-7 govuk-!-padding-right-7">All questions</h2>
+        <h2 class="govuk-body govuk-!-font-weight-bold govuk-!-padding-bottom-1 govuk-!-padding-top-5 govuk-!-padding-left-7 govuk-!-padding-right-7">All free text questions for review</h2>
         <ul class="govuk-body govuk-!-padding-0">
           {% for part in question_parts %}
             <li class="con-question-list__item iai-display-flex govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-left-7 govuk-!-padding-right-7">

--- a/consultation_analyser/consultations/jinja2/consultations/questions/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/index.html
@@ -36,7 +36,7 @@
                   Show next
                   <span class="govuk-visually-hidden"> - {{ part.text }}</span>
                 </a>
-                Reviewed {{ part.proportion_of_auditted_answers * 100 | round(0) }}%
+                <p>Reviewed {{ part.proportion_of_audited_answers * 100 | round(0) }}%
               </div>
             </li>
           {% endfor %}

--- a/consultation_analyser/consultations/jinja2/consultations/questions/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/index.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{%- from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs -%}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% set page_title = consultation.title %}
+
+{% block content %}
+
+  <h1 class="govuk-heading-m">{{ page_title }}</h1>
+  {{ govukBreadcrumbs({
+    "items": [
+      {
+        "text": "Back to your consultations",
+        "href": "/consultations",
+      }
+    ]
+  }) }}
+
+  {%- from "govuk_frontend_jinja/components/breadcrumbs/macro.html" import govukBreadcrumbs -%}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="con-question-list">
+        <h2 class="govuk-body govuk-!-font-weight-bold govuk-!-padding-bottom-1 govuk-!-padding-top-5 govuk-!-padding-left-7 govuk-!-padding-right-7">All questions</h2>
+        <ul class="govuk-body govuk-!-padding-0">
+          {% for part in question_parts %}
+            <li class="con-question-list__item iai-display-flex govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-left-7 govuk-!-padding-right-7">
+              <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">{{ part.question.text }}</p>
+              <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0">{{ part.text }}</p>
+              <div class="con-question-list__button-group iai-display-flex govuk-!-margin-left-3">
+
+
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" focusable="false" aria-hidden="true">
+                    <path d="M15 2H9C8.44772 2 8 2.44772 8 3V5C8 5.55228 8.44772 6 9 6H15C15.5523 6 16 5.55228 16 5V3C16 2.44772 15.5523 2 15 2Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M16 4H18C18.5304 4 19.0391 4.21071 19.4142 4.58579C19.7893 4.96086 20 5.46957 20 6V20C20 20.5304 19.7893 21.0391 19.4142 21.4142C19.0391 21.7893 18.5304 22 18 22H6C5.46957 22 4.96086 21.7893 4.58579 21.4142C4.21071 21.0391 4 20.5304 4 20V6C4 5.46957 4.21071 4.96086 4.58579 4.58579C4.96086 4.21071 5.46957 4 6 4H8" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M12 11H16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M12 16H16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M8 11H8.01" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M8 16H8.01" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  Question summary
+                  <span class="govuk-visually-hidden"> - {{ part.text }}</span>
+                </a>
+
+
+                  <svg width="18" height="13" viewBox="0 0 18 13" fill="none" focusable="false" aria-hidden="true">
+                    <path d="M1 6.71429C1 6.71429 3.90857 1 9 1C14.0903 1 17 6.71429 17 6.71429C17 6.71429 14.0903 12.4286 9 12.4286C3.90857 12.4286 1 6.71429 1 6.71429Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M9.00003 7.85713C9.30314 7.85713 9.59383 7.73672 9.80816 7.52239C10.0225 7.30806 10.1429 7.01737 10.1429 6.71427C10.1429 6.41116 10.0225 6.12047 9.80816 5.90615C9.59383 5.69182 9.30314 5.57141 9.00003 5.57141C8.69693 5.57141 8.40624 5.69182 8.19191 5.90615C7.97759 6.12047 7.85718 6.41116 7.85718 6.71427C7.85718 7.01737 7.97759 7.30806 8.19191 7.52239C8.40624 7.73672 8.69693 7.85713 9.00003 7.85713Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  Explore responses
+                  <span class="govuk-visually-hidden"> - {{ part.text }}</span>
+                </a>
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -157,6 +157,14 @@ class QuestionPart(UUIDPrimaryKeyModel, TimeStampedModel):
     options = models.JSONField(null=True)  # List, null if free-text
     number = models.IntegerField(null=False, default=0)
 
+    def get_proportion_of_auditted_answers(self) -> float:
+        # Only relevant for free text questions
+        total_answers = self.answer_set.count()
+        if total_answers == 0:
+            return 0
+        audited_answers = self.answer_set.filter(is_theme_mapping_audited=True).count()
+        return audited_answers / total_answers
+
     class Meta(UUIDPrimaryKeyModel.Meta, TimeStampedModel.Meta):
         constraints = [
             models.UniqueConstraint(fields=["question", "number"], name="unique_part_per_question"),

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -158,7 +158,7 @@ class QuestionPart(UUIDPrimaryKeyModel, TimeStampedModel):
     number = models.IntegerField(null=False, default=0)
 
     @property
-    def proportion_of_auditted_answers(self) -> float:
+    def proportion_of_audited_answers(self) -> float:
         # Only relevant for free text questions
         total_answers = self.answer_set.count()
         if total_answers == 0:

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -157,7 +157,8 @@ class QuestionPart(UUIDPrimaryKeyModel, TimeStampedModel):
     options = models.JSONField(null=True)  # List, null if free-text
     number = models.IntegerField(null=False, default=0)
 
-    def get_proportion_of_auditted_answers(self) -> float:
+    @property
+    def proportion_of_auditted_answers(self) -> float:
         # Only relevant for free text questions
         total_answers = self.answer_set.count()
         if total_answers == 0:

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -32,6 +32,11 @@ urlpatterns = [
         answers.show,
         name="show_response",
     ),
+    path(
+        "consultations/<str:consultation_slug>/review-free-text-questions/",
+        questions.index,
+        name="review_free_text_questions",
+    ),
     # authentication
     path("sign-in/", sessions.new, name="sign_in"),
     path("sign-out/", sessions.destroy, name="sign_out"),

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
         name="show_response",
     ),
     path(
-        "consultations/<str:consultation_slug>/review-free-text-questions/",
+        "consultations/<str:consultation_slug>/review-questions/",
         questions.index,
         name="review_free_text_questions",
     ),

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -13,8 +13,7 @@ logger = logging.getLogger("upload")
 def index(request: HttpRequest) -> HttpResponse:
     user = request.user
     consultations_for_user = models.Consultation.objects.filter(users=user)
-    is_staff = user.is_staff
-    context = {"consultations": consultations_for_user, "is_staff": is_staff}
+    context = {"consultations": consultations_for_user}
     return render(request, "consultations/consultations/index.html", context)
 
 

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -59,8 +59,6 @@ def show(
 def index(request, consultation_slug: str):
     consultation = get_object_or_404(models.Consultation, slug=consultation_slug)
     question_parts = models.QuestionPart.objects.filter(question__consultation=consultation, type=models.QuestionPart.QuestionType.FREE_TEXT)
-
-
     context = {
         "consultation": consultation,
         "question_parts": question_parts,

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -58,7 +58,9 @@ def show(
 @user_can_see_consultation
 def index(request, consultation_slug: str):
     consultation = get_object_or_404(models.Consultation, slug=consultation_slug)
-    question_parts = models.QuestionPart.objects.filter(question__consultation=consultation, type=models.QuestionPart.QuestionType.FREE_TEXT)
+    question_parts = models.QuestionPart.objects.filter(
+        question__consultation=consultation, type=models.QuestionPart.QuestionType.FREE_TEXT
+    )
     context = {
         "consultation": consultation,
         "question_parts": question_parts,

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -59,10 +59,10 @@ def show(
 def index(request, consultation_slug: str):
     consultation = get_object_or_404(models.Consultation, slug=consultation_slug)
     question_parts = models.QuestionPart.objects.filter(question__consultation=consultation, type=models.QuestionPart.QuestionType.FREE_TEXT)
+
+
     context = {
         "consultation": consultation,
         "question_parts": question_parts,
     }
-    print("Question parts")
-    print(question_parts)
     return render(request, "consultations/questions/index.html", context)

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -53,3 +53,16 @@ def show(
         "highest_theme_count": highest_theme_count,
     }
     return render(request, "consultations/questions/show.html", context)
+
+
+@user_can_see_consultation
+def index(request, consultation_slug: str):
+    consultation = get_object_or_404(models.Consultation, slug=consultation_slug)
+    question_parts = models.QuestionPart.objects.filter(question__consultation=consultation, type=models.QuestionPart.QuestionType.FREE_TEXT)
+    context = {
+        "consultation": consultation,
+        "question_parts": question_parts,
+    }
+    print("Question parts")
+    print(question_parts)
+    return render(request, "consultations/questions/index.html", context)

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -26,6 +26,9 @@ def show(
     total_responses = models.Answer.objects.filter(question_part=question_parts.first()).count()
 
     # Get latest themes for the free text part
+    theme_counts_dict = {}
+    highest_theme_count = 0
+
     if free_text_question_part:
         latest_theme_mappings = models.ThemeMapping.get_latest_theme_mappings_for_question_part(
             part=free_text_question_part
@@ -33,15 +36,12 @@ def show(
         theme_counts = (
             latest_theme_mappings.values("theme").annotate(count=Count("theme")).order_by("-count")
         )
-        highest_theme_count = theme_counts[0]["count"]
-        theme_counts_dict = {
-            models.Theme.objects.get(id=theme_count["theme"]): theme_count["count"]
+        if theme_counts:
+            highest_theme_count = theme_counts[0]["count"]
+            theme_counts_dict = {
+                models.Theme.objects.get(id=theme_count["theme"]): theme_count["count"]
             for theme_count in theme_counts
         }
-        print(theme_counts_dict)
-    else:
-        theme_counts_dict = {}
-        highest_theme_count = 0
 
     context = {
         "consultation_slug": consultation_slug,

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -40,8 +40,8 @@ def show(
             highest_theme_count = theme_counts[0]["count"]
             theme_counts_dict = {
                 models.Theme.objects.get(id=theme_count["theme"]): theme_count["count"]
-            for theme_count in theme_counts
-        }
+                for theme_count in theme_counts
+            }
 
     context = {
         "consultation_slug": consultation_slug,

--- a/tests/unit/models/test_question_part.py
+++ b/tests/unit/models/test_question_part.py
@@ -3,12 +3,11 @@ import pytest
 
 from consultation_analyser.consultations.models import QuestionPart
 from consultation_analyser.factories import (
+    FreeTextAnswerFactory,
     FreeTextQuestionPartFactory,
+    MultipleOptionQuestionPartFactory,
     QuestionFactory,
     SingleOptionQuestionPartFactory,
-    FreeTextAnswerFactory,
-    SingleOptionAnswerFactory,
-    MultipleOptionQuestionPartFactory,
 )
 
 
@@ -28,7 +27,6 @@ def test_only_one_free_text():
         excinfo.match(
             "UNIQUE constraint failed: consultations_questionpart.question_id, consultations_questionpart.type"
         )
-
 
 
 @pytest.mark.django_db

--- a/tests/unit/models/test_question_part.py
+++ b/tests/unit/models/test_question_part.py
@@ -6,6 +6,9 @@ from consultation_analyser.factories import (
     FreeTextQuestionPartFactory,
     QuestionFactory,
     SingleOptionQuestionPartFactory,
+    FreeTextAnswerFactory,
+    SingleOptionAnswerFactory,
+    MultipleOptionQuestionPartFactory,
 )
 
 
@@ -25,3 +28,26 @@ def test_only_one_free_text():
         excinfo.match(
             "UNIQUE constraint failed: consultations_questionpart.question_id, consultations_questionpart.type"
         )
+
+
+
+@pytest.mark.django_db
+def test_proportion_of_auditted_answers_no_answers():
+    question_part = FreeTextQuestionPartFactory()
+    assert question_part.proportion_of_audited_answers == 0
+    # Test with other question types to check it doesn't break
+    # In practice, this makes no sense and won't be used
+    question_part = SingleOptionQuestionPartFactory()
+    assert question_part.proportion_of_audited_answers == 0
+    question_part = MultipleOptionQuestionPartFactory()
+    assert question_part.proportion_of_audited_answers == 0
+
+
+@pytest.mark.django_db
+def test_proportion_of_auditted_answers_some_audited():
+    question_part = FreeTextQuestionPartFactory()
+    for _ in range(3):
+        FreeTextAnswerFactory(question_part=question_part, is_theme_mapping_audited=True)
+    for _ in range(2):
+        FreeTextAnswerFactory(question_part=question_part, is_theme_mapping_audited=False)
+    assert question_part.proportion_of_audited_answers == 0.6


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Add a page to list all free-text questions for review. Link to "show next".

This branches off the `feature/add-review-response-themes-form` so that should be merged first.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

On landing page - actually link to pages to review themes.
![image](https://github.com/user-attachments/assets/07260461-d804-44b6-9a9f-39df96d258d5)

I decided to make a separate review page (but basically copied the old page), as I think we might still want to use the existing page for the dashboard.

With dummy data:
![image](https://github.com/user-attachments/assets/695fd434-26fc-4f5c-8e39-cdce73d3b968)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/MHaQW6A4/136-django-evaluation-journey-update-list-questions-view


## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A