### PR TITLE
Correctly tag responses as evidence rich

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -168,52 +168,47 @@ def respondents_json(
             )
         )
 
-        respondents = (
-            models.Respondent.objects.annotate(
-                num_answers=Count(
-                    "answer", filter=Q(answer__question_part__question__slug=question_slug)
-                )
-            )
-            .filter(
-                consultation__slug=consultation_slug,
-                num_answers__gt=0,  #  Filter out respondents with no answers
-            )
-            .prefetch_related(
-                Prefetch("answer_set", queryset=filtered_answers, to_attr="prefetched_answers")
-            )
-            .distinct()
-        )
+        respondents = models.Respondent.objects.annotate(
+            num_answers=Count("answer")
+        ).filter(
+            consultation__slug=consultation_slug,
+            num_answers__gt=0 #  Filter out respondents with no answers
+        ).prefetch_related(
+            Prefetch("answer_set", queryset=filtered_answers, to_attr="prefetched_answers")
+        ).distinct()
 
-        data = {"all_respondents": []}
+        data = {
+            "all_respondents": []
+        }
 
         # Get individual data for each displayed respondent
         for respondent in respondents:
+
             # Defaults
             free_text_answer = None
             multiple_choice_answers = None
 
             # Free text response
             free_text_responses = [
-                answer
-                for answer in respondent.prefetched_answers
+                answer for answer in respondent.prefetched_answers
                 if answer.question_part.type == models.QuestionPart.QuestionType.FREE_TEXT
             ]
+
 
             if len(free_text_responses) > 0:
                 free_text_answer = free_text_responses[0]
 
-                respondent.themes = free_text_answer.prefetched_thememappings  # type: ignore
+                respondent.themes = free_text_answer.prefetched_thememappings # type: ignore
 
                 if len(free_text_answer.prefetched_sentimentmappings) > 0:
-                    respondent.sentiment = free_text_answer.prefetched_sentimentmappings[0]  # type: ignore
+                    respondent.sentiment = free_text_answer.prefetched_sentimentmappings[0] # type: ignore
 
                 if len(free_text_answer.prefetched_evidencerichmappings) > 0:
                     respondent.evidence_rich = free_text_answer.prefetched_evidencerichmappings[0]  # type: ignore
 
             # Multiple choice response
             multiple_choice_answers = [
-                answer
-                for answer in respondent.prefetched_answers
+                answer for answer in respondent.prefetched_answers
                 if answer.question_part.type == models.QuestionPart.QuestionType.MULTIPLE_OPTIONS
             ]
 
@@ -229,28 +224,28 @@ def respondents_json(
                     if hasattr(respondent, "sentiment")
                     and hasattr(respondent.sentiment, "position")
                     else "",
-                    "free_text_answer_text": free_text_answer.text  # type: ignore
+                "free_text_answer_text": free_text_answer.text # type: ignore
                     if hasattr(free_text_answer, "text")
                     else "",
-                    "demographic_data": hasattr(respondent, "data") or "",
-                    "themes": [
-                        {
-                            "id": theme.theme.id,
-                            "stance": theme.stance,
-                            "name": theme.theme.name,
-                            "description": theme.theme.description,
-                        }
-                        for theme in respondent.themes
-                    ]
+                "demographic_data": hasattr(respondent, "data") or "",
+                "themes": [
+                    {
+                        "id": theme.theme.id,
+                        "stance": theme.stance,
+                        "name": theme.theme.name,
+                        "description": theme.theme.description,
+                    }
+                    for theme in respondent.themes
+                ]
                     if hasattr(respondent, "themes")
                     else [],
-                    "multiple_choice_answer": [respondent.multiple_choice_answer.chosen_options]
+                "multiple_choice_answer": [respondent.multiple_choice_answer.chosen_options]
                     if hasattr(respondent, "multiple_choice_answer")
                     and hasattr(respondent.multiple_choice_answer, "chosen_options")
                     else [],
-                    "evidenceRich": True
+                "evidenceRich": True
                     if hasattr(respondent, "evidence_rich")
-                    and hasattr(respondent.evidence_rich, "evidence_rich")
+                    and respondent.evidence_rich.evidence_rich == True
                     else False,
                     "individual": True if hasattr(respondent, "individual") else False,
                 }

--- a/consultation_analyser/factories.py
+++ b/consultation_analyser/factories.py
@@ -219,3 +219,12 @@ class SentimentMappingFactory(DjangoModelFactory):
     answer = factory.SubFactory(FreeTextAnswerFactory)
     execution_run = factory.SubFactory(ExecutionRunFactory)
     position = fuzzy.FuzzyChoice(models.SentimentMapping.Position.values)
+
+
+class EvidenceRichMappingFactory(DjangoModelFactory):
+    class Meta:
+        model = models.EvidenceRichMapping
+
+    answer = factory.SubFactory(FreeTextAnswerFactory)
+    evidence_evaluation_execution_run = factory.SubFactory(ExecutionRunFactory)
+    evidence_rich = fake.boolean()

--- a/tests/integration/test_navigation.py
+++ b/tests/integration/test_navigation.py
@@ -46,7 +46,9 @@ def test_authenticated_navigation(django_app):
 @pytest.mark.django_db
 def test_authenticated_staff_navigation(django_app):
     UserFactory(
-        email="email@example.com", password="admin", is_staff=True # pragma: allowlist secret`
+        email="email@example.com",
+        password="admin",  # pragma: allowlist secret`
+        is_staff=True,
     )
     sign_in(django_app, "email@example.com")
 


### PR DESCRIPTION
## Context
Currently, all responses with an EvidenceRichMapping are displaying as evidence rich, even if the evidence_rich property is False.

## Changes proposed in this pull request
* Fix the logic for marking data for the FE json object as evidenceRich (line 249 in answers: everything else is a linting change).
* Write a test to check the above

## Guidance to review
Ask Rachael for the data to import to check locally (or just create some EvidenceRichMapping objects for a current local consultation, checking both true and false versions).

## Link to Trello ticket
https://trello.com/c/pbP6hDD8/437-fix-evidence-rich-display-everything-is-being-marked-as-evidence-rich

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo