### PR TITLE
Put the users in alphabetical order.

### DIFF
--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -10,7 +10,7 @@ from ..forms.new_user_form import NewUserForm
 
 
 def index(request: HttpRequest):
-    users = User.objects.all().order_by("-created_at")
+    users = User.objects.all().order_by("email")
     return render(request, "support_console/users/index.html", {"users": users})
 
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
In `/support/users/` put the users in alphabetical order as otherwise it is really annoying/hard to find the person you want!

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://github.com/user-attachments/assets/828f4184-810e-4231-b3b0-0c6b73bbb925)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A