### PR TITLE
just display questions with themes mapped

### DIFF
--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -61,9 +61,13 @@ def index(request, consultation_slug: str):
     question_parts = models.QuestionPart.objects.filter(
         question__consultation=consultation, type=models.QuestionPart.QuestionType.FREE_TEXT
     )
+    question_parts_with_themes = [
+        q
+        for q in question_parts
+        if models.ThemeMapping.get_latest_theme_mappings(question_part=q).exists()
+    ]
     context = {
         "consultation": consultation,
-        "question_parts": question_parts,
+        "question_parts": question_parts_with_themes,
     }
-    print(f"context:{context}")
     return render(request, "consultations/questions/index.html", context)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
In the eval app where the questions are displayed, only show questions where no themes have been mapped.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A - as discussed with Alex

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A