### PR TITLE
Feature/caching delete

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -68,8 +68,14 @@ def get_respondents_for_question(
     # Cache data for question/consultation. Default timeout to not clearing cache ever.
     cache_key = f"respondents_{consultation_slug}_{question_slug}"
 
+    print(f"cache_key: {cache_key}")
+
     # Retrieve cached data
     respondents = cache.get(cache_key)
+    if not respondents:
+        print("nothing cached")
+    else:
+        print(f"respondents: {respondents.count()}")
 
     # If no cached data found
     if respondents is None:

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -68,8 +68,6 @@ def get_respondents_for_question(
     # Cache data for question/consultation. Default timeout to not clearing cache ever.
     cache_key = f"respondents_{consultation_slug}_{question_slug}"
 
-    print(f"cache_key: {cache_key}")
-
     # Retrieve cached data
     respondents = cache.get(cache_key)
 

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -63,9 +63,9 @@ def get_selected_option_summary(question: models.Question, respondents: QuerySet
 
 
 def get_respondents_for_question(
-    consultation_slug: str, question_slug: str, cache_timeout: int = 60 * 20
+    consultation_slug: str, question_slug: str, cache_timeout: int | None = None
 ) -> QuerySet[models.Respondent]:
-    # Cache data for question/consultation. Default timeout to 20 mins.
+    # Cache data for question/consultation. Default timeout to not clearing cache ever.
     cache_key = f"respondents_{consultation_slug}_{question_slug}"
 
     # Retrieve cached data

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -72,10 +72,6 @@ def get_respondents_for_question(
 
     # Retrieve cached data
     respondents = cache.get(cache_key)
-    if not respondents:
-        print("nothing cached")
-    else:
-        print(f"respondents: {respondents.count()}")
 
     # If no cached data found
     if respondents is None:

--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -48,6 +48,11 @@ def app_config(request: HttpRequest):
                 path="/support/",
                 menu_items=[
                     {
+                        "href": "/support/cache/delete/",
+                        "text": "Clear cache",
+                        "active": request.path.startswith("/support/cache/delete"),
+                    },
+                    {
                         "href": "/support/consultations/",
                         "text": "Consultations",
                         "active": request.path.startswith("/support/consultations"),

--- a/consultation_analyser/support_console/jinja2/support_console/cache/delete.html
+++ b/consultation_analyser/support_console/jinja2/support_console/cache/delete.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% set page_title = "Delete cache" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ page_title }}</h1>
+  <div>
+    <p class="govuk-body">Are you sure you want to delete the Django cache?</p>
+  </div>
+
+  <br />
+
+  <form method="post" novalidate>{{ csrf_input }}
+    {{ govukButton({
+      'text': "Yes, delete it",
+      'name': "confirm_deletion",
+      'classes': "govuk-button--warning"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/cache/delete.html
+++ b/consultation_analyser/support_console/jinja2/support_console/cache/delete.html
@@ -18,6 +18,11 @@
       'name': "confirm_deletion",
       'classes': "govuk-button--warning"
     }) }}
+    {{ govukButton({
+      'text': "No, go back",
+      'name': "cancel_deletion",
+      'classes': "govuk-button"
+    }) }}
   </form>
 
 {% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/cache/delete.html
+++ b/consultation_analyser/support_console/jinja2/support_console/cache/delete.html
@@ -6,7 +6,8 @@
 {% block content %}
   <h1 class="govuk-heading-l">{{ page_title }}</h1>
   <div>
-    <p class="govuk-body">Are you sure you want to delete the Django cache?</p>
+    <p class="govuk-body">Are you sure you want to delete the default Django cache?</p>
+    <p class="govuk-body">This includes cached data for the dashboard</p>
   </div>
 
   <br />

--- a/consultation_analyser/support_console/jinja2/support_console/cache/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/cache/show.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% set page_title = "Delete cache" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ page_title }}</h1>
+  <div>
+    <p class="govuk-body">Delete the Django cache (including cached dashboard data)?</p>
+  </div>
+
+  <br />
+
+  <form method="post" novalidate>{{ csrf_input }}
+    {{ govukButton({
+      'text': "Delete cache",
+      'name': "delete_cache",
+      'classes': "govuk-button--warning"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/cache/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/cache/show.html
@@ -6,7 +6,7 @@
 {% block content %}
   <h1 class="govuk-heading-l">{{ page_title }}</h1>
   <div>
-    <p class="govuk-body">Delete the Django cache (including cached dashboard data)?</p>
+    <p class="govuk-body">Delete the default Django cache (including cached dashboard data)?</p>
   </div>
 
   <br />

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import include, path
 
-from .views import consultations, consultations_users, pages, question_parts, users
+from .views import consultations, consultations_users, pages, question_parts, users, cache
 
 urlpatterns = [
     path("", lambda request: redirect("/support/consultations/"), name="support"),
@@ -67,6 +67,8 @@ urlpatterns = [
         consultations.import_summary,
         name="import_summary",
     ),
+    path("cache/delete/", cache.show, name="cache-delete"),
+    path("cache/delete-confirm/", cache.delete, name="cache-delete-confirmation"),
     path("admin/", admin.site.urls),
     path("django-rq/", include("django_rq.urls")),
 ]

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import include, path
 
-from .views import consultations, consultations_users, pages, question_parts, users, cache
+from .views import cache, consultations, consultations_users, pages, question_parts, users
 
 urlpatterns = [
     path("", lambda request: redirect("/support/consultations/"), name="support"),

--- a/consultation_analyser/support_console/views/cache.py
+++ b/consultation_analyser/support_console/views/cache.py
@@ -1,8 +1,8 @@
-from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render, redirect
-from django.core.cache import cache
-from django_rq import job
 from django.contrib import messages
+from django.core.cache import cache
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import redirect, render
+from django_rq import job
 
 
 @job("default", timeout=900)
@@ -26,4 +26,3 @@ def delete(request: HttpRequest) -> HttpResponse:
             )
             return redirect("support")
     return render(request, "support_console/cache/delete.html")
-

--- a/consultation_analyser/support_console/views/cache.py
+++ b/consultation_analyser/support_console/views/cache.py
@@ -1,0 +1,29 @@
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render, redirect
+from django.core.cache import cache
+from django_rq import job
+from django.contrib import messages
+
+
+@job("default", timeout=900)
+def delete_cache_job():
+    cache.clear()
+
+
+def show(request: HttpRequest) -> HttpResponse:
+    if request.POST:
+        return redirect("cache-delete-confirmation")
+    return render(request, "support_console/cache/show.html")
+
+
+def delete(request: HttpRequest) -> HttpResponse:
+    if request.POST:
+        if "confirm_deletion" in request.POST:
+            delete_cache_job.delay()
+            messages.success(
+                request,
+                "The consultation has been sent for deletion - check queue dashboard for progress",
+            )
+            return redirect("support")
+    return render(request, "support_console/cache/delete.html")
+

--- a/consultation_analyser/support_console/views/cache.py
+++ b/consultation_analyser/support_console/views/cache.py
@@ -17,4 +17,6 @@ def delete(request: HttpRequest) -> HttpResponse:
             cache.clear()
             messages.success(request, "The default cache has been deleted")
             return redirect("support")
+        elif "cancel_deletion" in request.POST:
+            return redirect("support")
     return render(request, "support_console/cache/delete.html")

--- a/consultation_analyser/support_console/views/cache.py
+++ b/consultation_analyser/support_console/views/cache.py
@@ -2,12 +2,6 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
-from django_rq import job
-
-
-@job("default", timeout=900)
-def delete_cache_job():
-    cache.clear()
 
 
 def show(request: HttpRequest) -> HttpResponse:
@@ -19,10 +13,8 @@ def show(request: HttpRequest) -> HttpResponse:
 def delete(request: HttpRequest) -> HttpResponse:
     if request.POST:
         if "confirm_deletion" in request.POST:
-            delete_cache_job.delay()
-            messages.success(
-                request,
-                "The consultation has been sent for deletion - check queue dashboard for progress",
-            )
+            # Note this clears the default cache only
+            cache.clear()
+            messages.success(request, "The default cache has been deleted")
             return redirect("support")
     return render(request, "support_console/cache/delete.html")

--- a/tests/integration/test_clear_cache.py
+++ b/tests/integration/test_clear_cache.py
@@ -1,0 +1,27 @@
+import pytest
+from django.core.cache import cache
+
+from consultation_analyser import factories
+from tests.helpers import sign_in
+
+
+@pytest.mark.django_db
+def test_delete_default_cache(django_app):
+    # Create and login an admin user
+    user = factories.UserFactory(email="email@example.com", is_staff=True)
+    sign_in(django_app, user.email)
+
+    # Put stuff in the default cache
+    cache.set("test_key", "test_value")
+    assert cache.get("test_key") == "test_value"
+
+    # Go to consultation page in support & click delete
+    delete_cache_page = django_app.get("/support/cache/delete/")
+    delete_confirmation_page = delete_cache_page.form.submit("delete_cache").follow()
+    assert "Are you sure" in delete_confirmation_page
+
+    # Confirm deletion
+    delete_confirmation_page.form.submit("confirm_deletion")
+
+    # Check cache has been deleted
+    assert cache.get("test_key") is None


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to be able to clear the cache manually e.g. for testing, when dashboard data is updated.

## Changes proposed in this pull request

* Add a button to allow us to manually clear the cache.
* Set the cache for the dashboard data to be `None` i.e. infinite until cleared (for anything else, the default timeout is 5 minutes). The cache will also be cleared on restart.

<!-- If there are UI changes, please include Before and After screenshots. -->
Support area:
![image](https://github.com/user-attachments/assets/a821f1f0-e097-4405-9092-63ef1a5a71ad)

Clear cache page:
![image](https://github.com/user-attachments/assets/75fbddb8-0ce7-44fd-bf30-6058292326b2)

Confirmation page:
![image](https://github.com/user-attachments/assets/54d02c00-b869-4961-b842-cc57627b5c98)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

* Is it sensible to set the cache to be infinite?
* The current default cache https://docs.djangoproject.com/en/5.2/topics/cache/#local-memory-caching - should we be using this?


## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A