### PR TITLE
Bugfix for synthetic data import.

### DIFF
--- a/consultation_analyser/consultations/management/commands/import_synthetic_data.py
+++ b/consultation_analyser/consultations/management/commands/import_synthetic_data.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
                     position = models.SentimentMapping.Position.DISAGREEMENT
                 elif response.get("overall_agreement") == "Conflicted (Undecided)":
                     position = models.SentimentMapping.Position.UNCLEAR
-                
+
                 if position:
                     models.SentimentMapping.objects.create(
                         answer=answer,
@@ -117,7 +117,7 @@ class Command(BaseCommand):
                 models.Answer.objects.create(
                     question_part=multi_choice_qp,
                     respondent=respondents[i],
-                    chosen_options=response["multiple_choice_option"],
+                    chosen_options=[response["multiple_choice_option"]],
                 )
 
     def handle(self, *args, **options):

--- a/tests/commands/test_import_synthetic_data.py
+++ b/tests/commands/test_import_synthetic_data.py
@@ -95,4 +95,4 @@ def test_import_question():
     assert SentimentMapping.objects.get(answer=free_text_answer).position == "AGREEMENT"
 
     multiple_choice_answer = Answer.objects.filter(question_part=multiple_choice_qp).first()
-    assert multiple_choice_answer.chosen_options == "Strongly agree"
+    assert multiple_choice_answer.chosen_options == ["Strongly agree"]


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
The `chosen_options` field should be a list, in some cases there will be multiple chosen options (e.g. corresponding to a check-box question).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A