### PR TITLE
Make sure we get all themes in eval app, not just ones that have been mapped.

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -294,14 +294,16 @@ def show(
     consultation = get_object_or_404(models.Consultation, slug=consultation_slug)
     question = get_object_or_404(models.Question, slug=question_slug, consultation=consultation)
     response = get_object_or_404(models.Answer, id=response_id)
+    question_part = response.question_part
 
-    all_theme_mappings_for_framework = models.ThemeMapping.get_latest_theme_mappings(
-        response.question_part
+    all_theme_mappings_for_framework = models.ThemeMapping.get_latest_theme_mappings(question_part)
+
+    latest_framework = (
+        models.Framework.objects.filter(question_part=question_part).order_by("created_at").last()
     )
-
     all_themes = models.Theme.objects.filter(
-        id__in=all_theme_mappings_for_framework.values("theme")
-    )
+        framework=latest_framework
+    )  # May include themes not mapped to anything
 
     existing_themes = all_theme_mappings_for_framework.filter(answer=response).values_list(
         "theme", flat=True


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Make sure we include all themes in the eval app. We may have themes that haven't yet been mapped to anything, but we still want them to be considered.

Screenshot of the themes that haven't been mapped appearing in the eval app:

![image](https://github.com/user-attachments/assets/9c455d49-cab1-47d4-8b7a-dfea40025b42)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
https://trello.com/c/uZyDNDVy/395-check-any-extra-themes-that-havent-been-assigned-in-the-mapping-will-be-in-the-eval-app

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A