### PR TITLE
Feature/updated theme import

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -205,15 +205,3 @@ def import_themefinder_data_for_question_job(
         consultation=consultation, question_number=question_number, question_folder=question_folder
     )
 
-
-def import_all_questions_for_consultation(consultation_title: str, folder_name: str) -> None:
-    # folder in S3 should contain folders named `question_n` for each question
-    consultation = Consultation.objects.create(title=consultation_title)
-    question_folders = get_all_question_subfolders(folder_name, settings.AWS_BUCKET_NAME)
-    for i in range(len(question_folders)):
-        question_folder = question_folders[i]
-        logger.info(f"Importing data from folder: {question_folder}")
-        import_themefinder_data_for_question(
-            consultation=consultation, question_number=(i + 1), question_folder=question_folder
-        )
-    logger.info(f"Imported all data for consultation: {consultation.title}")

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -186,7 +186,7 @@ def import_themefinder_data_for_question(
 
     # Import responses and mappings
     list_theme_mappings = get_themefinder_outputs_for_question(
-        question_folder_key=question_folder, output_name="updated_mapping"
+        question_folder_key=question_folder, output_name="mapping"
     )
     if isinstance(list_theme_mappings, list):
         import_theme_mappings_for_framework(framework, list_theme_mappings)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,21 +7,13 @@ from moto import mock_aws
 
 @pytest.fixture
 def refined_themes():
-    refined_themes = [
-        {
-            "A": "Fair Trade Certification: Ensuring ethical sourcing and supporting sustainable farming practises by requiring fair trade certification for all chocolate products."
-        },
-        {
-            "B": "Sugar and Portion Sizing: Addressing public health concerns by reducing sugar content and implementing stricter portion size regulations for chocolate bars."
-        },
-        {
-            "C": "Transparent Labelling: Improving transparency by mandating clear and comprehensive labelling of ingredients, nutritional information, and potential allergens."
-        },
-        {
-            "D": "Environmental Impact: Introducing measures to minimise the environmental impact of chocolate production, such as reducing packaging waste and promoting eco-friendly practises."
-        },
-        {"E": "No theme: whatever the description of no theme is"},
-    ]
+    refined_themes = {
+        "A": "Fair Trade Certification: Ensuring ethical sourcing and supporting sustainable farming practises by requiring fair trade certification for all chocolate products.",
+        "B": "Sugar and Portion Sizing: Addressing public health concerns by reducing sugar content and implementing stricter portion size regulations for chocolate bars.",
+        "C": "Transparent Labelling: Improving transparency by mandating clear and comprehensive labelling of ingredients, nutritional information, and potential allergens.",
+        "D": "Environmental Impact: Introducing measures to minimise the environmental impact of chocolate production, such as reducing packaging waste and promoting eco-friendly practises.",
+        "E": "No theme: whatever the description of no theme is",
+    }
     return refined_themes
 
 
@@ -103,11 +95,12 @@ def mapping():
 
 @pytest.fixture
 def refined_themes2():
-    refined_themes = [
-        {"A": "Theme A: hello."},
-        {"B": "Theme B: hello again."},
-        {"E": "No theme: whatever the description of no theme is"},
-    ]
+    refined_themes = {
+        "A": "Theme A: hello.",
+        "B": "Theme B: hello again.",
+        "E": "No theme: whatever the description of no theme is",
+    }
+
     return refined_themes
 
 

--- a/tests/unit/models/test_framework.py
+++ b/tests/unit/models/test_framework.py
@@ -79,5 +79,3 @@ def test_get_themes_removed_from_previous_framework():
     assert initial_theme_2 in themes_removed
     assert initial_theme_3 in themes_removed
     assert initial_theme_1 not in themes_removed
-
-

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -4,11 +4,7 @@ from django.conf import settings
 from consultation_analyser import factories
 from consultation_analyser.consultations.models import (
     Answer,
-    Consultation,
     ExecutionRun,
-    Framework,
-    Question,
-    QuestionPart,
     Respondent,
     SentimentMapping,
     Theme,
@@ -16,7 +12,6 @@ from consultation_analyser.consultations.models import (
 )
 from consultation_analyser.support_console.ingest import (
     get_themefinder_outputs_for_question,
-    import_all_questions_for_consultation,
     import_theme_mappings_for_framework,
     import_themes,
 )
@@ -118,28 +113,3 @@ def test_get_themefinder_outputs_for_question(mock_s3_objects, monkeypatch):
     assert len(outputs) == 3
 
 
-@pytest.mark.django_db
-def test_import_all_questions_for_consultation(mock_s3_objects, monkeypatch):
-    monkeypatch.setattr(settings, "AWS_BUCKET_NAME", "test-bucket")
-    consultation_title = "My first consultation"
-    folder_name = "folder"
-
-    import_all_questions_for_consultation(consultation_title, folder_name)
-    consultation = Consultation.objects.get(title=consultation_title)
-    questions = Question.objects.filter(consultation=consultation)
-    assert questions.count() == 2
-    assert questions[0].number == 1
-
-    # Has the first question imported properly?
-    question_part = QuestionPart.objects.get(question=questions[0])
-    answers = Answer.objects.filter(question_part=question_part)
-    assert answers.count() == 6
-    framework = Framework.objects.filter(question_part=question_part).first()
-    assert Theme.objects.filter(framework=framework).count() == 5
-
-    # Has the second question imported properly?
-    question_part = QuestionPart.objects.get(question=questions[1])
-    answers = Answer.objects.filter(question_part=question_part)
-    assert answers.count() == 2
-    framework = Framework.objects.filter(question_part=question_part).first()
-    assert Theme.objects.filter(framework=framework).count() == 3


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
There are some slight changes to the import as the themefinder outputs are different:
* The themes are now a dictionary (instead of a list of dictionaries)
* The name of the file is `mapping.json` instead of `updated_mapping.json`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above. Additionally removed unused function.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Try running locally and check that stuff is imported. See the Google Doc on Slack for how to import for the current consultation.

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A