### PR TITLE
actually remove references to 'individual'

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -168,7 +168,6 @@ def build_respondent_data(respondent: models.Respondent, response: models.Respon
         "themes": [],
         "multiple_choice_answer": [response.chosen_options] if response.chosen_options else [],
         "evidenceRich": False,
-        "individual": respondent.demographics.get("individual", False),
     }
 
     if hasattr(response, "annotation") and response.annotation:
@@ -346,7 +345,6 @@ def index(
         "csv_button_data": [],  # Empty - loaded via AJAX
         "multiple_choice_summary": [],  # Empty - loaded via AJAX
         "stance_options": models.ResponseAnnotation.Sentiment.names,
-        "has_individual_data": False, # Shouldn't use this, demographic filters work more generally
     }
 
     return render(request, "consultations/answers/index.html", context)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Finish removing final references to "individual" as a special case. It does still appear in some tests, but it's treated like all other demographic data.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo