### PR TITLE
Show themefinder_respondent_id when it is 0

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/answers/show.html
+++ b/consultation_analyser/consultations/jinja2/consultations/answers/show.html
@@ -25,7 +25,7 @@
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       <p class="govuk-body" id="text">
-        Response{% if response.respondent.themefinder_respondent_id %} {{response.respondent.themefinder_respondent_id}}{% endif %}:
+        Response{% if response.respondent.themefinder_respondent_id or response.respondent.themefinder_respondent_id == 0 %} {{response.respondent.themefinder_respondent_id}}{% endif %}:
         <br>
         {{ response.text }}
       </p>


### PR DESCRIPTION
## Context
Currently, when themefinder_respondent_id is 0, no respondent id is shown, because jinja interprets `if response.respondent.themefinder_respondent_id` as falsy.

## Changes proposed in this pull request
Change the Jinja display logic to show the number 0 where expected:

### Themefinder response id = 0
<img width="548" alt="Screenshot 2025-03-13 at 16 50 21" src="https://github.com/user-attachments/assets/30c7184c-cc38-4d69-8e62-b61cda3e826c" />

### Themefinder response id exists but is not 0
<img width="546" alt="Screenshot 2025-03-13 at 16 50 42" src="https://github.com/user-attachments/assets/c84436e1-59c1-4ef3-9737-5349cfaed1bf" />

### Themefinder response id does not exist
<img width="551" alt="Screenshot 2025-03-13 at 16 50 29" src="https://github.com/user-attachments/assets/269e79bf-c641-46ea-8357-559f2203c124" />


## Guidance to review


## Link to Trello ticket
https://trello.com/c/cZ33PVnU/260-bug-response-id-doesnt-display-when-themefinder-id-is-0

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo