### PR TITLE
Bugfix/show user signed out

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -219,22 +219,41 @@ def respondents_json(
                 pass
 
         data = {
-            "all_respondents": [{
-                "id": f"response-{getattr(respondent, "identifier", '')}",
-                "identifier": getattr(respondent, "identifier", ""),
-                "sentiment_position": respondent.sentiment.position if hasattr(respondent, "sentiment") and hasattr(respondent.sentiment, "position") else "",
-                "free_text_answer_text": respondent.free_text_answer.text if hasattr(respondent, "free_text_answer") else "",
-                "demographic_data": hasattr(respondent, "data") or "",
-                "themes": [{
-                    "id": theme.theme.id,
-                    "stance": theme.stance,
-                    "name": theme.theme.name,
-                    "description": theme.theme.description,
-                } for theme in respondent.themes] if hasattr(respondent, "themes") else [],
-                "multiple_choice_answer": [respondent.multiple_choice_answer.chosen_options] if hasattr(respondent, "multiple_choice_answer") and hasattr(respondent.multiple_choice_answer, "chosen_options") else [],
-                "evidenceRich": True if hasattr(respondent, "evidence_rich") and hasattr(respondent.evidence_rich, "evidence_rich") else False,
-                "individual": True if hasattr(respondent, "individual") else False,
-            } for respondent in respondents]
+            "all_respondents": [
+                {
+                    "id": f"response-{getattr(respondent, 'identifier', '')}",
+                    "identifier": getattr(respondent, "identifier", ""),
+                    "sentiment_position": respondent.sentiment.position
+                    if hasattr(respondent, "sentiment")
+                    and hasattr(respondent.sentiment, "position")
+                    else "",
+                    "free_text_answer_text": respondent.free_text_answer.text
+                    if hasattr(respondent, "free_text_answer")
+                    else "",
+                    "demographic_data": hasattr(respondent, "data") or "",
+                    "themes": [
+                        {
+                            "id": theme.theme.id,
+                            "stance": theme.stance,
+                            "name": theme.theme.name,
+                            "description": theme.theme.description,
+                        }
+                        for theme in respondent.themes
+                    ]
+                    if hasattr(respondent, "themes")
+                    else [],
+                    "multiple_choice_answer": [respondent.multiple_choice_answer.chosen_options]
+                    if hasattr(respondent, "multiple_choice_answer")
+                    and hasattr(respondent.multiple_choice_answer, "chosen_options")
+                    else [],
+                    "evidenceRich": True
+                    if hasattr(respondent, "evidence_rich")
+                    and hasattr(respondent.evidence_rich, "evidence_rich")
+                    else False,
+                    "individual": True if hasattr(respondent, "individual") else False,
+                }
+                for respondent in respondents
+            ]
         }
         cache.set(cache_key, data, timeout=cache_timeout)
 

--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -41,35 +41,35 @@ def app_config(request: HttpRequest):
 
     current_app = resolved_url.func.__module__.split(".")[1]
 
-    if current_app == "support_console":
-        app_config = AppConfig(
-            name="Consult support console",
-            path="/support/",
-            menu_items=[
-                {
-                    "href": "/support/consultations/",
-                    "text": "Consultations",
-                    "active": request.path.startswith("/support/consultations"),
-                },
-                {
-                    "href": "/support/users/",
-                    "text": "Users",
-                    "active": request.path.startswith("/support/users"),
-                },
-                {
-                    "href": "/support/consultations/import-summary/",
-                    "text": "Import",
-                    "active": request.path.startswith("/support/consultations/import-summary"),
-                },
-                {
-                    "href": "/support/sign-out/",
-                    "text": "Sign out",
-                    "classes": "x-govuk-primary-navigation__item--right",
-                },
-            ],
-        )
-    else:
-        if request.user.is_authenticated:
+    if request.user.is_authenticated:
+        if current_app == "support_console":
+            app_config = AppConfig(
+                name="Consult support console",
+                path="/support/",
+                menu_items=[
+                    {
+                        "href": "/support/consultations/",
+                        "text": "Consultations",
+                        "active": request.path.startswith("/support/consultations"),
+                    },
+                    {
+                        "href": "/support/users/",
+                        "text": "Users",
+                        "active": request.path.startswith("/support/users"),
+                    },
+                    {
+                        "href": "/support/consultations/import-summary/",
+                        "text": "Import",
+                        "active": request.path.startswith("/support/consultations/import-summary"),
+                    },
+                    {
+                        "href": "/support/sign-out/",
+                        "text": "Sign out",
+                        "classes": "x-govuk-primary-navigation__item--right",
+                    },
+                ],
+            )
+        else:  # regular (non-support console) app
             menu_items = []
             if request.user.is_staff:
                 menu_items = [
@@ -93,8 +93,18 @@ def app_config(request: HttpRequest):
                     },
                 ]
             )
-        else:
-            menu_items = [
+
+            app_config = AppConfig(
+                name="Consult",
+                path="/",
+                menu_items=menu_items,
+            )
+
+    else:  # non-authenticated user
+        app_config = AppConfig(
+            name="Consult",
+            path="/",
+            menu_items=[
                 {
                     "href": "/how-it-works/",
                     "text": "How it works",
@@ -116,12 +126,7 @@ def app_config(request: HttpRequest):
                     "active": request.path == "/sign-in/",
                     "classes": "x-govuk-primary-navigation__item--right",
                 },
-            ]
-
-        app_config = AppConfig(
-            name="Consult",
-            path="/",
-            menu_items=menu_items,
+            ],
         )
 
     return {"app_config": app_config}

--- a/tests/integration/test_navigation.py
+++ b/tests/integration/test_navigation.py
@@ -1,0 +1,59 @@
+import pytest
+from webtest.app import AppError
+
+from consultation_analyser.factories import UserFactory
+from tests.helpers import sign_in
+
+CONSULTATIONS_ROUTE = "/consultations/"
+SUPPORT_ROUTE = "/support/consultations/"
+
+
+def assert_expected_menu_items(django_app, endpoint, menu_items):
+    response = django_app.get(endpoint)
+    response_header = str(response.html.header)
+
+    for menu_item in menu_items:
+        assert menu_item in response_header
+
+
+def test_not_authenticated_navigation(django_app):
+    expected_menu_items = ["How it works", "Data sharing", "Get involved", "Sign in"]
+
+    assert_expected_menu_items(django_app, "/", expected_menu_items)
+
+    with pytest.raises(AppError):  # expect a 404 response
+        assert_expected_menu_items(django_app, CONSULTATIONS_ROUTE, expected_menu_items)
+
+    with pytest.raises(AppError):
+        assert_expected_menu_items(django_app, SUPPORT_ROUTE, expected_menu_items)
+
+
+# Non-staff user
+@pytest.mark.django_db
+def test_authenticated_navigation(django_app):
+    UserFactory(email="email@example.com", password="admin")  # pragma: allowlist secret
+
+    sign_in(django_app, "email@example.com")
+
+    expected_menu_items = ["Your consultations", "Sign out"]
+
+    assert_expected_menu_items(django_app, CONSULTATIONS_ROUTE, expected_menu_items)
+
+    with pytest.raises(AppError):
+        assert_expected_menu_items(django_app, SUPPORT_ROUTE, expected_menu_items)
+
+
+@pytest.mark.django_db
+def test_authenticated_staff_navigation(django_app):
+    UserFactory(
+        email="email@example.com", password="admin", is_staff=True # pragma: allowlist secret`
+    )
+    sign_in(django_app, "email@example.com")
+
+    assert_expected_menu_items(
+        django_app, CONSULTATIONS_ROUTE, ["Support", "Your consultations", "Sign out"]
+    )
+
+    assert_expected_menu_items(
+        django_app, SUPPORT_ROUTE, ["Consultations", "Users", "Import", "Sign out"]
+    )


### PR DESCRIPTION
## Context
Currently, if you are logged out on prod and try accessing a support endpoint, the navigation bar reads 'sign out' not 'sign in', which has confused a few people thinking they've lost access to the console.

## Changes proposed in this pull request
* Updated the logic in the context processors to only display 'Sign in' only when users are logged out. 
* Added a test for the navigation display logic
* Some linting whitespace changes in `consultation_analyser/consultations/views/answers.py`

## Guidance to review
Check the test to see if you agree with what the 'expected menu' items should be for the consultations and the support page.

## Link to Trello ticket
https://trello.com/c/X5ppwWzq/413-sign-out-to-switch-to-sign-in-if-user-not-logged-in

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo