### PR TITLE
Feature/export task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: poetry run gunicorn --reload --workers=1 -c consultation_analyser/gunicorn.py consultation_analyser.wsgi
-worker: OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES poetry run python manage.py rqworker default # ENV var permits multithreading on MacOS
+worker: OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES poetry run python manage.py rqworker default --worker-class 'rq.worker.SimpleWorker' # ENV var permits multithreading on MacOS

--- a/consultation_analyser/consultations/export_user_theme.py
+++ b/consultation_analyser/consultations/export_user_theme.py
@@ -15,6 +15,8 @@ from consultation_analyser.consultations.models import (
     ThemeMapping,
 )
 
+from django.db import connection
+
 logger = logging.getLogger("export")
 
 
@@ -22,26 +24,9 @@ def get_timestamp() -> str:
     now = datetime.datetime.now()
     return now.strftime("%Y-%m-%d-%H%M%S")
 
-@job("default")
-def dummy_task_to_delete(input: str) -> None:
-    logger.info(f"Starting dummy task with input: {input}")
-    print("HELLO!!!!!")
-    output = [{"input": input, "output": "dummy_output"}, {"input": input, "output": "dummy_output"}]
-    if not os.path.exists("downloads"):
-        os.makedirs("downloads")
-    with open(
-        f"downloads/dummy.csv", mode="w"
-    ) as file:
-        writer = csv.DictWriter(file, fieldnames=output[0].keys())
-        writer.writeheader()
-        for row in output:
-            writer.writerow(row)
-    logger.info("Finishing dummy task")
-
 
 @job("default")
 def export_user_theme(consultation_slug: str, s3_key: str) -> None:
-    logger.info(f"Starting export for consultation: {consultation_slug}")
     consultation = Consultation.objects.get(slug=consultation_slug)
     output = []
 

--- a/consultation_analyser/consultations/export_user_theme.py
+++ b/consultation_analyser/consultations/export_user_theme.py
@@ -15,8 +15,6 @@ from consultation_analyser.consultations.models import (
     ThemeMapping,
 )
 
-from django.db import connection
-
 logger = logging.getLogger("export")
 
 

--- a/consultation_analyser/consultations/export_user_theme.py
+++ b/consultation_analyser/consultations/export_user_theme.py
@@ -22,6 +22,22 @@ def get_timestamp() -> str:
     now = datetime.datetime.now()
     return now.strftime("%Y-%m-%d-%H%M%S")
 
+@job("default")
+def dummy_task_to_delete(input: str) -> None:
+    logger.info(f"Starting dummy task with input: {input}")
+    print("HELLO!!!!!")
+    output = [{"input": input, "output": "dummy_output"}, {"input": input, "output": "dummy_output"}]
+    if not os.path.exists("downloads"):
+        os.makedirs("downloads")
+    with open(
+        f"downloads/dummy.csv", mode="w"
+    ) as file:
+        writer = csv.DictWriter(file, fieldnames=output[0].keys())
+        writer.writeheader()
+        for row in output:
+            writer.writerow(row)
+    logger.info("Finishing dummy task")
+
 
 @job("default")
 def export_user_theme(consultation_slug: str, s3_key: str) -> None:

--- a/consultation_analyser/consultations/export_user_theme.py
+++ b/consultation_analyser/consultations/export_user_theme.py
@@ -15,7 +15,6 @@ from consultation_analyser.consultations.models import (
     ThemeMapping,
 )
 
-
 logger = logging.getLogger("export")
 
 

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.auth",
+    "django.contrib.admin",
     "waffle",  # feature flags
     "magic_link",
     "consultation_analyser.authentication",
@@ -168,6 +169,10 @@ LOGGING = {
             "format": "[{server_time}] {name}: {message}",
             "style": "{",
         },
+        "rq_console": {
+            "format": "%(asctime)s %(message)s",
+            "datefmt": "%H:%M:%S",
+        },
     },
     "handlers": {
         "stdout": {
@@ -175,13 +180,20 @@ LOGGING = {
             "class": "logging.StreamHandler",
             "stream": sys.stdout,
             "formatter": "pipeline",
-        }
+        },
+        "rq_console": {
+            "level": "DEBUG",
+            "class": "rq.logutils.ColorizingStreamHandler",
+            "formatter": "rq_console",
+            "exclude": ["%(asctime)s"],
+        },
     },
     "loggers": {
         "pipeline": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
         "upload": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
         "import": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
         "export": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
+        "rq.worker": {"handlers": ["rq_console"], "level": "DEBUG"},
     },
 }
 

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -182,8 +182,9 @@ LOGGING = {
             "formatter": "pipeline",
         },
         "rq_console": {
-            "level": "DEBUG",
+            "level": "INFO",
             "class": "rq.logutils.ColorizingStreamHandler",
+            "stream": sys.stdout,
             "formatter": "rq_console",
             "exclude": ["%(asctime)s"],
         },
@@ -193,7 +194,7 @@ LOGGING = {
         "upload": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
         "import": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
         "export": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
-        "rq.worker": {"handlers": ["rq_console"], "level": "DEBUG"},
+        "rq.worker": {"handlers": ["rq_console"], "level": "INFO"},
     },
 }
 

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -1,5 +1,7 @@
+from django.conf import settings
+from django.contrib import admin
 from django.shortcuts import redirect
-from django.urls import path
+from django.urls import include, path
 
 from .views import consultations, consultations_users, pages, users
 
@@ -47,3 +49,10 @@ urlpatterns = [
         name="export_urls_for_consultation",
     ),
 ]
+
+
+if settings.DEBUG:
+    urlpatterns += [
+        path("admin/", admin.site.urls),
+        path("django-rq/", include("django_rq.urls")),
+    ]

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 
 from consultation_analyser.consultations import models
 from consultation_analyser.consultations.dummy_data import create_dummy_consultation_from_yaml
-from consultation_analyser.consultations.export_user_theme import export_user_theme
+from consultation_analyser.consultations.export_user_theme import export_user_theme, dummy_task_to_delete
 from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.support_console.export_url_guidance import get_urls_for_consultation
 from consultation_analyser.support_console.ingest import import_themefinder_data_for_question
@@ -80,6 +80,8 @@ def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID)
     }
 
     if request.method == "POST":
+        dummy_task_to_delete.delay("dummy_task")
+
         s3_key = request.POST.get("s3_key", "")
         try:
             logging.info("Exporting theme audit data - sending to queue")

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -82,7 +82,7 @@ def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID)
     if request.method == "POST":
         s3_key = request.POST.get("s3_key", "")
         try:
-            logging.info(f"Exporting theme audit data - sending to queue")
+            logging.info("Exporting theme audit data - sending to queue")
             # export_user_theme(consultation.slug, s3_key)
             export_user_theme.delay(consultation.slug, s3_key)
         except Exception as e:

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -80,7 +80,7 @@ def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID)
     }
 
     if request.method == "POST":
-        s3_key = request.POST.get("s3_key")
+        s3_key = request.POST.get("s3_key", "")
         try:
             logging.info(f"Exporting theme audit data - sending to queue")
             # export_user_theme(consultation.slug, s3_key)

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -83,12 +83,13 @@ def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID)
         s3_key = request.POST.get("s3_key")
         try:
             logging.info(f"Exporting theme audit data - sending to queue")
+            # export_user_theme(consultation.slug, s3_key)
             export_user_theme.delay(consultation.slug, s3_key)
         except Exception as e:
             messages.error(request, e)
             return render(request, "support_console/consultations/export_audit.html", context)
 
-        messages.success(request, "Consultation theme audit exported")
+        messages.success(request, "Consultation theme audit export started")
         return redirect("/support/consultations/")
 
     return render(request, "support_console/consultations/export_audit.html", context)

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -1,3 +1,4 @@
+import logging
 from uuid import UUID
 
 from django.conf import settings
@@ -12,6 +13,8 @@ from consultation_analyser.consultations.export_user_theme import export_user_th
 from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.support_console.export_url_guidance import get_urls_for_consultation
 from consultation_analyser.support_console.ingest import import_themefinder_data_for_question
+
+logger = logging.getLogger("export")
 
 
 def index(request: HttpRequest) -> HttpResponse:
@@ -79,7 +82,8 @@ def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID)
     if request.method == "POST":
         s3_key = request.POST.get("s3_key")
         try:
-            export_user_theme(consultation.slug, s3_key)
+            logging.info(f"Exporting theme audit data - sending to queue")
+            export_user_theme.delay(consultation.slug, s3_key)
         except Exception as e:
             messages.error(request, e)
             return render(request, "support_console/consultations/export_audit.html", context)

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 
 from consultation_analyser.consultations import models
 from consultation_analyser.consultations.dummy_data import create_dummy_consultation_from_yaml
-from consultation_analyser.consultations.export_user_theme import export_user_theme, dummy_task_to_delete
+from consultation_analyser.consultations.export_user_theme import export_user_theme
 from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.support_console.export_url_guidance import get_urls_for_consultation
 from consultation_analyser.support_console.ingest import import_themefinder_data_for_question
@@ -80,12 +80,9 @@ def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID)
     }
 
     if request.method == "POST":
-        dummy_task_to_delete.delay("dummy_task")
-
         s3_key = request.POST.get("s3_key", "")
         try:
             logging.info("Exporting theme audit data - sending to queue")
-            # export_user_theme(consultation.slug, s3_key)
             export_user_theme.delay(consultation.slug, s3_key)
         except Exception as e:
             messages.error(request, e)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Export takes ages - run as a task using django-rq (already set-up).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

- Run export as a task.
- Add django-rq to admin (and also add django-admin which is a pre-requisite) - so can see the queue at `/support/django-rq/`.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

- Go to `/support/` - click on a consultation.
- Then click "export theme mapping" - then click to export.
- Check the export has been generated (locally, the CSV should be in your `downloads` file in the `consult` repo - it's timestamped).

We decided to switch to `SimpleWorker` as everything else was broken (see Slack for info) - we think it's fine for now, we won't have many jobs.

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/5TukmHs7/246-turn-eval-data-export-into-a-task

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A