### PR TITLE
443: If signed out, doesn't tell users to log in again to get access but shows error

### DIFF
--- a/consultation_analyser/error_pages/jinja2/error_pages/404.html
+++ b/consultation_analyser/error_pages/jinja2/error_pages/404.html
@@ -12,6 +12,9 @@
         <p class="govuk-body">
           If you pasted the web address, check you copied the entire address.
         </p>
+        <p class="govuk-body">
+          If you are signed out, try signing in.
+        </p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Context
When users try accessing a protected url when logged out, they get the 404 page. This sometimes confuses them as they think the url is incorrect, rather than they are logged out.

## Changes proposed in this pull request
There is an additional sentence on the 404 page to suggest signing in.

### Screenshot
![image](https://github.com/user-attachments/assets/422c60b2-e269-49dc-a177-5378c52e88ce)

## Guidance to review
Confirm 404 page has the additional phrase on signing in.

## Link to Trello ticket
https://trello.com/c/dieZvvoD/443-if-signed-out-doesnt-tell-users-to-log-in-again-to-get-access-but-shows-error

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo