### PR TITLE
Export XLSX file with respondent IDs and response URLs

### DIFF
--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -181,6 +181,7 @@ LOGGING = {
         "pipeline": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
         "upload": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
         "import": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
+        "export": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
     },
 }
 

--- a/consultation_analyser/support_console/export_url_guidance.py
+++ b/consultation_analyser/support_console/export_url_guidance.py
@@ -1,27 +1,30 @@
 import logging
 
+import boto3
 import pandas as pd
+from django.conf import settings
 
-from consultation_analyser.consultations.models import QuestionPart, Respondent
+from consultation_analyser.consultations.models import Consultation, QuestionPart, Respondent
 
 logger = logging.getLogger("export")
 
 
-def get_response_id_mapping():
+def get_response_id_mapping(s3_key: str) -> dict:
     # Get the response ID mapping
+    s3 = boto3.client("s3")
+    response = s3.get_object(Bucket=settings.AWS_BUCKET_NAME, Key=s3_key)
+    answer_df = pd.read_excel(response["Body"].read(), sheet_name="Sheet2")
 
-    # TODO: import from S3
-    xls = pd.ExcelFile("downloads/Consultation Data Extract.xlsx")
-    df = pd.read_excel(xls, "Sheet2")
-
-    return df["Response ID"].to_dict()
+    return answer_df["Response ID"].to_dict()
 
 
-def get_key_for_question_part(question_part):
+def get_key_for_question_part(question_part: QuestionPart) -> str:
     return f"Question {question_part.question.number}: {question_part.text}"
 
 
-def get_urls_for_respondent(respondent, consultation, base_url):
+def get_urls_for_respondent(
+    respondent: Respondent, consultation: Consultation, base_url: str
+) -> dict:
     urls = {}
 
     # Not all respondents have answered all questions, but we should provide a string for each question for the xlsx export formatting
@@ -35,8 +38,10 @@ def get_urls_for_respondent(respondent, consultation, base_url):
     return urls
 
 
-def get_urls_for_consultation(consultation, base_url):
-    response_id_mapping = get_response_id_mapping()
+def get_urls_for_consultation(
+    consultation: Consultation, base_url: str, s3_key: str
+) -> pd.DataFrame:
+    response_id_mapping = get_response_id_mapping(s3_key)
 
     data = []
 
@@ -57,6 +62,6 @@ def get_urls_for_consultation(consultation, base_url):
 
             data.append(respondent_data)
         except Respondent.DoesNotExist:
-            logger.error(f"Respondent with themefinder_response_id {id} does not exist")
+            logger.info(f"Respondent with themefinder_response_id {id} does not exist")
 
     return pd.DataFrame.from_dict(data)

--- a/consultation_analyser/support_console/export_url_guidance.py
+++ b/consultation_analyser/support_console/export_url_guidance.py
@@ -1,0 +1,62 @@
+import logging
+
+import pandas as pd
+
+from consultation_analyser.consultations.models import QuestionPart, Respondent
+
+logger = logging.getLogger("export")
+
+
+def get_response_id_mapping():
+    # Get the response ID mapping
+
+    # TODO: import from S3
+    xls = pd.ExcelFile("downloads/Consultation Data Extract.xlsx")
+    df = pd.read_excel(xls, "Sheet2")
+
+    return df["Response ID"].to_dict()
+
+
+def get_key_for_question_part(question_part):
+    return f"Question {question_part.question.number}: {question_part.text}"
+
+
+def get_urls_for_respondent(respondent, consultation, base_url):
+    urls = {}
+
+    # Not all respondents have answered all questions, but we should provide a string for each question for the xlsx export formatting
+    for question_part in QuestionPart.objects.filter(question__consultation=consultation):
+        urls[get_key_for_question_part(question_part)] = ""
+
+    for answer in respondent.answer_set.all():
+        urls[get_key_for_question_part(answer.question_part)] = (
+            f"{base_url}consultations/{consultation.slug}/responses/{answer.question_part.question.slug}/{answer.id}/"
+        )
+    return urls
+
+
+def get_urls_for_consultation(consultation, base_url):
+    response_id_mapping = get_response_id_mapping()
+
+    data = []
+
+    for id, respondent_key in response_id_mapping.items():
+        try:
+            logger.info(f"Processing respondent {id}")
+            respondent = Respondent.objects.get(
+                consultation=consultation, themefinder_respondent_id=id
+            )
+            respondent_data = {
+                "Original ID": respondent_key,
+                "Website ID": id,
+            }
+
+            respondent_data = respondent_data | get_urls_for_respondent(
+                respondent, consultation, base_url
+            )
+
+            data.append(respondent_data)
+        except Respondent.DoesNotExist:
+            logger.error(f"Respondent with themefinder_response_id {id} does not exist")
+
+    return pd.DataFrame.from_dict(data)

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/export_urls.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/export_urls.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% set page_title = "Export mapping URLs for consultations" %}
+
+{% block content %}
+<h1 class="govuk-heading-l">{{ page_title }}</h1>
+
+<form method="post" enctype="multipart/form-data" novalidate>{{ csrf_input }}
+  <div class="govuk-form-group">
+    <p class="govuk-label-wrapper">
+      <label class="govuk-label govuk-label--l" for="s3_key">
+        What is the file path of the document with the original department IDs?
+      </label>
+      <div id="s3_key-hint" class="govuk-hint iai-hint">
+        The file will be accessed at: {{ bucket_name }}/[YOUR PATH] eg {{ bucket_name }}/[CONSULTATION_ID]/RAW_DATA/filename.xlsx
+      </div>
+      <input class="govuk-input" id="s3_key" name="s3_key" type="text" aria-describedby="s3_key-hint">
+    </p>
+  </div>
+  {{ govukButton({
+    'text': "Submit",
+    'name': "submit"
+  }) }}
+</form>
+{% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -27,6 +27,12 @@
         </p>
 
         <p class="govuk-body">
+          <a href="{{ url('export_urls_for_consultation', kwargs={'consultation_id': consultation.id}) }}" class="govuk-link govuk-body">
+            Export respondent ID / URL mapping for this consultation
+          </a>
+        </p>
+
+        <p class="govuk-body">
           <a href="{{ url('delete_consultation', kwargs={'consultation_id': consultation.id}) }}" class="govuk-link govuk-link--warning govuk-body">
             Delete this consultation
           </a>

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -41,4 +41,9 @@ urlpatterns = [
         consultations.export_consultation_theme_audit,
         name="export_consultation_theme_audit",
     ),
+    path(
+        "consultations/<uuid:consultation_id>/export-urls/",
+        consultations.export_urls_for_consultation,
+        name="export_urls_for_consultation",
+    ),
 ]

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+import pandas as pd
 from django.conf import settings
 from django.contrib import messages
 from django.core.management import call_command
@@ -10,6 +11,7 @@ from consultation_analyser.consultations import models
 from consultation_analyser.consultations.dummy_data import create_dummy_consultation_from_yaml
 from consultation_analyser.consultations.export_user_theme import export_user_theme
 from consultation_analyser.hosting_environment import HostingEnvironment
+from consultation_analyser.support_console.export_url_guidance import get_urls_for_consultation
 from consultation_analyser.support_console.ingest import import_themefinder_data_for_question
 
 NO_SUMMARY_STR = "Unable to generate summary for this theme"
@@ -133,3 +135,16 @@ def import_theme_mapping(request: HttpRequest) -> HttpResponse:
         return redirect("/support/consultations/")
     context = {"bucket_name": settings.AWS_BUCKET_NAME}
     return render(request, "support_console/consultations/import.html", context=context)
+
+
+def export_urls_for_consultation(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
+    consultation = get_object_or_404(models.Consultation, id=consultation_id)
+    base_url = request.build_absolute_uri("/")
+    df = get_urls_for_consultation(consultation, base_url)
+
+    response = HttpResponse(content_type="application/xlsx")
+    response["Content-Disposition"] = 'attachment; filename="url_mappings.xlsx"'
+    with pd.ExcelWriter(response) as writer:
+        df.to_excel(writer, sheet_name="Sheet 1", index=False)
+
+    return response


### PR DESCRIPTION
## Context
The consultation team we are working with have different respondent IDs to the ones we have on file.

## Changes proposed in this pull request
Creates an view allowing admin users to download the original respondent IDs from S3 and create a reference `.xlsx` file with the respondent ID and their respective response URLs

## Guidance to review
Try running this locally (I'll give you the right S3 key).

## Link to Trello ticket
https://trello.com/c/1l8PlYBq/228-id-spreadsheet-for-scot-gov

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo