### PR TITLE
Feature/delete question

### DIFF
--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -110,6 +110,9 @@
               {{ question.text }}
             </td>
             <td class="govuk-table__cell">
+              <a href="{{ url('delete_question', kwargs={'consultation_id': consultation.id, 'question_id': question.id}) }}" class="govuk-link govuk-link--warning govuk-body">
+                Delete this question
+              </a>
             </td>
           </tr>
         {% endfor %}

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -88,4 +88,42 @@
     </div>
   </div>
 
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">Questions</h2>
+      {% if questions %}
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Question number</th>
+            <th scope="col" class="govuk-table__header">Question text</th>
+            <th scope="col" class="govuk-table__header">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        {% for question in questions %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              {{ question.number }}
+            </td>
+            <td class="govuk-table__cell">
+              {{ question.text }}
+            </td>
+            <td class="govuk-table__cell">
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
+      {% else %}
+        <p class="govuk-body">There are no questions associated with this consultation</p>
+      {% endif %}
+
+
+
+    </div>
+  </div>
+
+
+
+
 {% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/questions/delete.html
+++ b/consultation_analyser/support_console/jinja2/support_console/questions/delete.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% set page_title = "Delete question" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ page_title }}</h1>
+  <div>
+    <p class="govuk-body">This question is part of the consultation with title: {{ question.consultation.title }}</p>
+    <p class="govuk-body">Are you sure you want to delete the question: {{ question.text }}</p>
+  </div>
+
+  <br />
+
+  <form method="post" novalidate>{{ csrf_input }}
+    {{ govukButton({
+      'text': "Yes, delete it",
+      'name': "confirm_deletion",
+      'classes': "govuk-button--warning"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/questions/delete.html
+++ b/consultation_analyser/support_console/jinja2/support_console/questions/delete.html
@@ -18,6 +18,11 @@
       'name': "confirm_deletion",
       'classes': "govuk-button--warning"
     }) }}
+    {{ govukButton({
+      'text': "No, go back",
+      'name': "cancel_deletion",
+      'classes': "govuk-button"
+    }) }}
   </form>
 
 {% endblock %}

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import include, path
 
-from .views import consultations, consultations_users, pages, users
+from .views import consultations, consultations_users, pages, questions, users
 
 urlpatterns = [
     path("", lambda request: redirect("/support/consultations/"), name="support"),
@@ -47,6 +47,11 @@ urlpatterns = [
         "consultations/<uuid:consultation_id>/export-urls/",
         consultations.export_urls_for_consultation,
         name="export_urls_for_consultation",
+    ),
+    path(
+        "consultations/<uuid:consultation_id>/questions/<uuid:question_id>/delete/",
+        questions.delete,
+        name="delete_question",
     ),
 ]
 

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -52,10 +52,12 @@ def delete(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
 
 def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = models.Consultation.objects.get(id=consultation_id)
+    questions = models.Question.objects.filter(consultation=consultation).order_by("number")
 
     context = {
         "consultation": consultation,
         "users": consultation.users.all(),
+        "questions": questions,
     }
     return render(request, "support_console/consultations/show.html", context=context)
 

--- a/consultation_analyser/support_console/views/questions.py
+++ b/consultation_analyser/support_console/views/questions.py
@@ -18,5 +18,6 @@ def delete(request: HttpRequest, consultation_id: UUID, question_id: UUID) -> Ht
             question.delete()
             messages.success(request, "The question has been deleted")
             return redirect("/support/consultations/")
-
+        else:
+            return redirect(f"/support/consultations/{consultation_id}/")
     return render(request, "support_console/questions/delete.html", context=context)

--- a/consultation_analyser/support_console/views/questions.py
+++ b/consultation_analyser/support_console/views/questions.py
@@ -1,0 +1,22 @@
+from uuid import UUID
+
+from django.contrib import messages
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+
+from consultation_analyser.consultations import models
+
+
+def delete(request: HttpRequest, consultation_id: UUID, question_id: UUID) -> HttpResponse:
+    question = models.Question.objects.get(consultation__id=consultation_id, id=question_id)
+    context = {
+        "question": question,
+    }
+
+    if request.POST:
+        if "confirm_deletion" in request.POST:
+            question.delete()
+            messages.success(request, "The question has been deleted")
+            return redirect("/support/consultations/")
+
+    return render(request, "support_console/questions/delete.html", context=context)

--- a/tests/integration/test_deleting_question_support.py
+++ b/tests/integration/test_deleting_question_support.py
@@ -1,0 +1,35 @@
+import pytest
+
+from consultation_analyser import factories
+from consultation_analyser.consultations.models import Question
+from tests.helpers import sign_in
+
+
+@pytest.mark.django_db
+def test_deleting_consultation_questions_via_support(django_app):
+    question_part = factories.FreeTextQuestionPartFactory()
+    question = question_part.question
+    consultation = question.consultation
+
+    # given I am an admin user
+    user = factories.UserFactory(email="email@example.com", is_staff=True)
+    consultation.users.add(user)
+
+    sign_in(django_app, user.email)
+
+    # Go to consultation page in support
+    consultations_page = django_app.get(f"/support/consultations/{consultation.id}/")
+
+    # Click delete question
+    delete_confirmation_page = consultations_page.click("Delete this question")
+
+    # Confirm the delete question page URL is correct
+    expected_url = f"/support/consultations/{consultation.id}/questions/{question.id}/delete/"
+    assert delete_confirmation_page.request.path == expected_url
+    assert "Are you sure you want to delete the question" in delete_confirmation_page
+
+    # Confirm deletion
+    delete_confirmation_page.form.submit("confirm_deletion")
+
+    # Check question deleted
+    assert Question.objects.filter(id=question.id).count() == 0

--- a/tests/integration/test_deleting_question_support.py
+++ b/tests/integration/test_deleting_question_support.py
@@ -28,6 +28,18 @@ def test_deleting_consultation_questions_via_support(django_app):
     assert delete_confirmation_page.request.path == expected_url
     assert "Are you sure you want to delete the question" in delete_confirmation_page
 
+    # Cancel deletion
+    delete_confirmation_page.form.submit("cancel_deletion")
+
+    # Check question still exists
+    assert Question.objects.filter(id=question.id).count() == 1
+
+    # Go to consultation page in support
+    consultations_page = django_app.get(f"/support/consultations/{consultation.id}/")
+
+    # Click delete question
+    delete_confirmation_page = consultations_page.click("Delete this question")
+
     # Confirm deletion
     delete_confirmation_page.form.submit("confirm_deletion")
 

--- a/tests/unit/test_delete_question.py
+++ b/tests/unit/test_delete_question.py
@@ -1,0 +1,35 @@
+import pytest
+
+from consultation_analyser import factories
+from consultation_analyser.consultations import models
+
+
+@pytest.mark.django_db
+def test_delete_question():
+    consultation = factories.ConsultationFactory()
+    question = factories.QuestionFactory(consultation=consultation)
+    question_part = factories.FreeTextQuestionPartFactory(question=question)
+    respondent = factories.RespondentFactory(consultation=consultation)
+    answer = factories.FreeTextAnswerFactory(question_part=question_part, respondent=respondent)
+    framework = factories.InitialFrameworkFactory(question_part=question_part)
+    theme = factories.InitialThemeFactory(framework=framework, key="A")
+    factories.ThemeMappingFactory(answer=answer, theme=theme)
+
+    num_respondents = models.Respondent.objects.count()
+
+    assert models.Question.objects.count() == 1
+    assert models.QuestionPart.objects.count() == 1
+    assert models.Answer.objects.count() == 1
+    assert models.Framework.objects.count() == 1
+    assert models.Theme.objects.count() == 1
+    assert models.ThemeMapping.objects.count() == 1
+
+    question.delete()
+
+    assert models.Respondent.objects.count() == num_respondents
+    assert models.Question.objects.count() == 0
+    assert models.QuestionPart.objects.count() == 0
+    assert models.Answer.objects.count() == 0
+    assert models.Framework.objects.count() == 0
+    assert models.Theme.objects.count() == 0
+    assert models.ThemeMapping.objects.count() == 0


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Allow us to delete questions in the support area. This is to delete questions accidentally updated twice in import.

Once import is improved, can remove this.


## Changes proposed in this pull request

In the page where a consultation is displayed (in support area), add a list of questions with an option to delete question.


In `http://localhost:8000/support/consultations/<consultation-id>/` (dummy consultation):
![image](https://github.com/user-attachments/assets/c646bb48-fdb8-4b00-bc77-5a0db534aa49)


Confirm deletion:
![image](https://github.com/user-attachments/assets/402ba5c8-9ba6-44d7-a44b-615afba3f8d2)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

- If needed, create support user: `make dev_admin_user` - login using `email@example.com`.
- Go to support area: `http://localhost:8000/support/`.
- Go to a specific consultation (e.g. create a dummy consultation).
- Check deleting/cancel deleting a question.

How should the buttons for "Yes, delete" and "No, go back" be styled?

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/4TBrHfi8/285-bugfix-allow-us-to-delete-a-question-to-deal-with-dodgy-import

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A