### PR TITLE
Add has_more_pages to respondents json

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import TypedDict
 from uuid import UUID
 
 from django.core.cache import cache
@@ -11,6 +12,11 @@ from django.shortcuts import get_object_or_404, redirect, render
 
 from .. import models
 from .decorators import user_can_see_consultation, user_can_see_dashboards
+
+
+class DataDict(TypedDict):
+    all_respondents: list
+    has_more_pages: bool
 
 
 def filter_by_response_and_theme(
@@ -195,13 +201,17 @@ def respondents_json(
         consultation_slug=consultation_slug, question_slug=question_slug
     )
 
+    data: DataDict = {
+        "all_respondents": [],
+        "has_more_pages": False,
+    }
+
     # Pagination
     if page_size:
         pagination = Paginator(respondents, page_size)
         current_page = pagination.page(page)
         respondents = current_page.object_list
-
-    data: dict[str, list] = {"all_respondents": []}
+        data["has_more_pages"] = current_page.has_next()
 
     # Get individual data for each displayed respondent
     for respondent in respondents:

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -493,16 +493,16 @@ def test_respondents_json(client, question, consultation_user):
 
 
 @pytest.mark.parametrize(
-    "querystring, expected_count",
+    "querystring, expected_count, has_more_pages",
     [
-        ("?", 7),
-        ("?page_size=4", 4),
-        ("?page_size=4&page=2", 3),
+        ("?", 7, False),
+        ("?page_size=4", 4, True),
+        ("?page_size=4&page=2", 3, False),
     ],
 )
 @pytest.mark.django_db
 def test_respondents_json_pagination(
-    querystring, expected_count, client, consultation_user, question_part, question
+    querystring, expected_count, has_more_pages, client, consultation_user, question_part, question
 ):
     for i in range(7):
         respondent = RespondentFactory(
@@ -517,6 +517,7 @@ def test_respondents_json_pagination(
     assert response.status_code == 200
     response_json = response.json()
     assert len(response_json["all_respondents"]) == expected_count
+    assert response_json["has_more_pages"] == has_more_pages
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context
The FE currently keeps requesting the next page of results from the BE; however, there is no indication of when to stop.

## Changes proposed in this pull request
Adds a `has_more_pages` boolean to the respondents json to tell the FE to stop requesting more information

## Guidance to review
Is this a reasonable format?

## Link to Trello ticket

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo