### PR TITLE
Use bulk_create with history for Answer.

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -169,7 +169,7 @@ def import_responses(question_part: QuestionPart, responses_data: list) -> None:
         )
         for response in decoded_responses
     ]
-    Answer.objects.bulk_create(answers)
+    bulk_create_with_history(answers, Answer)
     logger.info(
         f"Saved batch of responses for question_number {question_part.question.number} and question part {question_part.number}"
     )

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -124,11 +124,14 @@ def test_import_all_responses_from_jsonl(mock_consultation_input_objects):
     # TODO - improve this, but it works for now!
     time.sleep(5)
     responses = Answer.objects.filter(question_part=question_part)
+    historical_responses = Answer.history.filter(question_part=question_part)
     assert responses.count() == 3
     assert responses[0].respondent.themefinder_respondent_id == 1
     assert responses[0].text == "It's really fun."
     assert responses[2].text == "I need more info."
     assert responses[2].respondent.themefinder_respondent_id == 4
+    assert historical_responses.count() == 3
+    assert historical_responses[0].history_type == "+"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Actually listen to my own advice, and make sure we save the history for all objects with history (Answer, ThemeMapping, SentimentMapping - but the other two are covered in a separate PR).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/cNpMDUYQ/344-import-bugfix-answer-has-history-use-bulkcreatewithhistory

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A