### PR TITLE
Update the import to run question by question

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -158,7 +158,7 @@ def import_theme_mappings_for_framework(framework: Framework, list_mappings: lis
         )
 
 
-def import_themefinder_data_for_question_part(
+def import_themefinder_data_for_question(
     consultation: Consultation, question_number: int, question_folder: str
 ) -> None:
     logger.info(f"Importing data for question {question_number}")
@@ -207,7 +207,7 @@ def import_all_questions_for_consultation(consultation_title: str, folder_name: 
     for i in range(len(question_folders)):
         question_folder = question_folders[i]
         logger.info(f"Importing data from folder: {question_folder}")
-        import_themefinder_data_for_question_part(
+        import_themefinder_data_for_question(
             consultation=consultation, question_number=(i + 1), question_folder=question_folder
         )
     logger.info(f"Imported all data for consultation: {consultation.title}")

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import.html
@@ -10,18 +10,34 @@
   <div class="govuk-form-group">
     <p class="govuk-label-wrapper">
       <label class="govuk-label govuk-label--l" for="consultation_name">
+        Consultation slug
+      </label>
+      <input class="govuk-input" id="consultation_slug" name="consultation_slug" type="text" required>
+      <div id="s3_key-hint" class="govuk-hint iai-hint">
+        Leave blank if it is a new consultation and add the consultation name below
+      </div>
+    </p>
+  </div>
+
+  <div class="govuk-form-group">
+    <p class="govuk-label-wrapper">
+      <label class="govuk-label govuk-label--l" for="consultation_name">
         Consultation name
       </label>
       <input class="govuk-input" id="consultation_name" name="consultation_name" type="text" required>
+      <div id="s3_key-hint" class="govuk-hint iai-hint">
+        Leave blank unless it is a new consultation or you wish to update the consultation name
+      </div>
     </p>
   </div>
+
   <div class="govuk-form-group">
     <p class="govuk-label-wrapper">
       <label class="govuk-label govuk-label--l" for="path">
         Where are the outputs located?
       </label>
       <div id="s3_key-hint" class="govuk-hint iai-hint">
-        The outputs will be saved in: {{ bucket_name }}/[YOUR PATH] eg {{ bucket_name }}/[CONSULTATION_ID]/06_02_2025_theme_generation/
+        The should be saved in: {{ bucket_name }}/[YOUR PATH] eg {{ bucket_name }}/[CONSULTATION_ID]/06_02_2025_theme_generation/question_1/
       </div>
       <input class="govuk-input" id="path" name="path" type="text">
     </p>

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -10,7 +10,7 @@ from consultation_analyser.consultations import models
 from consultation_analyser.consultations.dummy_data import create_dummy_consultation_from_yaml
 from consultation_analyser.consultations.export_user_theme import export_user_theme
 from consultation_analyser.hosting_environment import HostingEnvironment
-from consultation_analyser.support_console.ingest import import_all_questions_for_consultation
+from consultation_analyser.support_console.ingest import import_themefinder_data_for_question
 
 NO_SUMMARY_STR = "Unable to generate summary for this theme"
 
@@ -107,10 +107,28 @@ def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID)
 
 def import_theme_mapping(request: HttpRequest) -> HttpResponse:
     if request.POST:
+        consultation_slug = request.POST.get("consultation_slug")
         consultation_name = request.POST.get("consultation_name")
         path_to_outputs = request.POST.get("path")
-        import_all_questions_for_consultation(
-            consultation_title=consultation_name, folder_name=path_to_outputs
+        if consultation_slug:
+            consultation = models.Consultation.objects.get(slug=consultation_slug)
+            if consultation_name:
+                consultation.title = consultation_name
+                consultation.save()
+        else:
+            if not consultation_name:
+                consultation_name = "New Consultation"
+            consultation = models.Consultation.objects.create(title=consultation_name)
+
+        question_numbers = models.Question.objects.filter(consultation=consultation).values_list(
+            "number", flat=True
+        )
+        max_existing = max(question_numbers) if question_numbers else 0
+        next_question_number = max_existing + 1
+        import_themefinder_data_for_question(
+            consultation=consultation,
+            question_number=next_question_number,
+            question_folder=path_to_outputs,
         )
         return redirect("/support/consultations/")
     context = {"bucket_name": settings.AWS_BUCKET_NAME}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -157,14 +157,18 @@ def mock_s3_objects(mock_s3_bucket, mapping, mapping2, refined_themes, refined_t
     conn.Object(mock_s3_bucket, "folder/question_0/question.json").put(
         Body=json.dumps({"question": "What do you think?"})
     )
-    conn.Object(mock_s3_bucket, "folder/question_0/updated_mapping.json").put(Body=json.dumps(mapping))
+    conn.Object(mock_s3_bucket, "folder/question_0/updated_mapping.json").put(
+        Body=json.dumps(mapping)
+    )
     conn.Object(mock_s3_bucket, "folder/question_0/themes.json").put(
         Body=json.dumps(refined_themes)
     )
     conn.Object(mock_s3_bucket, "folder/question_1/question.json").put(
         Body=json.dumps({"question": "What do you think this time?"})
     )
-    conn.Object(mock_s3_bucket, "folder/question_1/updated_mapping.json").put(Body=json.dumps(mapping2))
+    conn.Object(mock_s3_bucket, "folder/question_1/updated_mapping.json").put(
+        Body=json.dumps(mapping2)
+    )
     conn.Object(mock_s3_bucket, "folder/question_1/themes.json").put(
         Body=json.dumps(refined_themes2)
     )


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Run the import question by question instead of in one go.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
As before, use the `updated_eva_mapping` data.

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo