### PR TITLE
fix S3 IAM policy structure

### DIFF
--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -148,10 +148,10 @@ data "aws_iam_policy_document" "ecs" {
     actions = [
       "s3:List*",
       "s3:Get*",
-      "s3:GetObject",
       "s3:PutObject*"
     ]
     resources = [
+      "arn:aws:s3:::${local.base_env_vars.AWS_BUCKET_NAME}/",
       "arn:aws:s3:::${local.base_env_vars.AWS_BUCKET_NAME}/app_data/*"
     ]
   }


### PR DESCRIPTION
## Context

Adds the S3 bucket name as a resource arn so that ListBuckets can work as expected. I've also removed the redundant GetObjects policy above `s3:Get*` as this statement covers all get actions.


<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo