### PR TITLE
Include question_part type

### DIFF
--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -97,6 +97,7 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Question number</th>
             <th scope="col" class="govuk-table__header">Question part number</th>
+            <th scope="col" class="govuk-table__header">Question part type</th>
             <th scope="col" class="govuk-table__header">Text</th>
             <th scope="col" class="govuk-table__header">Actions</th>
           </tr>
@@ -109,6 +110,9 @@
             </td>
             <td class="govuk-table__cell">
               {{ part.number }}
+            </td>
+            <td class="govuk-table__cell">
+              {{ part.type }}
             </td>
             <td class="govuk-table__cell">
               {{ part.question.text }} {{ part.text }}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Include the question (part) type e.g. "free text" in the consultation page in support (where we have the option to delete a question part).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
On the consultation page in support: `/support/consultations/<consultation-id>/`.
![image](https://github.com/user-attachments/assets/1c2b4631-842c-40a6-b64f-29ac19119526)

Haven't made the formatting good - I think unncessary as just for internal users i.e. i.AI.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A - quick fix on the back of previous code review.

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A.