### PR TITLE
426: Look at slow query

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -150,7 +150,14 @@ def respondents_json(
 
     # If no cached data found
     if data is None:
+
         # Prefetch all related data to avoid multiple db hits
+        # filtered_answers is not querying the database yet,
+        # only building the query (as querysets are lazily fetched).
+        # This then gets passed as the queryset param of respondent prefetch,
+        # updating that query with the filter logic.
+        # Ultimately the returned answers are only for the current consultation.
+
         filtered_answers = models.Answer.objects.filter(
             question_part__question__slug=question_slug
         ).prefetch_related(

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -141,7 +141,8 @@ def respondents_json(
     consultation_slug: str,
     question_slug: str,
 ):
-    cache_key = f"respondents_{request.user.id}_{consultation_slug}_{question_slug}"
+    # If needed, add request.user.id to make cache unique to each user
+    cache_key = f"respondents_{consultation_slug}_{question_slug}"
     cache_timeout = 60 * 20  #  20 mins
 
     # Retrieve cached data

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -4,11 +4,10 @@ from uuid import UUID
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator
-from django.db.models import Count, F, Q, QuerySet, Sum, Value
+from django.db.models import Count, F, Prefetch, Q, QuerySet, Sum, Value
 from django.db.models.functions import Length, Replace
 from django.http import HttpRequest, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.db.models import Prefetch
 
 from .. import models
 from .decorators import user_can_see_consultation, user_can_see_dashboards


### PR DESCRIPTION
## Context

While querying the respondents, Django ORM currently hits the database multiple times in a for loop, causing very slow response times due to excessive hits to the database.

## Changes proposed in this pull request

This PR switches to using Django's prefetch_related method to query the database once to retrieve all necessary data, avoiding db hits inside the for loop, resulting in around 90% percent faster responses.

## Guidance to review
Navigate to answers index template to gauge answers table response time.

## Link to Trello ticket
https://trello.com/c/l0uGlaTW/426-look-at-slow-query

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo