### PR TITLE
Update prefetch to select related theme

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -159,7 +159,13 @@ def respondents_json(
 
         filtered_answers = (
             models.Answer.objects.filter(question_part__question__slug=question_slug)
-            .prefetch_related(Prefetch("thememapping_set", to_attr="prefetched_thememappings"))
+            .prefetch_related(
+                Prefetch(
+                    "thememapping_set",
+                    queryset=models.ThemeMapping.objects.select_related("theme"),
+                    to_attr="prefetched_thememappings",
+                )
+            )
             .prefetch_related(
                 Prefetch("evidencerichmapping_set", to_attr="prefetched_evidencerichmappings")
             )


### PR DESCRIPTION
I had a suspicion that looping through the theme keys for each response might be slowing down the query. I did a bit of digging and I think this solution should improve performance, we should now only have to fetch the relevant themes once rather than once per row.

I have tested this on a local deployment of the app and it seems to speed things up significantly, would be keen for others to play around with it and confirm if it is working.