### PR TITLE
341: Improve minimum response word count input

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/answers/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/answers/index.html
@@ -248,13 +248,15 @@
           
             {% if free_text_question_part %}
               <div class="govuk-form-group">
-                <label class="govuk-label govuk-label--m" for="wordcount">
-                  Response length that is at least
-                </label>
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                  Response word count
+                </legend>
       
                 <div class="govuk-input__wrapper">
-                  <input class="govuk-input govuk-input--width-5" id="wordcount" name="wordcount" type="text" spellcheck="false" {% if active_filters.wordcount.selected %} value="{{ active_filters.wordcount.selected[0].id }}" {% endif %}>
-                  <div class="govuk-input__suffix" aria-hidden="true">words</div>
+                  <label class="govuk-label govuk-label--m govuk-!-margin-right-2 v-centered" for="wordcount">
+                    Minimum:
+                  </label>
+                  <input class="govuk-input govuk-input--width-5 govuk-input--full-border" id="wordcount" name="wordcount" type="number" spellcheck="false" {% if active_filters.wordcount.selected %} value="{{ active_filters.wordcount.selected[0].id }}" {% endif %} />
                 </div>
               </div>
             {% endif %}

--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -367,3 +367,13 @@ horizontal-bar-chart {
 .clickable:hover  {
     color: $iai-colour-pink;
 }
+
+.govuk-input.govuk-input--full-border {
+    border: 1px solid var(--iai-colour-text-secondary);
+    border-radius: var(--iai-border-radius);
+}
+
+.v-centered {
+    margin-top: auto;
+    margin-bottom: auto;
+}


### PR DESCRIPTION
## Context

The minimum word count filter on answers index template had confusing UX that needed to be improved.

## Changes proposed in this pull request

 - The input is not type number instead of text
 - Rephrased title and removed the info text that looks like a button
 - Added “Minimum” label to number input so a maximum input can later be added if needed
 - Made the title not a label, instead a title tag same as the other titles

### After
![image](https://github.com/user-attachments/assets/07decd02-840b-491f-8109-40e2e3fccd35)

### Before
![image](https://github.com/user-attachments/assets/2c0dac65-5388-4aad-bf0b-07c687ca28f7)


## Guidance to review

View the input on answers index template, regression testing the functionality of word count input.

## Link to Trello ticket

https://trello.com/c/tf9UVSfX/341-improve-minimum-response-word-count-input

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo