### PR TITLE
436: Remove blank respondents in dashboard

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -168,8 +168,11 @@ def respondents_json(
             Prefetch("sentimentmapping_set", to_attr="prefetched_sentimentmappings")
         )
 
-        respondents = models.Respondent.objects.filter(
-            consultation__slug=consultation_slug
+        respondents = models.Respondent.objects.annotate(
+            num_answers=Count("answer")
+        ).filter(
+            consultation__slug=consultation_slug,
+            num_answers__gt=0
         ).prefetch_related(
             Prefetch("answer_set", queryset=filtered_answers, to_attr="prefetched_answers")
         ).distinct()

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -172,7 +172,7 @@ def respondents_json(
             num_answers=Count("answer")
         ).filter(
             consultation__slug=consultation_slug,
-            num_answers__gt=0
+            num_answers__gt=0 #  Filter out respondents with no answers
         ).prefetch_related(
             Prefetch("answer_set", queryset=filtered_answers, to_attr="prefetched_answers")
         ).distinct()


### PR DESCRIPTION
## Context

Some respondents have no related answers, leading to lots of empty entries on the table and inflated numbers in terms of total respondents.

## Changes proposed in this pull request

This PR adds a filter that counts number of responses and removes ones that are not greater than 0. This does not cause any additional hits on the database and even improves response time due to processing fewer respondents.

## Guidance to review

Navigate to answers index template dashboard, confirm there is no entry without any answers.

## Link to Trello ticket

https://trello.com/c/DNUZfhKc/436-remove-blank-respondents-in-dashboard

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo