### PR TITLE
Use themefinder_id.

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -281,7 +281,7 @@ def import_evidence_rich_mappings(
     evidence_rich_mappings = []
     for evidence_rich_mapping in evidence_rich_mapping_data:
         evidence_rich_mapping = json.loads(evidence_rich_mapping.decode("utf-8"))
-        themefinder_respondent_id = evidence_rich_mapping["response_id"]
+        themefinder_respondent_id = evidence_rich_mapping["themefinder_id"]
         answer = Answer.objects.get(
             question_part=question_part,
             respondent=Respondent.objects.get(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,18 +98,18 @@ def mock_consultation_input_objects(mock_s3_bucket):
     )
 
     evidence_rich_mappings = [
-        {"response_id": 1, "evidence_rich": "YES"},
-        {"response_id": 2, "evidence_rich": "NO"},
-        {"response_id": 4, "evidence_rich": "YES"},
+        {"themefinder_id": 1, "evidence_rich": "YES"},
+        {"themefinder_id": 2, "evidence_rich": "NO"},
+        {"themefinder_id": 4, "evidence_rich": "YES"},
     ]
     evidence_rich_mappings_jsonl = "\n".join(
         [json.dumps(evidence_rich_mapping) for evidence_rich_mapping in evidence_rich_mappings]
     )
 
     evidence_rich_mappings_2 = [
-        {"response_id": 1, "evidence_rich": "YES"},
-        {"response_id": 3, "evidence_rich": "NO"},
-        {"response_id": 4, "evidence_rich": "YES"},
+        {"themefinder_id": 1, "evidence_rich": "YES"},
+        {"themefinder_id": 3, "evidence_rich": "NO"},
+        {"themefinder_id": 4, "evidence_rich": "YES"},
     ]
     evidence_rich_mappings_2_jsonl = "\n".join(
         [json.dumps(evidence_rich_mapping) for evidence_rich_mapping in evidence_rich_mappings_2]

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -306,9 +306,9 @@ def test_import_all_sentiment_mappings_from_jsonl(
 @pytest.mark.django_db
 def test_import_evidence_rich_mappings(question_part_with_4_responses):
     evidence_rich_mapping_data = [
-        b'{"response_id":1,"evidence_rich":"YES"}',
-        b'{"response_id":2,"evidence_rich":"NO"}',
-        b'{"response_id":4,"evidence_rich":"YES"}',
+        b'{"themefinder_id":1,"evidence_rich":"YES"}',
+        b'{"themefinder_id":2,"evidence_rich":"NO"}',
+        b'{"themefinder_id":4,"evidence_rich":"YES"}',
     ]
 
     import_evidence_rich_mappings(


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to use `themefinder_id` for importing evidence rich data.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A