### PR TITLE
308: Handle Long Title Cases on Answer Detail Page

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/answers/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/answers/index.html
@@ -24,7 +24,10 @@
   <div class="govuk-grid-row govuk-!-margin-top-5">
     <div class="govuk-grid-column-full">
       <span class="govuk-caption-xl govuk-!-display-block">Question {{question.number}}</span>
-      <h1 class="govuk-heading-l">
+      <h1
+        class="govuk-heading-l long-header clickable text-truncated"
+        onclick="document.getElementsByTagName('h1')[0].classList.toggle('text-truncated')"
+      >
         {{ question.text }}
       </h1>
       {% if free_text_question_part %}

--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -345,3 +345,24 @@ horizontal-bar-chart {
     align-items: center;
     gap: 1%;
 }
+
+.long-header {
+    line-height: 3rem;
+    text-align: justify;
+}
+
+.text-truncated {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.clickable {
+    cursor: pointer;
+    transition-property: color;
+    transition: 0.3s ease-in-out;
+}
+
+.clickable:hover  {
+    color: $iai-colour-pink;
+}


### PR DESCRIPTION
## Context

When the title on answer detail page is extremely long, the UX of the page suffers.

## Changes proposed in this pull request

The title is now truncated by default with ellipsis. When clicked on, the full title is revealed. When clicked on again, it goes back to truncated version. The untruncated text is now also justified and line height is increased to leave more room between lines.  When hovered, the title smoothly transitions to iai pink color and cursor appears as pointer.

### Before
![image](https://github.com/user-attachments/assets/344774d8-54ba-4f2e-880e-35e1654a8d9c)

### After
![image](https://github.com/user-attachments/assets/f145b882-bf67-4e92-8a16-0143610f8781)
![image](https://github.com/user-attachments/assets/b009a015-fac0-4f7d-a230-dfc8413899db)

## Guidance to review

View answer detail page, click on title to expand/collapse.

## Link to Trello ticket

https://trello.com/c/8uJ8XdN6/308-handle-long-title-cases-on-answer-detail-page

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo