### PR TITLE
rename response to text in import

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -159,7 +159,7 @@ def import_responses(question_part: QuestionPart, responses_data: list) -> None:
         Answer(
             question_part=question_part,
             respondent=respondent_dictionary[response["themefinder_id"]],
-            text=response["response"],
+            text=response["text"],
         )
         for response in decoded_responses
     ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,16 +42,16 @@ def mock_consultation_input_objects(mock_s3_bucket):
     respondents_jsonl = "\n".join([json.dumps(respondent) for respondent in respondents])
 
     responses_1 = [
-        {"themefinder_id": 1, "response": "Yes, I think so."},
-        {"themefinder_id": 2, "response": "Not sure about that."},
-        {"themefinder_id": 3, "response": "I don't think so."},
-        {"themefinder_id": 4, "response": "Maybe, but I need more info."},
+        {"themefinder_id": 1, "text": "Yes, I think so."},
+        {"themefinder_id": 2, "text": "Not sure about that."},
+        {"themefinder_id": 3, "text": "I don't think so."},
+        {"themefinder_id": 4, "text": "Maybe, but I need more info."},
     ]
     responses_jsonl_1 = "\n".join([json.dumps(response) for response in responses_1])
     responses_2 = [
-        {"themefinder_id": 1, "response": "It's really fun."},
-        {"themefinder_id": 3, "response": "It's goog."},
-        {"themefinder_id": 4, "response": "I need more info."},
+        {"themefinder_id": 1, "text": "It's really fun."},
+        {"themefinder_id": 3, "text": "It's goog."},
+        {"themefinder_id": 4, "text": "I need more info."},
     ]
     responses_jsonl_2 = "\n".join([json.dumps(response) for response in responses_2])
 

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -82,9 +82,9 @@ def test_import_responses():
     for i in range(1, 5):
         factories.RespondentFactory(consultation=consultation, themefinder_respondent_id=i)
     responses_data = [
-        b'{"themefinder_id":1, "response":"response 1"}',
-        b'{"themefinder_id":2, "response":"response 2"}',
-        b'{"themefinder_id":4, "response":"response 4"}',
+        b'{"themefinder_id":1, "text":"response 1"}',
+        b'{"themefinder_id":2, "text":"response 2"}',
+        b'{"themefinder_id":4, "text":"response 4"}',
     ]
 
     import_responses(question_part=question_part, responses_data=responses_data)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Updating the import for the changes that we've made to the data structure.

For the import of the inputs, that's really only changing of response -> text.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/UGCc6u13/330-import-dwp-any-tweaks-to-import-inputs-subject-to-alexs-changes

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A