### PR TITLE
Feature/bulk ingest fix

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -492,7 +492,7 @@ def import_respondents(consultation: Consultation, consultation_code: str):
 
     respondents_to_save = []
 
-    for line in response["Body"].iter_lines():
+    for i, line in enumerate(response["Body"].iter_lines()):
         respondent_data = json.loads(line.decode("utf-8"))
         themefinder_id = respondent_data.get("themefinder_id")
         demographics = respondent_data.get("demographic_data", {})
@@ -507,7 +507,7 @@ def import_respondents(consultation: Consultation, consultation_code: str):
         if len(respondents_to_save) >= DEFAULT_BATCH_SIZE:
             Respondent.objects.bulk_create(respondents_to_save)
             respondents_to_save = []
-            logger.info("saved batch of Respondents")
+            logger.info("saved %s Respondents", i)
 
     Respondent.objects.bulk_create(respondents_to_save)
 
@@ -557,6 +557,7 @@ def create_consultation(
         for question_folder in question_folders:
             queue.enqueue(
                 import_question,
+                consultation,
                 consultation_code,
                 timestamp,
                 question_folder,

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -314,9 +314,8 @@ def import_responses(question: Question, responses_file_key: str):
         raise
 
 
-def import_themes(question: Question, outputs_path: str):
+def import_themes(question: Question, output_folder: str):
     s3_client = boto3.client("s3")
-    output_folder = f"{outputs_path}question_part_{question.number}/"
     themes_file_key = f"{output_folder}themes.json"
     response = s3_client.get_object(Bucket=settings.AWS_BUCKET_NAME, Key=themes_file_key)
     theme_data = json.loads(response["Body"].read())

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -388,8 +388,25 @@ def import_responses(
 
 
 def import_question(
-    consultation: Consultation, bucket_name: str, question_folder: str, outputs_path: str
+    consultation: Consultation,
+    consultation_code: str,
+    timestamp: str,
+    question_folder: str,
 ):
+    """
+    Import question data for a consultation.
+    Args:
+        consultation: Consultation object for questions
+        consultation_code:
+        timestamp: Timestamp folder name for the AI outputs
+        question_folder: S3 folder name containing the consultation data
+    """
+    logger.info(f"Starting question import for consultation {consultation.title})")
+
+    bucket_name = settings.AWS_BUCKET_NAME
+    base_path = f"app_data/{consultation_code}/"
+    outputs_path = f"{base_path}outputs/mapping/{timestamp}/"
+
     s3_client = boto3.client("s3")
 
     question_num_str = question_folder.split("/")[-2].replace("question_part_", "")
@@ -537,10 +554,9 @@ def create_consultation(
         for question_folder in question_folders:
             queue.enqueue(
                 import_question,
-                consultation,
-                settings.AWS_BUCKET_NAME,
+                consultation_code,
+                timestamp,
                 question_folder,
-                f"app_data/{consultation_code}/outputs/mapping/{timestamp}/",
             )
 
         logger.info(f"Imported {len(question_folders)} questions")

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -476,6 +476,7 @@ def import_question(
         logger.error(f"Error importing question data for {consultation_code}: {str(e)}")
         raise
 
+
 def import_respondents(consultation: Consultation, consultation_code: str):
     """
     Import respondent data for a consultation.
@@ -507,7 +508,7 @@ def import_respondents(consultation: Consultation, consultation_code: str):
         if len(respondents_to_save) >= DEFAULT_BATCH_SIZE:
             Respondent.objects.bulk_create(respondents_to_save)
             respondents_to_save = []
-            logger.info("saved %s Respondents", i)
+            logger.info("saved %s Respondents", i + 1)
 
     Respondent.objects.bulk_create(respondents_to_save)
 

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -202,13 +202,13 @@ def import_response_annotation_themes(question: Question, output_folder: str):
                 )
             )
             if len(objects_to_save) >= DEFAULT_BATCH_SIZE:
-                ResponseAnnotationTheme.objects.batch_create(objects_to_save)
+                ResponseAnnotationTheme.objects.bulk_create(objects_to_save)
                 objects_to_save = []
                 logger.info(
                     "saved %s ResponseAnnotationTheme for question %s", i + 1, question.number
                 )
 
-    ResponseAnnotationTheme.objects.batch_create(objects_to_save)
+    ResponseAnnotationTheme.objects.bulk_create(objects_to_save)
 
 
 def import_response_annotations(question: Question, output_folder: str):

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -456,46 +456,6 @@ def import_question(
     import_mapping(consultation, question, output_folder)
 
 
-def import_questions(
-    consultation: Consultation,
-    consultation_code: str,
-    timestamp: str,
-):
-    """
-    Import question data for a consultation.
-
-    Args:
-        consultation: Consultation object for questions
-        consultation_code: S3 folder name containing the consultation data
-        timestamp: Timestamp folder name for the AI outputs
-    """
-
-    logger.info(f"Starting question import for consultation {consultation.title})")
-
-    bucket_name = settings.AWS_BUCKET_NAME
-    base_path = f"app_data/{consultation_code}/"
-    inputs_path = f"{base_path}inputs/"
-    outputs_path = f"{base_path}outputs/mapping/{timestamp}/"
-    queue = get_queue(default_timeout=15000)
-    try:
-        question_folders = get_question_folders(inputs_path, bucket_name)
-
-        for question_folder in question_folders:
-            queue.enqueue(
-                import_question,
-                consultation,
-                bucket_name,
-                question_folder,
-                outputs_path,
-            )
-
-        logger.info(f"Imported {len(question_folders)} questions")
-
-    except Exception as e:
-        logger.error(f"Error importing question data for {consultation_code}: {str(e)}")
-        raise
-
-
 def import_respondents(consultation: Consultation, consultation_code: str):
     """
     Import respondent data for a consultation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
 ]
 
 [tool.poetry.dependencies]
-python = "3.12.3"
+python = ">=3.12,<3.13"
 django = "^5.2"
 django-environ = "^0.12.0"
 psycopg = "^3.2.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.12,<3.13"
+python = "3.12.3"
 django = "^5.2"
 django-environ = "^0.12.0"
 psycopg = "^3.2.9"

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -14,9 +14,9 @@ from consultation_analyser.support_console.ingest import (
     create_consultation,
     get_consultation_codes,
     get_question_folders,
-    import_mapping,
-    import_question,
+    import_questions,
     import_respondents,
+    import_response_annotations,
     import_responses,
     validate_consultation_structure,
 )
@@ -323,8 +323,10 @@ class TestQuestionsImport:
         Respondent.objects.create(consultation=consultation, themefinder_id=2)
 
         # Run the import
-        import_question(
-            consultation, consultation_code, "2024-01-01", "app_data/test/inputs/question_part_1/"
+        import_questions(
+            consultation,
+            consultation_code,
+            "2024-01-01",
         )
 
         # Verify results
@@ -371,11 +373,10 @@ class TestQuestionsImport:
         consultation_code = "test"
 
         with pytest.raises(ValueError) as exc_info:
-            import_question(
+            import_questions(
                 consultation,
                 consultation_code,
                 "2024-01-01",
-                "app_data/test/inputs/question_part_1/",
             )
 
         assert "Question text is required" in str(exc_info.value)
@@ -400,7 +401,8 @@ class TestResponsesImport:
         Respondent.objects.create(consultation=consultation, themefinder_id=2)
 
         # Run the import
-        import_responses(consultation, question, question_folder)
+        responses_file_key = f"{question_folder}responses.jsonl"
+        import_responses(question, responses_file_key)
 
         # Verify results
         responses = Response.objects.filter(question=question)
@@ -429,7 +431,7 @@ class TestMappingImport:
         Response.objects.create(respondent=respondent_2, question=question)
 
         # Run the import
-        import_mapping(consultation, question, output_folder)
+        import_response_annotations(question, output_folder)
 
         # Verify results
         annotations = ResponseAnnotation.objects.filter(

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -15,7 +15,7 @@ from consultation_analyser.support_console.ingest import (
     get_consultation_codes,
     get_question_folders,
     import_mapping,
-    import_questions,
+    import_question,
     import_respondents,
     import_responses,
     validate_consultation_structure,
@@ -329,7 +329,7 @@ class TestQuestionsImport:
         mock_queue.enqueue = MagicMock()
 
         # Run the import
-        import_questions(consultation, consultation_code, "2024-01-01")
+        import_question(consultation, consultation_code, "2024-01-01")
 
         # Verify results
         questions = Question.objects.filter(consultation=consultation)
@@ -384,7 +384,7 @@ class TestQuestionsImport:
         consultation_code = "test"
 
         with pytest.raises(ValueError) as exc_info:
-            import_questions(consultation, consultation_code, "2024-01-01")
+            import_question(consultation, consultation_code, "2024-01-01")
 
         assert "Question text is required" in str(exc_info.value)
 


### PR DESCRIPTION
## Context

Our underpowered Redis was falling over because three methods are loading all the file data into it as arguments:
* `save_mapping_data(…, responses)`
* `import_responses(…, responses_data)`
* `import_respondents(…,respondents_data)`

## Changes proposed in this pull request

1. I have reverted(?) `import_responses` and `import_respondents` to run the import sequentially in batches rather than in parallel. Yes, this takes forever, but it does work! If we wanted to improve the speed of this we could either batch the job but by reference, e.g. `import_responses(..., start_row: int, end_row: int)` or use something like https://github.com/palewire/django-postgres-copy
2. I have merged `import_mapping` & `save_mapping_data` and then split them into:
    * `import_response_annotations`
    * `import_response_annotation_themes`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo