### PR TITLE
Removed trailing slash from bucket name in ecs execution role iam to …

### DIFF
--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -151,7 +151,7 @@ data "aws_iam_policy_document" "ecs" {
       "s3:PutObject*"
     ]
     resources = [
-      "arn:aws:s3:::${local.base_env_vars.AWS_BUCKET_NAME}/",
+      "arn:aws:s3:::${local.base_env_vars.AWS_BUCKET_NAME}",
       "arn:aws:s3:::${local.base_env_vars.AWS_BUCKET_NAME}/app_data/*"
     ]
   }


### PR DESCRIPTION
…allow bucket access

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo