### PR TITLE
Add support link from main page - for staff users only.

### DIFF
--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -70,18 +70,29 @@ def app_config(request: HttpRequest):
         )
     else:
         if request.user.is_authenticated:
-            menu_items = [
-                {
-                    "href": "/consultations/",
-                    "text": "Your consultations",
-                    "active": request.path.startswith("/consultations"),
-                },
-                {
-                    "href": "/sign-out/",
-                    "text": "Sign out",
-                    "classes": "x-govuk-primary-navigation__item--right",
-                },
-            ]
+            menu_items = []
+            if request.user.is_staff:
+                menu_items = [
+                    {
+                        "href": "/support/",
+                        "text": "Support",
+                    },
+                ]
+
+            menu_items.extend(
+                [
+                    {
+                        "href": "/consultations/",
+                        "text": "Your consultations",
+                        "active": request.path.startswith("/consultations"),
+                    },
+                    {
+                        "href": "/sign-out/",
+                        "text": "Sign out",
+                        "classes": "x-govuk-primary-navigation__item--right",
+                    },
+                ]
+            )
         else:
             menu_items = [
                 {


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Add a link to the support area for staff users only.



## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
If staff user:
![image](https://github.com/user-attachments/assets/02404afe-de39-45ba-a2a3-0c3f389c779d)

If not staff user:
![image](https://github.com/user-attachments/assets/1fd9191d-0362-41b9-a9bb-40d4812b2736)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A - just changed as it was getting really annoying to navigate to it.

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A