### PR TITLE
Improvements to import - don't get respondents one by one, and use list comprehension

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -123,21 +123,14 @@ def import_responses(question_part: QuestionPart, responses_data: list) -> None:
     )
     consultation = question_part.question.consultation
 
-    answers = []
-    for response in responses_data:
-        response = json.loads(response.decode("utf-8"))
-        themefinder_respondent_id = response["themefinder_id"]
-        # Respondents should have been imported already
-        respondent = Respondent.objects.get(
-            consultation=consultation, themefinder_respondent_id=themefinder_respondent_id
-        )
-        response_text = response["response"]
-        # TODO - add import of options for non-free-text data
-        # response_chosen_options = responses_data.get("options")
-        answers.append(
-            Answer(question_part=question_part, respondent=respondent, text=response_text)
-        )
+    # Respondents should have been imported already
+    decoded_responses = [json.loads(response.decode("utf-8")) for response in responses_data]
+    themefinder_ids = [response["themefinder_id"] for response in decoded_responses]
+    corresponding_respondents = Respondent.objects.filter(consultation=consultation).filter(themefinder_respondent_id__in=themefinder_ids)
+    respondent_dictionary = {r.themefinder_respondent_id: r for r in corresponding_respondents}
 
+    # TODO - "response" field will change to "text", will also need to add import of options for non-free-text data
+    answers = [Answer(question_part=question_part, respondent=respondent_dictionary[response_dictionary["themefinder_id"]], text=response_dictionary["response"]) for response_dictionary in decoded_responses]
     Answer.objects.bulk_create(answers)
     logger.info(
         f"Saved batch of responses for question_number {question_part.question.number} and question part {question_part.number}"

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -130,7 +130,7 @@ def import_responses(question_part: QuestionPart, responses_data: list) -> None:
     respondent_dictionary = {r.themefinder_respondent_id: r for r in corresponding_respondents}
 
     # TODO - "response" field will change to "text", will also need to add import of options for non-free-text data
-    answers = [Answer(question_part=question_part, respondent=respondent_dictionary[response_dictionary["themefinder_id"]], text=response_dictionary["response"]) for response_dictionary in decoded_responses]
+    answers = [Answer(question_part=question_part, respondent=respondent_dictionary[response["themefinder_id"]], text=response["response"]) for response in decoded_responses]
     Answer.objects.bulk_create(answers)
     logger.info(
         f"Saved batch of responses for question_number {question_part.question.number} and question part {question_part.number}"


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
I think this will make the import faster - before we were getting the respondents one by one (and I think this is why it was slow with lots of respondents).

The actual result of the import should be the same.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Change the underlying code that imports responses to get respondents in one query.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Assume your AWS role via AWS vault and import data.
Check the import works as expected - see Slack for details.



## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A - part of improving import.

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A