### PR TITLE
Import Themefinder outputs, making use of RQ workers

### DIFF
--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
 from collections import Counter, OrderedDict
+from enum import Enum
 
 import faker as _faker
 import pydantic
@@ -417,7 +418,7 @@ class Theme(UUIDPrimaryKeyModel, TimeStampedModel):
 class ThemeMapping(UUIDPrimaryKeyModel, TimeStampedModel):
     # When changing the mapping for an answer, don't change the answer
     # change the theme.
-    class Stance(models.TextChoices):
+    class Stance(models.TextChoices, Enum):
         POSITIVE = "POSITIVE", "Positive"
         NEGATIVE = "NEGATIVE", "Negative"
 
@@ -451,7 +452,7 @@ class ThemeMapping(UUIDPrimaryKeyModel, TimeStampedModel):
 
 
 class SentimentMapping(UUIDPrimaryKeyModel, TimeStampedModel):
-    class Position(models.TextChoices):
+    class Position(models.TextChoices, Enum):
         AGREEMENT = "AGREEMENT", "Agreement"
         DISAGREEMENT = "DISAGREEMENT", "Disagreement"
         UNCLEAR = "UNCLEAR", "Unclear"

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -185,17 +185,15 @@ def import_themes(question_part: QuestionPart, theme_data: list) -> None:
         execution_run=execution_run, question_part=question_part
     )
 
-    themes = []
-    for theme in theme_data:
-        themes.append(
-            Theme(
-                framework=framework,
-                name=theme["theme_name"],
-                description=theme["theme_description"],
-                key=theme["theme_key"],
-            )
+    themes = [
+        Theme(
+            framework=framework,
+            name=theme["theme_name"],
+            description=theme["theme_description"],
+            key=theme["theme_key"],
         )
-        # TODO: check if we are appending 'other' etc.
+        for theme in theme_data
+    ]
 
     Theme.objects.bulk_create(themes)
     logger.info(

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -4,14 +4,18 @@ import logging
 import boto3
 from django.conf import settings
 from django_rq import job
+from simple_history.utils import bulk_create_with_history
 
 from consultation_analyser.consultations.models import (
     Answer,
     Consultation,
+    ExecutionRun,
+    Framework,
     Question,
     QuestionPart,
     Respondent,
     SentimentMapping,
+    Theme,
     ThemeMapping,
 )
 
@@ -30,7 +34,9 @@ SENTIMENT_MAPPING = {
 }
 
 
-def get_all_question_part_subfolders(folder_name: str, bucket_name: str) -> list:
+def get_all_question_part_subfolders(
+    folder_name: str, bucket_name: str, subfolder_key: int = -2
+) -> list:
     s3 = boto3.resource("s3")
     objects = s3.Bucket(bucket_name).objects.filter(Prefix=folder_name)
     object_names_set = {obj.key for obj in objects}
@@ -41,7 +47,9 @@ def get_all_question_part_subfolders(folder_name: str, bucket_name: str) -> list
         subfolders.add(folder)
     # Only the ones that are question_folders
     question_folders = [
-        name for name in subfolders if name.split("/")[-2].startswith("question_part_")
+        "/".join(name.split("/")[0 : subfolder_key + 1]) + "/"
+        for name in subfolders
+        if name.split("/")[subfolder_key].startswith("question_part_")
     ]
     question_folders.sort()
     return question_folders
@@ -169,6 +177,100 @@ def import_responses(question_part: QuestionPart, responses_data: list) -> None:
     )
 
 
+def import_themes(question_part: QuestionPart, theme_data: list) -> None:
+    logger.info(
+        f"Importing themes for question_number {question_part.question.number}, part_number: {question_part.number}"
+    )
+
+    execution_run = ExecutionRun.objects.create(type=ExecutionRun.TaskType.THEME_GENERATION)
+    framework = Framework.create_initial_framework(
+        execution_run=execution_run, question_part=question_part
+    )
+
+    themes = []
+    for theme in theme_data:
+        themes.append(
+            Theme(
+                framework=framework,
+                name=theme["Theme Name"],
+                description=theme["Theme Description"],
+                key=theme["topic_id"],
+            )
+        )
+        # TODO: check if we are appending 'other' etc.
+
+    Theme.objects.bulk_create(themes)
+    logger.info(
+        f"Saved batch of themes for question_number {question_part.question.number} and question part {question_part.number}"
+    )
+
+
+def import_theme_mappings(question_part: QuestionPart, thememapping_data: list) -> None:
+    logger.info(
+        f"Importing batch of theme mappings for question_number {question_part.question.number} and question part {question_part.number}"
+    )
+    consultation = question_part.question.consultation
+    latest_framework = (
+        Framework.objects.filter(question_part=question_part).order_by("created_at").last()
+    )
+    execution_run = ExecutionRun.objects.create(type=ExecutionRun.TaskType.THEME_MAPPING)
+
+    theme_mappings = []
+    for data in thememapping_data:
+        data = json.loads(data.decode("utf-8"))
+        themefinder_respondent_id = data["themefinder_id"]
+        answer = Answer.objects.get(
+            question_part=question_part,
+            respondent=Respondent.objects.get(
+                consultation=consultation, themefinder_respondent_id=themefinder_respondent_id
+            ),
+        )
+        for idx, theme_key in enumerate(data["labels"]):
+            theme_mappings.append(
+                ThemeMapping(
+                    answer=answer,
+                    theme=Theme.objects.get(framework=latest_framework, key=theme_key),
+                    execution_run=execution_run,
+                    stance=ThemeMapping.Stance[data["stances"][idx]],
+                )
+            )
+
+    bulk_create_with_history(theme_mappings, ThemeMapping)
+    logger.info(
+        f"Saved batch of theme mappings for question_number {question_part.question.number} and question part {question_part.number}"
+    )
+
+
+def import_sentiment_mappings(question_part: QuestionPart, sentimentmapping_data: list) -> None:
+    logger.info(
+        f"Importing batch of sentiment mappings for question_number {question_part.question.number} and question part {question_part.number}"
+    )
+    consultation = question_part.question.consultation
+    execution_run = ExecutionRun.objects.create(type=ExecutionRun.TaskType.SENTIMENT_ANALYSIS)
+
+    sentiment_mappings = []
+    for sentiment_mapping in sentimentmapping_data:
+        sentiment_mapping = json.loads(sentiment_mapping.decode("utf-8"))
+        themefinder_respondent_id = sentiment_mapping["themefinder_id"]
+        answer = Answer.objects.get(
+            question_part=question_part,
+            respondent=Respondent.objects.get(
+                consultation=consultation, themefinder_respondent_id=themefinder_respondent_id
+            ),
+        )
+        sentiment_mappings.append(
+            SentimentMapping(
+                answer=answer,
+                execution_run=execution_run,
+                position=SentimentMapping.Position[sentiment_mapping["position"].upper()],
+            )
+        )
+    bulk_create_with_history(sentiment_mappings, SentimentMapping)
+    logger.info(
+        f"Saved batch of sentiment mappings for question_number {question_part.question.number} and question part {question_part.number}"
+    )
+
+
 @job("default", timeout=900)
 def import_respondent_data_job(consultation: Consultation, respondent_data: list):
     import_respondent_data(consultation=consultation, respondent_data=respondent_data)
@@ -177,6 +279,16 @@ def import_respondent_data_job(consultation: Consultation, respondent_data: list
 @job("default", timeout=900)
 def import_responses_job(question_part: QuestionPart, responses_data: list):
     import_responses(question_part, responses_data)
+
+
+@job("default", timeout=900)
+def import_theme_mappings_job(question_part: QuestionPart, thememapping_data: list):
+    import_theme_mappings(question_part, thememapping_data)
+
+
+@job("default", timeout=900)
+def import_sentiment_mappings_job(question_part: QuestionPart, sentimentmapping_data: list):
+    import_sentiment_mappings(question_part, sentimentmapping_data)
 
 
 def import_all_respondents_from_jsonl(
@@ -223,3 +335,55 @@ def import_all_responses_from_jsonl(
     # Any remaining lines < batch size
     if lines:
         import_responses_job.delay(question_part=question_part, responses_data=lines)
+
+
+def import_themes_from_json(question_part: QuestionPart, question_part_folder_key: str) -> None:
+    s3 = boto3.client("s3")
+    data_key = f"{question_part_folder_key}themes.json"
+    response = s3.get_object(Bucket=settings.AWS_BUCKET_NAME, Key=data_key)
+    theme_data = json.loads(response["Body"].read().decode("utf-8"))
+    import_themes(question_part=question_part, theme_data=theme_data)
+
+
+def import_all_theme_mappings_from_jsonl(
+    question_part: QuestionPart, bucket_name: str, question_part_folder_key: str, batch_size: int
+) -> None:
+    logger.info(
+        f"Importing theme_mappings from {question_part_folder_key}, batch_size {batch_size}"
+    )
+    theme_mappings_file_key = f"{question_part_folder_key}mapping.jsonl"
+    s3_client = boto3.client("s3")
+    response = s3_client.get_object(Bucket=bucket_name, Key=theme_mappings_file_key)
+    lines = []
+    for line in response["Body"].iter_lines():
+        lines.append(line)
+        if len(lines) == batch_size:
+            import_theme_mappings_job.delay(question_part=question_part, thememapping_data=lines)
+            lines = []
+    # Any remaining lines < batch size
+    if lines:
+        import_theme_mappings_job.delay(question_part=question_part, thememapping_data=lines)
+
+
+def import_all_sentiment_mappings_from_jsonl(
+    question_part: QuestionPart, bucket_name: str, question_part_folder_key: str, batch_size: int
+) -> None:
+    logger.info(
+        f"Importing sentiment mappings from {question_part_folder_key}, batch_size {batch_size}"
+    )
+    sentiment_mappings_file_key = f"{question_part_folder_key}position.jsonl"
+    s3_client = boto3.client("s3")
+    response = s3_client.get_object(Bucket=bucket_name, Key=sentiment_mappings_file_key)
+    lines = []
+    for line in response["Body"].iter_lines():
+        lines.append(line)
+        if len(lines) == batch_size:
+            import_sentiment_mappings_job.delay(
+                question_part=question_part, sentimentmapping_data=lines
+            )
+            lines = []
+    # Any remaining lines < batch size
+    if lines:
+        import_sentiment_mappings_job.delay(
+            question_part=question_part, sentimentmapping_data=lines
+        )

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_summary.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_summary.html
@@ -21,6 +21,12 @@
         </p>
 
         <p class="govuk-body">
+          <a href="{{ url('import_themes') }}" class="govuk-link govuk-body govuk-link--no-visited-state">
+            Import consultation theme data
+          </a>
+        </p>
+
+        <p class="govuk-body">
           <a href="/support/django-rq/" class="govuk-link govuk-body govuk-link--no-visited-state">
             See progress of import tasks in Django RQ dashboard
           </a>

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_themes.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_themes.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/select/macro.html' import govukSelect -%}
+
+{% set page_title = "Import themefinder output data for consultation" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ page_title }}</h1>
+  <p class="govuk-body">Import theme, theme mapping and position data. This should be for a consultation where we have already imported the respondents, question and response data.</p>
+
+  <form method="post" enctype="multipart/form-data" novalidate>{{ csrf_input }}
+
+    {{ govukSelect({
+      "id": "consultation_slug",
+      "name": "consultation_slug",
+      "label": {
+          "text": "Select an existing consultation slug"
+      },
+      "items": consultations
+    }) }}
+
+    <div class="govuk-form-group">
+      <p class="govuk-label-wrapper">
+        <label class="govuk-label govuk-label--l" for="consultation_code">
+          What is the name of the consultation folder?
+        </label>
+        <div id="s3_key-hint" class="govuk-hint iai-hint">
+          Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]
+        </div>
+        <input class="govuk-input" id="consultation_code" name="consultation_code" type="text">
+      </p>
+    </div>
+
+    <div class="govuk-form-group">
+      <p class="govuk-label-wrapper">
+        <label class="govuk-label govuk-label--l" for="consultation_mapping_date">
+          Which dated subfolder should be used? e.g. 2025-01-01/
+        </label>
+        <div id="s3_key-hint" class="govuk-hint iai-hint">
+          Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]/mapping/[QUESTION NUMBER]/[DATED SUBFOLDER]
+        </div>
+        <input class="govuk-input" id="consultation_mapping_date" name="consultation_mapping_date" type="text">
+      </p>
+    </div>
+
+    {{ govukButton({
+      'text': "Submit",
+      'name': "submit"
+    }) }}
+
+  </form>
+{% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_themes.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_themes.html
@@ -10,24 +10,29 @@
 
   <form method="post" enctype="multipart/form-data" novalidate>{{ csrf_input }}
 
-    {{ govukSelect({
-      "id": "consultation_slug",
-      "name": "consultation_slug",
-      "label": {
-          "text": "Select an existing consultation slug"
-      },
-      "items": consultations
-    }) }}
+    <div class="govuk-form-group">
+      <p class="govuk-label-wrapper">
+        {{ govukSelect({
+          "id": "consultation_slug",
+          "name": "consultation_slug",
+          "label": {
+              "text": "Select an existing consultation slug"
+          },
+          "items": consultations
+        })}}
+    </p>
+  </div>
 
     <div class="govuk-form-group">
       <p class="govuk-label-wrapper">
-        <label class="govuk-label govuk-label--l" for="consultation_code">
-          What is the name of the consultation folder?
-        </label>
-        <div id="s3_key-hint" class="govuk-hint iai-hint">
-          Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]
-        </div>
-        <input class="govuk-input" id="consultation_code" name="consultation_code" type="text">
+        {{ govukSelect({
+          'id': "consultation_code",
+          'name': "consultation_code",
+          'label': {
+            'text': "Select consultation folder",
+          },
+          'items': consultation_folders
+        }) }}
       </p>
     </div>
 
@@ -37,7 +42,7 @@
           Which dated subfolder should be used? e.g. 2025-01-01/
         </label>
         <div id="s3_key-hint" class="govuk-hint iai-hint">
-          Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]/mapping/[QUESTION NUMBER]/[DATED SUBFOLDER]
+          Consultation data should be saved in: {{ bucket_name }}/app_data/[CONSULTATION FOLDER]/mapping/[DATED SUBFOLDER]/
         </div>
         <input class="govuk-input" id="consultation_mapping_date" name="consultation_mapping_date" type="text">
       </p>

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -58,6 +58,11 @@ urlpatterns = [
         name="import_inputs",
     ),
     path(
+        "consultations/import-themes/",
+        consultations.import_consultation_themes,
+        name="import_themes",
+    ),
+    path(
         "consultations/import-summary/",
         consultations.import_summary,
         name="import_summary",

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -203,7 +203,8 @@ def import_consultation_inputs(request: HttpRequest) -> HttpResponse:
 
 
 def import_consultation_themes(request: HttpRequest) -> HttpResponse:
-    # TODO: write helptext here
+    # Imports themefinder outputs: themes, theme mappings and sentiment mappings
+    # Responses should already have been imported
     bucket_name = settings.AWS_BUCKET_NAME
     consultation_options = [
         {"value": c.slug, "text": c.slug} for c in models.Consultation.objects.all()
@@ -224,7 +225,6 @@ def import_consultation_themes(request: HttpRequest) -> HttpResponse:
 
         consultation = models.Consultation.objects.get(slug=consultation_slug)
         if not models.Question.objects.filter(consultation=consultation).exists():
-            # TODO: handle with raise error and try/except
             messages.error(request, "Questions have not yet been imported for this Consultation")
             return render(
                 request, "support_console/consultations/import_themes.html", context=context
@@ -260,7 +260,8 @@ def import_consultation_themes(request: HttpRequest) -> HttpResponse:
                 batch_size=batch_size,
             )
 
-        # TODO: add a message
+        msg = f"Importing themefinder outputs started for consultation with slug {consultation.slug} - check for progress in dashboard"
+        messages.success(request, msg)
         return redirect("/support/consultations/import-summary/")
 
     return render(request, "support_console/consultations/import_themes.html", context=context)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,6 +55,30 @@ def mock_consultation_input_objects(mock_s3_bucket):
     ]
     responses_jsonl_2 = "\n".join([json.dumps(response) for response in responses_2])
 
+    themes = [
+        {"theme_key": "A", "theme_name": "Theme A", "theme_description": "A description"},
+        {"theme_key": "B", "theme_name": "Theme B", "theme_description": "B description"},
+        {"theme_key": "C", "theme_name": "Theme C", "theme_description": "C description"},
+    ]
+
+    theme_mappings = [
+        {"themefinder_id": 1, "theme_keys": ["A"]},
+        {"themefinder_id": 2, "theme_keys": ["B"]},
+        {"themefinder_id": 4, "theme_keys": ["A", "B"]},
+    ]
+    theme_mappings_jsonl = "\n".join(
+        [json.dumps(theme_mapping) for theme_mapping in theme_mappings]
+    )
+
+    sentiment_mappings = [
+        {"themefinder_id": 1, "sentiment": "AGREEMENT"},
+        {"themefinder_id": 2, "sentiment": "DISAGREEMENT"},
+        {"themefinder_id": 4, "sentiment": "UNCLEAR"},
+    ]
+    sentiment_mappings_jsonl = "\n".join(
+        [json.dumps(sentiment_mapping) for sentiment_mapping in sentiment_mappings]
+    )
+
     conn.Object(mock_s3_bucket, "app_data/CON1/inputs/respondents.jsonl").put(
         Body=respondents_jsonl
     )
@@ -70,3 +94,12 @@ def mock_consultation_input_objects(mock_s3_bucket):
     conn.Object(mock_s3_bucket, "app_data/CON1/inputs/question_part_2/responses.jsonl").put(
         Body=responses_jsonl_2
     )
+    conn.Object(
+        mock_s3_bucket, "app_data/CON1/outputs/mapping/2025-04-01/question_part_1/themes.json"
+    ).put(Body=json.dumps(themes))
+    conn.Object(
+        mock_s3_bucket, "app_data/CON1/outputs/mapping/2025-04-01/question_part_1/mapping.jsonl"
+    ).put(Body=theme_mappings_jsonl)
+    conn.Object(
+        mock_s3_bucket, "app_data/CON1/outputs/mapping/2025-04-01/question_part_1/sentiment.jsonl"
+    ).put(Body=sentiment_mappings_jsonl)


### PR DESCRIPTION
## Context
We need a more robust, batchable import process for larger datasets.
Additionally, the outputs from `themefinder` have recently been updated.
This also builds on work from @nmenezes0 importing PRs for importing consultation question and response data.

## Changes proposed in this pull request
Adds a new form to select where to find the relevant S3 data

<img width="1151" alt="Screenshot 2025-04-15 at 15 46 54" src="https://github.com/user-attachments/assets/2ac28190-18a6-45f1-b392-b969c3dee26a" />

Adds `Theme`s on submit, and enqueues adding `ThemeMapping`s and `SentimentMapping`s.

## Guidance to review
Can you run this locally - ask me for the relevant keys for S3.
Does the process look reasonable? I've avoided abstracting similar methods for now (as I don't think they're quite similar *enough*), but let me know if you think this should be changed.

## Link to Trello ticket
https://trello.com/c/fQcHBhbf/316-import-dwp-import-for-the-themefinder-outputs

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo