### PR TITLE
376: Dashboard | Cannot get back to consultations, only evaluation part (without removing url)

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
@@ -19,14 +19,16 @@
               href="{{ url('review_free_text_questions', kwargs={'consultation_slug': consultation.slug}) }}"
               class="govuk-body-l govuk-link govuk-link--no-visited-state govuk-!-margin-right-5"
             >
-              View Evaluation
+              View evaluation
             </a>
-            <a
-              href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}"
-              class="govuk-body-l govuk-link govuk-link--no-visited-state govuk-!-margin-right-5"
-            >
-              View Dashboard
-            </a>
+            {% if user_has_dashboard_access %}
+              <a
+                href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}"
+                class="govuk-body-l govuk-link govuk-link--no-visited-state govuk-!-margin-right-5"
+              >
+                View dashboard
+              </a>
+            {% endif %}
           </li>
         {% endfor %}
       </ul>

--- a/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
@@ -12,8 +12,20 @@
       <ul class="govuk-list">
         {% for consultation in consultations %}
           <li class="govuk-!-margin-top-2">
-            <a href="{{ url('review_free_text_questions', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-body-l govuk-link govuk-link--no-visited-state">
+            <h2 class="govuk-heading-m">
               {{ consultation.title }}
+            </h2>
+            <a
+              href="{{ url('review_free_text_questions', kwargs={'consultation_slug': consultation.slug}) }}"
+              class="govuk-body-l govuk-link govuk-link--no-visited-state govuk-!-margin-right-5"
+            >
+              View Evaluation
+            </a>
+            <a
+              href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}"
+              class="govuk-body-l govuk-link govuk-link--no-visited-state govuk-!-margin-right-5"
+            >
+              View Dashboard
             </a>
           </li>
         {% endfor %}

--- a/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/consultations/index.html
@@ -11,7 +11,7 @@
     <p class="govuk-body">Click to review themes for your consultations</p>
       <ul class="govuk-list">
         {% for consultation in consultations %}
-          <li class="govuk-!-margin-top-2">
+          <li class="govuk-!-margin-top-2 govuk-!-margin-bottom-6">
             <h2 class="govuk-heading-m">
               {{ consultation.title }}
             </h2>

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -23,7 +23,10 @@ logger = logging.getLogger("upload")
 def index(request: HttpRequest) -> HttpResponse:
     user = request.user
     consultations_for_user = Consultation.objects.filter(users=user)
-    context = {"consultations": consultations_for_user}
+    context = {
+        "consultations": consultations_for_user,
+        "user_has_dashboard_access": user.has_dashboard_access
+    }
     return render(request, "consultations/consultations/index.html", context)
 
 


### PR DESCRIPTION
## Context
Consultations page need a link to the consultation dashboard to facilitate navigation.

## Changes proposed in this pull request
This PR adds a link to the consultation dashboard alongside the existing evaluation link, moving the consultation title into a h2 element.

### Screenshot
![image](https://github.com/user-attachments/assets/1b640f25-1ce2-494d-bc24-cd5f40e67dd4)

## Guidance to review
Navigate to the consultation index page, confirm both Evaluation and Dashboard links are correct.

## Link to Trello ticket
https://trello.com/c/6mIXAjR5/376-dashboard-cannot-get-back-to-consultations-only-evaluation-part-without-removing-url

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo