### PR TITLE
Use consult as the repo name tag

### DIFF
--- a/infrastructure/provider.tf
+++ b/infrastructure/provider.tf
@@ -27,7 +27,7 @@ provider "aws" {
     tags = {
       "platform:environment"    = terraform.workspace
       "platform:deployed-via"   = "github"
-      "platform:repository"     = "https://github.com/i-dot-ai/consultation-analyser"
+      "platform:repository"     = "https://github.com/i-dot-ai/consult"
       "platform:security-level" = "base"
 
       Organisation = "co"


### PR DESCRIPTION
## Context

This change updates the repository name tag to reflect the updated repository name, and brings into our standards to avoid deployment IAM denies. Our deployment policies look for an active repository name tag, which is currently set to consult.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo