### PR TITLE
Feature/350 eval question by question

### DIFF
--- a/consultation_analyser/consultations/export_user_theme.py
+++ b/consultation_analyser/consultations/export_user_theme.py
@@ -11,7 +11,6 @@ from django_rq import job
 
 from consultation_analyser.consultations.models import (
     Answer,
-    Consultation,
     ExecutionRun,
     QuestionPart,
     SentimentMapping,
@@ -118,7 +117,6 @@ def get_theme_mapping_rows(question_part: QuestionPart) -> list[dict]:
     return output
 
 
-
 # def get_theme_mapping_output(consultation: Consultation, question_part: QuestionPart) -> list[dict]:
 #     output = []
 #     for question_part in QuestionPart.objects.filter(
@@ -157,9 +155,7 @@ def export_user_theme(question_part_id: uuid.UUID, s3_key: str) -> None:
     if settings.ENVIRONMENT == "local":
         if not os.path.exists("downloads"):
             os.makedirs("downloads")
-        with open(
-            f"downloads/{filename}", mode="w"
-        ) as file:
+        with open(f"downloads/{filename}", mode="w") as file:
             writer = csv.DictWriter(file, fieldnames=output[0].keys())
             writer.writeheader()
             for row in output:
@@ -182,9 +178,11 @@ def export_user_theme(question_part_id: uuid.UUID, s3_key: str) -> None:
             Body=csv_buffer.getvalue(),
         )
         csv_buffer.close()
-    logger.info(f"Finishing export for question {question_number} for consultation {question_part.question.consultation.title}")
+    logger.info(
+        f"Finishing export for question {question_number} for consultation {question_part.question.consultation.title}"
+    )
 
 
 @job("default", timeout=900)
-def export_user_theme_job(question_part_id: str, s3_key: str) -> None:
+def export_user_theme_job(question_part_id: uuid.UUID, s3_key: str) -> None:
     export_user_theme(question_part_id, s3_key)

--- a/consultation_analyser/consultations/export_user_theme.py
+++ b/consultation_analyser/consultations/export_user_theme.py
@@ -117,33 +117,6 @@ def get_theme_mapping_rows(question_part: QuestionPart) -> list[dict]:
     return output
 
 
-# def get_theme_mapping_output(consultation: Consultation, question_part: QuestionPart) -> list[dict]:
-#     output = []
-#     for question_part in QuestionPart.objects.filter(
-#         question__consultation=consultation,
-#         type=QuestionPart.QuestionType.FREE_TEXT,
-#     ):
-#         # Default to latest execution run
-#         sentiment_run = get_latest_sentiment_execution_run_for_question_part(question_part)
-#         answer_qs = Answer.objects.filter(question_part=question_part)
-#         # Get themes from latest framework
-#         current_theme_mappings = ThemeMapping.get_latest_theme_mappings(
-#             question_part=question_part, history=False
-#         )
-#         historical_theme_mappings = ThemeMapping.get_latest_theme_mappings(
-#             question_part=question_part, history=True
-#         )
-#         for response in answer_qs:
-#             row = get_theme_mapping_output_row(
-#                 mappings_for_framework=current_theme_mappings,
-#                 historical_mappings_for_framework=historical_theme_mappings,
-#                 response=response,
-#                 sentiment_execution_run=sentiment_run,
-#             )
-#             output.append(row)
-#     return output
-
-
 def export_user_theme(question_part_id: uuid.UUID, s3_key: str) -> None:
     question_part = QuestionPart.objects.get(id=question_part_id)
     output = get_theme_mapping_rows(question_part)

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/export_audit.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/export_audit.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
-{%- from 'govuk_frontend_jinja/components/select/macro.html' import govukSelect -%}
+{%- from 'govuk_frontend_jinja/components/checkboxes/macro.html' import govukCheckboxes -%}
+
 
 {% set page_title = "Export consultation audit data from " + consultation.title %}
 
@@ -10,6 +11,22 @@
 <form method="post" enctype="multipart/form-data" novalidate>{{ csrf_input }}
 
   <div class="govuk-form-group">
+    {{ govukCheckboxes({
+      'name': "question_parts",
+      'fieldset': {
+        'legend': {
+          'text': "Which question do you want to download data for?",
+          'isPageHeading': false,
+          'classes': "govuk-fieldset__legend--l"
+        }
+      },
+      'hint': {
+        'text': "Select all that apply"
+      },
+      'items': question_parts_items
+    }) }}
+
+
 
     {% if environment == 'local' %}
       <p>The file will be saved in: downloads/[timestamp]-example_consultation_theme_changes.csv</p>

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/export_audit.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/export_audit.html
@@ -15,28 +15,23 @@
       'name': "question_parts",
       'fieldset': {
         'legend': {
-          'text': "Which question do you want to download data for?",
+          'text': "Which questions do you want to download data for?",
           'isPageHeading': false,
           'classes': "govuk-fieldset__legend--l"
         }
       },
-      'hint': {
-        'text': "Select all that apply"
-      },
       'items': question_parts_items
     }) }}
 
-
-
     {% if environment == 'local' %}
-      <p>The file will be saved in: downloads/[timestamp]-example_consultation_theme_changes.csv</p>
+      <p>The file will be saved in: downloads/[timestamp]_question_[question_number]_theme_changes</p>
     {% else %}
       <p class="govuk-label-wrapper">
         <label class="govuk-label govuk-label--l" for="s3_key">
           Where should the file be saved?
         </label>
         <div id="s3_key-hint" class="govuk-hint iai-hint">
-          The file will be saved as: {{bucket_name}}/[YOUR PATH]/[timestamp]-consultation_theme_changes.csv
+          The file will be saved as: {{bucket_name}}/[YOUR PATH]/[timestamp]_question_[question_number]_theme_changes.csv
         </div>
         <input class="govuk-input govuk-input--width-20" id="s3_key" name="s3_key" type="text">
       </p>

--- a/tests/integration/test_export_user_theme.py
+++ b/tests/integration/test_export_user_theme.py
@@ -109,7 +109,7 @@ def test_export_user_theme(mock_boto_client, django_app):
         review_response_page.form.submit("Save and continue to a new response")
 
     # Call the method
-    export_user_theme(consultation.slug, "test_key")
+    export_user_theme(question_part.id, "test_key")
 
     # Test the results
     # TODO: Unlear why this is this called twice?


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
It will be easier to download evaluation audit data by question:
* Questions are often completed at different times
* It will be a smaller file to read in (especially relevant as the data gets larger)
* The task to export the data will be shorter, and we can run different question downloads in parallel

@mitchfruin - for info, once this has been merged in, evaluation data will be provided question by question (but the format of the CSV is unchanged.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Added checkboxes to select questions for download.

![image](https://github.com/user-attachments/assets/82a8ee93-bc2d-4a08-a104-ab20f870ef85)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/CO6ofezl/350-export-evaluation-data-question-by-question

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A