### PR TITLE
Update naming to be explicit that data is a dictionary for demographic data

### DIFF
--- a/consultation_analyser/consultations/import_schema/inputs/respondent.json
+++ b/consultation_analyser/consultations/import_schema/inputs/respondent.json
@@ -7,8 +7,9 @@
     "supplied_respondent_id": {
       "type": "string"
     },
-    "data": {
-      "type": "object"
+    "demographics": {
+      "type": "object",
+      "description": "Dictionary with any demographic data."
     }
   },
   "required": ["themefinder_id"],


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo