### PR TITLE
Feature/drop downs

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -53,13 +53,21 @@ def get_all_folder_names_within_folder(
     s3 = boto3.resource("s3")
     objects = s3.Bucket(bucket_name).objects.filter(Prefix=folder_name)
     set_object_names = {obj.key for obj in objects}
+    # Remove prefix
+    set_object_names = {name.replace(f"folder_name/", "") for name in set_object_names}
     # Folders end in slash
-    folders_only = {name for name in set_object_names if name.endswith("/")}
-    # Exclude the name for the folder itself
-    folder_names = {name.split("/")[1] for name in folders_only}
-    folder_names = folder_names - {""}
+    folder_names = {name.split("/")[1] for name in set_object_names}
+    folder_names = set(folder_names) - {""}
     return folder_names
 
+
+def get_list_consultation_folder_names_formatted_for_dropdown() -> list[dict]:
+    try:
+        consultation_folder_names = get_all_folder_names_within_folder(folder_name="app_data", bucket_name=settings.AWS_BUCKET_NAME)
+    except RuntimeError: # If no credentials for AWS
+        consultation_folder_names = set()
+    consultation_folders_formatted = [{"text": x, "value": x} for x in consultation_folder_names]
+    return consultation_folders_formatted
 
 
 

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -47,6 +47,22 @@ def get_all_question_part_subfolders(folder_name: str, bucket_name: str) -> list
     return question_folders
 
 
+def get_all_folder_names_within_folder(
+    folder_name: str, bucket_name: str
+) -> set:
+    s3 = boto3.resource("s3")
+    objects = s3.Bucket(bucket_name).objects.filter(Prefix=folder_name)
+    set_object_names = {obj.key for obj in objects}
+    # Folders end in slash
+    folders_only = {name for name in set_object_names if name.endswith("/")}
+    # Exclude the name for the folder itself
+    folder_names = {name.split("/")[1] for name in folders_only}
+    folder_names = folder_names - {""}
+    return folder_names
+
+
+
+
 def get_themefinder_outputs_for_question(
     question_folder_key: str, output_name: str
 ) -> dict | list[dict]:

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -59,7 +59,7 @@ def get_all_folder_names_within_folder(folder_name: str, bucket_name: str) -> se
     return folder_names
 
 
-def get_list_consultation_folder_names_formatted_for_dropdown() -> list[dict]:
+def get_folder_names_for_dropdown() -> list[dict]:
     try:
         consultation_folder_names = get_all_folder_names_within_folder(
             folder_name="app_data", bucket_name=settings.AWS_BUCKET_NAME

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -47,14 +47,12 @@ def get_all_question_part_subfolders(folder_name: str, bucket_name: str) -> list
     return question_folders
 
 
-def get_all_folder_names_within_folder(
-    folder_name: str, bucket_name: str
-) -> set:
+def get_all_folder_names_within_folder(folder_name: str, bucket_name: str) -> set:
     s3 = boto3.resource("s3")
     objects = s3.Bucket(bucket_name).objects.filter(Prefix=folder_name)
     set_object_names = {obj.key for obj in objects}
     # Remove prefix
-    set_object_names = {name.replace(f"folder_name/", "") for name in set_object_names}
+    set_object_names = {name.replace("folder_name/", "") for name in set_object_names}
     # Folders end in slash
     folder_names = {name.split("/")[1] for name in set_object_names}
     folder_names = set(folder_names) - {""}
@@ -63,12 +61,13 @@ def get_all_folder_names_within_folder(
 
 def get_list_consultation_folder_names_formatted_for_dropdown() -> list[dict]:
     try:
-        consultation_folder_names = get_all_folder_names_within_folder(folder_name="app_data", bucket_name=settings.AWS_BUCKET_NAME)
-    except RuntimeError: # If no credentials for AWS
+        consultation_folder_names = get_all_folder_names_within_folder(
+            folder_name="app_data", bucket_name=settings.AWS_BUCKET_NAME
+        )
+    except RuntimeError:  # If no credentials for AWS
         consultation_folder_names = set()
     consultation_folders_formatted = [{"text": x, "value": x} for x in consultation_folder_names]
     return consultation_folders_formatted
-
 
 
 def get_themefinder_outputs_for_question(

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <h1 class="govuk-heading-l">{{ page_title }}</h1>
-  <p class="govuk-body">Import question and response data. This should be for a consultation where we have already imported the respondents data.</p>
+  <p class="govuk-body">Import question and response data. This should be for a consultation where we have already imported the respondents data. Data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER].</p>
 
 <form method="post" enctype="multipart/form-data" novalidate>{{ csrf_input }}
 
@@ -31,9 +31,6 @@
         'name': "consultation_code",
         'label': {
           'text': "Select consultation folder",
-        },
-        'hint': {
-          'text': "Data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]"
         },
         'items': consultation_folders
       }) }}

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
@@ -23,18 +23,25 @@
     </p>
 
     <p class="govuk-label-wrapper">
-      <label class="govuk-label govuk-label--l" for="consultation_code">
-        What is the name of the consultation folder?
-      </label>
-      <div id="s3_key-hint" class="govuk-hint iai-hint">
-        Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]
-      </div>
-      <input class="govuk-input" id="consultation_code" name="consultation_code" type="text">
+
+      {{ govukSelect({
+        'id': "consultation_code",
+        'name': "consultation_code",
+        'label': {
+          'text': "Select consultation folder",
+        },
+        'hint': {
+          'text': "Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]"
+        },
+        'items': consultation_folders
+      }) }}
     </p>
   </div>
+
   {{ govukButton({
     'text': "Submit",
     'name': "submit"
   }) }}
+
 </form>
 {% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
@@ -21,7 +21,9 @@
         'items': consultations_for_select
       }) }}
     </p>
+  </div>
 
+  <div class="govuk-form-group">
     <p class="govuk-label-wrapper">
 
       {{ govukSelect({
@@ -31,7 +33,7 @@
           'text': "Select consultation folder",
         },
         'hint': {
-          'text': "Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]"
+          'text': "Data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]"
         },
         'items': consultation_folders
       }) }}

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_inputs.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/select/macro.html' import govukSelect -%}
 
 {% set page_title = "Import consultation input data" %}
 
@@ -11,14 +12,16 @@
 
   <div class="govuk-form-group">
     <p class="govuk-label-wrapper">
-      <label class="govuk-label govuk-label--l" for="consultation_slug">
-        Consultation slug
-      </label>
-      <input class="govuk-input" id="consultation_slug" name="consultation_slug" type="text" required>
+      {{ govukSelect({
+        'id': "consultation_id",
+        'name': "consultation_id",
+        'label': {
+          'text': "Select consultation"
+        },
+        'items': consultations_for_select
+      }) }}
     </p>
-  </div>
 
-  <div class="govuk-form-group">
     <p class="govuk-label-wrapper">
       <label class="govuk-label govuk-label--l" for="consultation_code">
         What is the name of the consultation folder?

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_respondents.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_respondents.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/select/macro.html' import govukSelect -%}
 
 {% set page_title = "Import respondent data for a new consultation" %}
 
@@ -19,15 +20,17 @@
   </div>
 
   <div class="govuk-form-group">
-    <p class="govuk-label-wrapper">
-      <label class="govuk-label govuk-label--l" for="consultation_code">
-        What is the name of the consultation folder in the S3 bucket?
-      </label>
-      <div id="s3_key-hint" class="govuk-hint iai-hint">
-        Data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER NAME]
-      </div>
-      <input class="govuk-input" id="consultation_code" name="consultation_code" type="text">
-    </p>
+    {{ govukSelect({
+      'id': "consultation_code",
+      'name': "consultation_code",
+      'label': {
+        'text': "Select consultation folder",
+      },
+      'hint': {
+        'text': "Data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]"
+      },
+      'items': consultation_folders
+    }) }}
   </div>
   {{ govukButton({
     'text': "Submit",

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_respondents.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_respondents.html
@@ -6,14 +6,14 @@
 
 {% block content %}
 <h1 class="govuk-heading-l">{{ page_title }}</h1>
-  <p class="govuk-body">Import respondents for a consultation</p>
+  <p class="govuk-body">Import respondents for a consultation. Data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER].</p>
 
 <form method="post" enctype="multipart/form-data" novalidate>{{ csrf_input }}
 
   <div class="govuk-form-group">
     <p class="govuk-label-wrapper">
       <label class="govuk-label govuk-label--l" for="consultation_name">
-        Consultation name
+        Enter the consultation title
       </label>
       <input class="govuk-input" id="consultation_name" name="consultation_name" type="text" required>
     </p>
@@ -25,9 +25,6 @@
       'name': "consultation_code",
       'label': {
         'text': "Select consultation folder",
-      },
-      'hint': {
-        'text': "Data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]"
       },
       'items': consultation_folders
     }) }}

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -17,6 +17,7 @@ from consultation_analyser.support_console.ingest import (
     import_all_respondents_from_jsonl,
     import_all_responses_from_jsonl,
     import_question_part,
+    get_all_folder_names_within_folder
 )
 
 logger = logging.getLogger("export")
@@ -162,6 +163,11 @@ def import_consultation_inputs(request: HttpRequest) -> HttpResponse:
     consultations_for_select = all_consultations.values("id", "title")
     consultations_for_select = [{"text": f'{d["title"]} ({d["id"]})', "value": d['id']} for d in consultations_for_select]
 
+    try:
+        consultation_folders = get_all_folder_names_within_folder(folder_name="app_data", bucket_name=bucket_name)
+    except RuntimeError:
+        consultation_folders = set()
+
     if request.POST:
         consultation_id = request.POST.get("consultation_id")
         consultation_code = request.POST.get("consultation_code")
@@ -184,7 +190,7 @@ def import_consultation_inputs(request: HttpRequest) -> HttpResponse:
         msg = f"Import for consultation inputs started for consultation with slug {consultation.slug} - check for progress in dashboard"
         messages.success(request, msg)
         return redirect("/support/consultations/import-summary/")
-    context = {"bucket_name": bucket_name, "consultations_for_select": consultations_for_select}
+    context = {"bucket_name": bucket_name, "consultations_for_select": consultations_for_select, "consultation_folders": consultation_folders}
     return render(request, "support_console/consultations/import_inputs.html", context=context)
 
 

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -17,7 +17,7 @@ from consultation_analyser.support_console.ingest import (
     import_all_respondents_from_jsonl,
     import_all_responses_from_jsonl,
     import_question_part,
-    get_all_folder_names_within_folder
+    get_list_consultation_folder_names_formatted_for_dropdown
 )
 
 logger = logging.getLogger("export")
@@ -131,6 +131,9 @@ def import_consultation_respondents(request: HttpRequest) -> HttpResponse:
     current_user = request.user
     bucket_name = settings.AWS_BUCKET_NAME
     batch_size = 100
+
+    consultation_folders = get_list_consultation_folder_names_formatted_for_dropdown()
+
     if request.POST:
         consultation_name = request.POST.get("consultation_name")
         consultation_code = request.POST.get("consultation_code")
@@ -149,7 +152,7 @@ def import_consultation_respondents(request: HttpRequest) -> HttpResponse:
         msg = f"Importing respondents started for consultation with slug {consultation.slug} - check for progress in dashboard"
         messages.success(request, msg)
         return redirect("/support/consultations/import-summary/")
-    context = {"bucket_name": bucket_name}
+    context = {"bucket_name": bucket_name, "consultation_folders": consultation_folders}
     return render(request, "support_console/consultations/import_respondents.html", context=context)
 
 
@@ -163,10 +166,7 @@ def import_consultation_inputs(request: HttpRequest) -> HttpResponse:
     consultations_for_select = all_consultations.values("id", "title")
     consultations_for_select = [{"text": f'{d["title"]} ({d["id"]})', "value": d['id']} for d in consultations_for_select]
 
-    try:
-        consultation_folders = get_all_folder_names_within_folder(folder_name="app_data", bucket_name=bucket_name)
-    except RuntimeError:
-        consultation_folders = set()
+    consultation_folders = get_list_consultation_folder_names_formatted_for_dropdown()
 
     if request.POST:
         consultation_id = request.POST.get("consultation_id")

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -82,7 +82,6 @@ def import_consultations_xlsx(request: HttpRequest) -> HttpResponse:
 
 def export_consultation_theme_audit(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
     consultation = get_object_or_404(models.Consultation, id=consultation_id)
-
     context = {
         "consultation": consultation,
         "bucket_name": settings.AWS_BUCKET_NAME,

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -14,7 +14,7 @@ from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.support_console.export_url_guidance import get_urls_for_consultation
 from consultation_analyser.support_console.ingest import (
     get_all_question_part_subfolders,
-    get_list_consultation_folder_names_formatted_for_dropdown,
+    get_folder_names_for_dropdown,
     import_all_respondents_from_jsonl,
     import_all_responses_from_jsonl,
     import_question_part,
@@ -131,7 +131,7 @@ def import_consultation_respondents(request: HttpRequest) -> HttpResponse:
     bucket_name = settings.AWS_BUCKET_NAME
     batch_size = 100
 
-    consultation_folders = get_list_consultation_folder_names_formatted_for_dropdown()
+    consultation_folders = get_folder_names_for_dropdown()
 
     if request.POST:
         consultation_name = request.POST.get("consultation_name")
@@ -167,7 +167,7 @@ def import_consultation_inputs(request: HttpRequest) -> HttpResponse:
         {"text": f"{d['title']} ({d['id']})", "value": d["id"]} for d in consultations_for_select
     ]
 
-    consultation_folders = get_list_consultation_folder_names_formatted_for_dropdown()
+    consultation_folders = get_folder_names_for_dropdown()
 
     if request.POST:
         consultation_id = request.POST.get("consultation_id")

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -14,10 +14,10 @@ from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.support_console.export_url_guidance import get_urls_for_consultation
 from consultation_analyser.support_console.ingest import (
     get_all_question_part_subfolders,
+    get_list_consultation_folder_names_formatted_for_dropdown,
     import_all_respondents_from_jsonl,
     import_all_responses_from_jsonl,
     import_question_part,
-    get_list_consultation_folder_names_formatted_for_dropdown
 )
 
 logger = logging.getLogger("export")
@@ -164,7 +164,9 @@ def import_consultation_inputs(request: HttpRequest) -> HttpResponse:
 
     all_consultations = models.Consultation.objects.all().order_by("-created_at")
     consultations_for_select = all_consultations.values("id", "title")
-    consultations_for_select = [{"text": f'{d["title"]} ({d["id"]})', "value": d['id']} for d in consultations_for_select]
+    consultations_for_select = [
+        {"text": f"{d['title']} ({d['id']})", "value": d["id"]} for d in consultations_for_select
+    ]
 
     consultation_folders = get_list_consultation_folder_names_formatted_for_dropdown()
 
@@ -190,7 +192,11 @@ def import_consultation_inputs(request: HttpRequest) -> HttpResponse:
         msg = f"Import for consultation inputs started for consultation with slug {consultation.slug} - check for progress in dashboard"
         messages.success(request, msg)
         return redirect("/support/consultations/import-summary/")
-    context = {"bucket_name": bucket_name, "consultations_for_select": consultations_for_select, "consultation_folders": consultation_folders}
+    context = {
+        "bucket_name": bucket_name,
+        "consultations_for_select": consultations_for_select,
+        "consultation_folders": consultation_folders,
+    }
     return render(request, "support_console/consultations/import_inputs.html", context=context)
 
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Let's make the import easier by having drop-downs instead of having to know the folder name or consultation slug.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
In the import respondents page `/support/consultations/import-respondents/`:
![image](https://github.com/user-attachments/assets/6e01598f-222e-401e-9a40-bb8ebcbcc86b)


In the import responses page `/support/consultations/import-inputs/`:
![image](https://github.com/user-attachments/assets/3be39d01-5318-4d55-9c25-af596a2d66ad)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check the import works:
* AWS vault into your role (to give you access to the data).
* Try and import for a consultation (ask Nina for the one that is in the right format).
* Instructions for how to import: https://github.com/i-dot-ai/consult?tab=readme-ov-file#importing-data.


## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/RUpfUhAw/328-import-add-dropdowns-in-the-forms-to-select-the-folders-for-import

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A