### PR TITLE
add autoscale params to worker

### DIFF
--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -55,6 +55,7 @@ module "ecs" {
   }
   environment_variables = local.ecs_env_vars
 
+
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id
   private_subnets              = data.terraform_remote_state.vpc.outputs.private_subnets
   container_port               = "8000"
@@ -91,6 +92,9 @@ module "worker" {
     port                = 8000
   }
   environment_variables = local.ecs_env_vars
+
+  autoscaling_minimum_target = 2
+  autoscaling_maximum_target = 4
 
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id
   private_subnets              = data.terraform_remote_state.vpc.outputs.private_subnets

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -93,7 +93,6 @@ module "worker" {
   }
   environment_variables = local.ecs_env_vars
 
-  autoscaling_minimum_target = 2
   autoscaling_maximum_target = 4
 
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo