### PR TITLE
feature/initial-admin-users

### DIFF
--- a/consultation_analyser/consultations/management/commands/createadminusers.py
+++ b/consultation_analyser/consultations/management/commands/createadminusers.py
@@ -4,16 +4,12 @@ from django.core.management import BaseCommand
 
 from consultation_analyser.authentication.models import User
 
-
 class Command(BaseCommand):
     help = "creates initial admin users who can add others"
 
     def handle(self, *args, **options):
         for email in os.environ.get("ADMIN_USERS", "").split(","):
-            email = email.strip()
-            try:
-                user = User.objects.get(email=email)
-                user.is_staff = True
-                user.save()
-            except User.DoesNotExist:
-                User.objects.create(email=email, is_staff=True)
+            User.objects.update_or_create(
+                email=email.strip(),
+                defaults={'is_staff': True}
+            )

--- a/consultation_analyser/consultations/management/commands/createadminusers.py
+++ b/consultation_analyser/consultations/management/commands/createadminusers.py
@@ -1,12 +1,12 @@
 import os
+from logging import getLogger
 
 from django.core.management import BaseCommand
 
 from consultation_analyser.authentication.models import User
 
-from logging import getLogger
-
 logger = getLogger(__file__)
+
 
 class Command(BaseCommand):
     help = "creates initial admin users who can add others"
@@ -14,8 +14,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         for email in os.environ.get("ADMIN_USERS", "").split(","):
             user, created = User.objects.update_or_create(
-                email=email.strip(),
-                defaults={'is_staff': True}
+                email=email.strip(), defaults={"is_staff": True}
             )
             if created:
                 logger.info("created %s as admin", user.email)

--- a/consultation_analyser/consultations/management/commands/createadminusers.py
+++ b/consultation_analyser/consultations/management/commands/createadminusers.py
@@ -1,0 +1,19 @@
+import os
+
+from django.core.management import BaseCommand
+
+from consultation_analyser.authentication.models import User
+
+
+class Command(BaseCommand):
+    help = "creates initial admin users who can add others"
+
+    def handle(self, *args, **options):
+        for email in os.environ.get("ADMIN_USERS", "").split(","):
+            email = email.strip()
+            try:
+                user = User.objects.get(email=email)
+                user.is_staff = True
+                user.save()
+            except User.DoesNotExist:
+                User.objects.create(email=email, is_staff=True)

--- a/consultation_analyser/consultations/management/commands/createadminusers.py
+++ b/consultation_analyser/consultations/management/commands/createadminusers.py
@@ -4,12 +4,20 @@ from django.core.management import BaseCommand
 
 from consultation_analyser.authentication.models import User
 
+from logging import getLogger
+
+logger = getLogger(__file__)
+
 class Command(BaseCommand):
     help = "creates initial admin users who can add others"
 
     def handle(self, *args, **options):
         for email in os.environ.get("ADMIN_USERS", "").split(","):
-            User.objects.update_or_create(
+            user, created = User.objects.update_or_create(
                 email=email.strip(),
                 defaults={'is_staff': True}
             )
+            if created:
+                logger.info("created %s as admin", user.email)
+            else:
+                logger.info("set %s as admin", user.email)

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -16,6 +16,7 @@ locals {
     "APP_BUCKET"                           = local.secret_env_vars.APP_BUCKET,
     "GUNICORN_WORKERS"                     = local.secret_env_vars.GUNICORN_WORKERS,
     "GUNICORN_TIMEOUT"                     = local.secret_env_vars.GUNICORN_TIMEOUT,
+    "ADMIN_USERS"                          = local.secret_env_vars.ADMIN_USERS
 
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
 ]
 
 [tool.poetry.dependencies]
-python = "3.13"
+python = "3.12.3"
 django = "^5.2"
 django-environ = "^0.12.0"
 psycopg = "^3.2.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
 ]
 
 [tool.poetry.dependencies]
-python = "3.12.3"
+python = "3.13"
 django = "^5.2"
 django-environ = "^0.12.0"
 psycopg = "^3.2.9"

--- a/start.sh
+++ b/start.sh
@@ -3,5 +3,6 @@
 venv/bin/django-admin migrate
 venv/bin/django-admin collectstatic --noinput
 venv/bin/django-admin compress --force --engine jinja2
+venv/bin/django-admin createadminusers
 
 exec venv/bin/gunicorn -c ./consultation_analyser/gunicorn.py consultation_analyser.wsgi


### PR DESCRIPTION
## Context

As a PM I need a safe way to be able to set an initial admin user(s) so that they can create other users

## Changes proposed in this pull request

A management command that runs on-start has been added that creates admins from an environment variable

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo