### PR TITLE
Fix broken link

### DIFF
--- a/consultation_analyser/support_console/jinja2/support_console/users/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/users/show.html
@@ -45,7 +45,7 @@
                   {{ datetime(consultation.created_at) }}
                 </td>
                 <td class="govuk-table__cell">
-                  <a class="govuk-link" href="/support/consultations/{{ consultation.slug }}">View in support</a><br />
+                  <a class="govuk-link" href="/support/consultations/{{ consultation.id }}">View in support</a><br />
                   <a class="govuk-link" href="/consultations/{{ consultation.slug }}">View on frontend</a>
                 </td>
               </tr>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Fix broken "View in support" to link to a consultation in a given user page in the support area.

![image](https://github.com/user-attachments/assets/eda55218-eb95-4874-9bfd-a3b606ed0dba)


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo