### PR TITLE
DRAFT: Bugfix/export latest

### DIFF
--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -433,12 +433,16 @@ class ThemeMapping(UUIDPrimaryKeyModel, TimeStampedModel):
         ]
 
     @classmethod
-    def get_latest_theme_mappings(cls, question_part: QuestionPart) -> models.QuerySet:
+    def get_latest_theme_mappings(
+        cls, question_part: QuestionPart, history: bool = False
+    ) -> models.QuerySet:
         latest_framework = (
             Framework.objects.filter(question_part=question_part).order_by("created_at").last()
         )
         if latest_framework:
-            return latest_framework.get_theme_mappings()
+            return latest_framework.get_theme_mappings(history=history)
+        if history:
+            return ThemeMapping.history.none()
         return ThemeMapping.objects.none()
 
 

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -338,6 +338,9 @@ class Framework(UUIDPrimaryKeyModel, TimeStampedModel):
     def get_theme_mappings(self) -> models.QuerySet:
         return ThemeMapping.objects.filter(theme__framework=self)
 
+    def get_theme_mappings_with_history(self) -> models.QuerySet:
+        return ThemeMapping.history.filter(theme__framework=self)
+
 
 class Theme(UUIDPrimaryKeyModel, TimeStampedModel):
     # The new theme is assigned to a new framework with the change reason and user.

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -335,11 +335,10 @@ class Framework(UUIDPrimaryKeyModel, TimeStampedModel):
         new_themes = self.theme_set.exclude(precursor__id__in=previous_framework_themes)
         return new_themes
 
-    def get_theme_mappings(self) -> models.QuerySet:
+    def get_theme_mappings(self, history=False) -> models.QuerySet:
+        if history:
+            return ThemeMapping.history.filter(theme__framework=self)
         return ThemeMapping.objects.filter(theme__framework=self)
-
-    def get_theme_mappings_with_history(self) -> models.QuerySet:
-        return ThemeMapping.history.filter(theme__framework=self)
 
 
 class Theme(UUIDPrimaryKeyModel, TimeStampedModel):

--- a/tests/unit/models/test_framework.py
+++ b/tests/unit/models/test_framework.py
@@ -115,8 +115,8 @@ def test_get_theme_mappings():
     assert tm1 in latest_qs
     assert tm2 not in latest_qs
 
-    # Check get_theme_mappings_with_history
-    theme_mappings_with_history = framework2.get_theme_mappings_with_history()
+    # Check with history
+    theme_mappings_with_history = framework2.get_theme_mappings(history=True)
     assert theme_mappings_with_history.count() == 5
     mapping = theme_mappings_with_history.get(theme=theme_a, answer=answer_1)
     assert mapping.history_type == "+"


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Currently we are getting all theme mappings, but we want to get theme mappings from the latest framework only.

This won't affect past data downloads - as in all those cases we only had one framework per question (part).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Restrict themes in export to be from the latest framework.

TODO - fix flaky test, ensure tests for the rest of e

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/kN6AKyxr/277-bug-fix-eval-data-export

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A