### PR TITLE
Add /consultation/ to s3 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ On any environment, if you are a staff user, you can give other users permission
 ## Importing data
 
 ### Data import format
-Data should be stored in the appropriate S3 bucket (`AWS_DATA_BUCKET`) and within a folder called `app_data`.
+Data should be stored in the appropriate S3 bucket (`AWS_DATA_BUCKET`) and within a folder called `app_data/consultations/`.
 
 It should be stored in the following structure for a given consultation:
 ```

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -57,14 +57,16 @@ def get_consultation_codes() -> list[dict]:
     """
     try:
         s3 = boto3.resource("s3")
-        objects = s3.Bucket(settings.AWS_BUCKET_NAME).objects.filter(Prefix="app_data/")
+        objects = s3.Bucket(settings.AWS_BUCKET_NAME).objects.filter(
+            Prefix="app_data/consultations/"
+        )
 
         # Get unique consultation folders
         consultation_codes = set()
         for obj in objects:
             parts = obj.key.split("/")
-            if len(parts) >= 2 and parts[1]:  # Has consultation code
-                consultation_codes.add(parts[1])
+            if len(parts) >= 3 and parts[2]:  # Has consultation code
+                consultation_codes.add(parts[2])
 
         # Format for dropdown
         return [{"text": code, "value": code} for code in sorted(consultation_codes)]
@@ -86,7 +88,7 @@ def validate_consultation_structure(
     errors = []
 
     # Define required structure
-    base_path = f"app_data/{consultation_code}/"
+    base_path = f"app_data/consultations/{consultation_code}/"
     inputs_path = f"{base_path}inputs/"
     outputs_path = f"{base_path}outputs/mapping/{timestamp}/"
 
@@ -351,7 +353,7 @@ def import_questions(
     logger.info(f"Starting question import for consultation {consultation.title})")
 
     bucket_name = settings.AWS_BUCKET_NAME
-    base_path = f"app_data/{consultation_code}/"
+    base_path = f"app_data/consultations/{consultation_code}/"
     outputs_path = f"{base_path}outputs/mapping/{timestamp}/"
 
     queue = get_queue(default_timeout=DEFAULT_TIMEOUT_SECONDS)
@@ -359,7 +361,7 @@ def import_questions(
     try:
         s3_client = boto3.client("s3")
         question_folders = get_question_folders(
-            f"app_data/{consultation_code}/inputs/", settings.AWS_BUCKET_NAME
+            f"app_data/consultations/{consultation_code}/inputs/", settings.AWS_BUCKET_NAME
         )
 
         for question_folder in question_folders:
@@ -417,7 +419,7 @@ def import_respondents(consultation: Consultation, consultation_code: str):
     logger.info(f"Starting import_respondents batch for consultation {consultation.title})")
 
     s3_client = boto3.client("s3")
-    respondents_file_key = f"app_data/{consultation_code}/inputs/respondents.jsonl"
+    respondents_file_key = f"app_data/consultations/{consultation_code}/inputs/respondents.jsonl"
     response = s3_client.get_object(Bucket=settings.AWS_BUCKET_NAME, Key=respondents_file_key)
 
     respondents_to_save = []

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_consultation.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_consultation.html
@@ -38,11 +38,11 @@
         </li>
         {% endfor %}
       </ul>
-      
+
       {% set missing_files = validation_errors | selectattr('type', 'equalto', 'missing_file') | list %}
       {% set missing_outputs = validation_errors | selectattr('type', 'equalto', 'missing_output') | list %}
       {% set format_issues = validation_errors | selectattr('type', 'in', ['invalid_format', 'empty_file']) | list %}
-      
+
       {% if missing_files or missing_outputs %}
       <div class="govuk-inset-text">
         <h3 class="govuk-heading-s">What you need to do:</h3>
@@ -60,7 +60,7 @@
         <p class="govuk-body-s">Once you've resolved these issues, you can try importing again.</p>
       </div>
       {% endif %}
-      
+
       <details class="govuk-details">
         <summary class="govuk-details__summary">
           <span class="govuk-details__summary-text">
@@ -84,7 +84,7 @@
 <p class="govuk-body">This will import both the consultation data (questions, respondents, responses) and AI analysis
   results (themes, sentiment, evidence) sequentially.</p>
 
-<p class="govuk-body">Data should be saved in: <code>{{ bucket_name }}/app_data/[CONSULTATION FOLDER]</code></p>
+<p class="govuk-body">Data should be saved in: <code>{{ bucket_name }}/app_data/consultations/[CONSULTATION FOLDER]</code></p>
 
 {{ govukDetails({
 'summaryText': 'Expected S3 Structure',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,44 +115,50 @@ def mock_consultation_input_objects(mock_s3_bucket):
         [json.dumps(evidence_rich_mapping) for evidence_rich_mapping in evidence_rich_mappings_2]
     )
 
-    conn.Object(mock_s3_bucket, "app_data/con1/inputs/respondents.jsonl").put(
+    conn.Object(mock_s3_bucket, "app_data/consultations/con1/inputs/respondents.jsonl").put(
         Body=respondents_jsonl
     )
-    conn.Object(mock_s3_bucket, "app_data/con1/inputs/question_part_1/question.json").put(
-        Body=json.dumps(question_part_1)
-    )
-    conn.Object(mock_s3_bucket, "app_data/con1/inputs/question_part_1/responses.jsonl").put(
-        Body=responses_jsonl_1
-    )
-    conn.Object(mock_s3_bucket, "app_data/con1/inputs/question_part_2/question.json").put(
-        Body=json.dumps(question_part_2)
-    )
-    conn.Object(mock_s3_bucket, "app_data/con1/inputs/question_part_2/responses.jsonl").put(
-        Body=responses_jsonl_2
-    )
     conn.Object(
-        mock_s3_bucket, "app_data/con1/outputs/mapping/2025-04-01/question_part_1/themes.json"
+        mock_s3_bucket, "app_data/consultations/con1/inputs/question_part_1/question.json"
+    ).put(Body=json.dumps(question_part_1))
+    conn.Object(
+        mock_s3_bucket, "app_data/consultations/con1/inputs/question_part_1/responses.jsonl"
+    ).put(Body=responses_jsonl_1)
+    conn.Object(
+        mock_s3_bucket, "app_data/consultations/con1/inputs/question_part_2/question.json"
+    ).put(Body=json.dumps(question_part_2))
+    conn.Object(
+        mock_s3_bucket, "app_data/consultations/con1/inputs/question_part_2/responses.jsonl"
+    ).put(Body=responses_jsonl_2)
+    conn.Object(
+        mock_s3_bucket,
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_1/themes.json",
     ).put(Body=json.dumps(themes))
     conn.Object(
-        mock_s3_bucket, "app_data/con1/outputs/mapping/2025-04-01/question_part_2/themes.json"
+        mock_s3_bucket,
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_2/themes.json",
     ).put(Body=json.dumps(themes))
     conn.Object(
-        mock_s3_bucket, "app_data/con1/outputs/mapping/2025-04-01/question_part_1/mapping.jsonl"
+        mock_s3_bucket,
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_1/mapping.jsonl",
     ).put(Body=theme_mappings_jsonl)
     conn.Object(
-        mock_s3_bucket, "app_data/con1/outputs/mapping/2025-04-01/question_part_2/mapping.jsonl"
+        mock_s3_bucket,
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_2/mapping.jsonl",
     ).put(Body=theme_mappings_2_jsonl)
     conn.Object(
-        mock_s3_bucket, "app_data/con1/outputs/mapping/2025-04-01/question_part_1/sentiment.jsonl"
+        mock_s3_bucket,
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_1/sentiment.jsonl",
     ).put(Body=sentiment_mappings_jsonl)
     conn.Object(
-        mock_s3_bucket, "app_data/con1/outputs/mapping/2025-04-01/question_part_2/sentiment.jsonl"
+        mock_s3_bucket,
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_2/sentiment.jsonl",
     ).put(Body=sentiment_mappings_2_jsonl)
     conn.Object(
         mock_s3_bucket,
-        "app_data/con1/outputs/mapping/2025-04-01/question_part_1/detail_detection.jsonl",
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_1/detail_detection.jsonl",
     ).put(Body=evidence_rich_mappings_jsonl)
     conn.Object(
         mock_s3_bucket,
-        "app_data/con1/outputs/mapping/2025-04-01/question_part_2/detail_detection.jsonl",
+        "app_data/consultations/con1/outputs/mapping/2025-04-01/question_part_2/detail_detection.jsonl",
     ).put(Body=evidence_rich_mappings_2_jsonl)

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -73,22 +73,22 @@ class TestGetQuestionFolders:
     def test_get_question_folders(self, mock_boto3):
         # Mock S3 objects
         mock_objects = [
-            Mock(key="app_data/test/inputs/question_part_1/question.json"),
-            Mock(key="app_data/test/inputs/question_part_1/responses.jsonl"),
-            Mock(key="app_data/test/inputs/question_part_2/question.json"),
-            Mock(key="app_data/test/inputs/question_part_2/responses.jsonl"),
-            Mock(key="app_data/test/inputs/other_file.txt"),
+            Mock(key="app_data/consultations/test/inputs/question_part_1/question.json"),
+            Mock(key="app_data/consultations/test/inputs/question_part_1/responses.jsonl"),
+            Mock(key="app_data/consultations/test/inputs/question_part_2/question.json"),
+            Mock(key="app_data/consultations/test/inputs/question_part_2/responses.jsonl"),
+            Mock(key="app_data/consultations/test/inputs/other_file.txt"),
         ]
 
         mock_bucket = Mock()
         mock_bucket.objects.filter.return_value = mock_objects
         mock_boto3.resource.return_value.Bucket.return_value = mock_bucket
 
-        result = get_question_folders("app_data/test/inputs/", "test-bucket")
+        result = get_question_folders("app_data/consultations/test/inputs/", "test-bucket")
 
         expected = [
-            "app_data/test/inputs/question_part_1/",
-            "app_data/test/inputs/question_part_2/",
+            "app_data/consultations/test/inputs/question_part_1/",
+            "app_data/consultations/test/inputs/question_part_2/",
         ]
         assert sorted(result) == sorted(expected)
 
@@ -98,7 +98,7 @@ class TestGetQuestionFolders:
         mock_bucket.objects.filter.return_value = []
         mock_boto3.resource.return_value.Bucket.return_value = mock_bucket
 
-        result = get_question_folders("app_data/test/inputs/", "test-bucket")
+        result = get_question_folders("app_data/consultations/test/inputs/", "test-bucket")
         assert result == []
 
 
@@ -109,10 +109,10 @@ class TestGetConsultationCodes:
         mock_settings.AWS_BUCKET_NAME = "test-bucket"
 
         mock_objects = [
-            Mock(key="app_data/consultation1/inputs/file.json"),
-            Mock(key="app_data/consultation2/inputs/file.json"),
-            Mock(key="app_data/consultation1/outputs/file.json"),
-            Mock(key="app_data/other/file.json"),
+            Mock(key="app_data/consultations/consultation1/inputs/file.json"),
+            Mock(key="app_data/consultations/consultation2/inputs/file.json"),
+            Mock(key="app_data/consultations/consultation1/outputs/file.json"),
+            Mock(key="app_data/consultations/other/file.json"),
         ]
 
         mock_bucket = Mock()
@@ -142,7 +142,7 @@ class TestValidateConsultationStructure:
     @patch("consultation_analyser.support_console.ingest.boto3")
     @patch("consultation_analyser.support_console.ingest.get_question_folders")
     def test_validate_consultation_structure_valid(self, mock_get_folders, mock_boto3):
-        mock_get_folders.return_value = ["app_data/test/inputs/question_part_1/"]
+        mock_get_folders.return_value = ["app_data/consultations/test/inputs/question_part_1/"]
 
         mock_s3_client = Mock()
         mock_s3_client.head_object.return_value = {}
@@ -174,7 +174,7 @@ class TestValidateConsultationStructure:
     def test_validate_consultation_structure_missing_respondents(
         self, mock_get_folders, mock_boto3
     ):
-        mock_get_folders.return_value = ["app_data/test/inputs/question_part_1/"]
+        mock_get_folders.return_value = ["app_data/consultations/test/inputs/question_part_1/"]
 
         mock_s3_client = Mock()
 
@@ -221,7 +221,7 @@ class TestImportConsultationFullFlow:
         user = User.objects.create_user(email="test@example.com")
 
         mock_settings.AWS_BUCKET_NAME = "test-bucket"
-        mock_get_folders.return_value = ["app_data/test/inputs/question_part_1/"]
+        mock_get_folders.return_value = ["app_data/consultations/test/inputs/question_part_1/"]
 
         # Mock S3 responses
         mock_s3_client = Mock()
@@ -313,7 +313,7 @@ class TestQuestionsImport:
 
         # Mock S3 responses
         mock_s3_client = Mock()
-        mock_get_folders.return_value = ["app_data/test/inputs/question_part_1/"]
+        mock_get_folders.return_value = ["app_data/consultations/test/inputs/question_part_1/"]
         mock_s3_client.get_object.side_effect = get_object_side_effect
         mock_boto3.client.return_value = mock_s3_client
 
@@ -348,7 +348,7 @@ class TestQuestionsImport:
 
         # Mock S3 responses
         mock_s3_client = Mock()
-        mock_get_folders.return_value = ["app_data/test/inputs/question_part_1/"]
+        mock_get_folders.return_value = ["app_data/consultations/test/inputs/question_part_1/"]
 
         # Mock question file
         question_data = b'{"question_text": ""}'
@@ -396,7 +396,7 @@ class TestResponsesImport:
 
         consultation = Consultation.objects.create(title="Test Consultation")
         question = Question.objects.create(consultation=consultation, number=1)
-        question_folder = "app_data/test/outputs/2024-01-01/question_part_1/"
+        question_folder = "app_data/consultations/test/outputs/2024-01-01/question_part_1/"
         Respondent.objects.create(consultation=consultation, themefinder_id=1)
         Respondent.objects.create(consultation=consultation, themefinder_id=2)
 
@@ -420,7 +420,7 @@ class TestMappingImport:
         mock_s3_client = Mock()
         mock_s3_client.get_object.side_effect = get_object_side_effect
         mock_boto3.client.return_value = mock_s3_client
-        output_folder = "app_data/test/outputs/mapping/2024-01-01/"
+        output_folder = "app_data/consultations/test/outputs/mapping/2024-01-01/"
 
         consultation = Consultation.objects.create(title="Test Consultation")
         question = Question.objects.create(consultation=consultation, number=1)

--- a/tests/unit/test_validation_utils.py
+++ b/tests/unit/test_validation_utils.py
@@ -5,55 +5,57 @@ from consultation_analyser.support_console.validation_utils import (
 
 class TestFormatValidationError:
     def test_missing_required_file(self):
-        error = "Missing required file: app_data/test/inputs/respondents.jsonl"
+        error = "Missing required file: app_data/consultations/test/inputs/respondents.jsonl"
         result = format_validation_error(error)
         assert result["type"] == "missing_file"
         assert "respondents.jsonl" in result["message"]
-        assert result["file_path"] == "app_data/test/inputs/respondents.jsonl"
+        assert result["file_path"] == "app_data/consultations/test/inputs/respondents.jsonl"
 
     def test_missing_file_with_question_part(self):
-        error = "Missing app_data/test/inputs/question_part_1/question.json"
+        error = "Missing app_data/consultations/test/inputs/question_part_1/question.json"
         result = format_validation_error(error)
         assert result["type"] == "missing_file"
         assert "question.json" in result["message"]
         assert "question part 1" in result["message"]
 
     def test_missing_output_file(self):
-        error = "Missing output file: app_data/test/outputs/mapping/2024-01-01/question_part_1/themes.json"
+        error = "Missing output file: app_data/consultations/test/outputs/mapping/2024-01-01/question_part_1/themes.json"
         result = format_validation_error(error)
         assert result["type"] == "missing_output"
         assert "themes.json" in result["message"]
         assert "question part 1" in result["message"]
 
     def test_no_questions_found(self):
-        error = "No question_part folders found in app_data/test/inputs/"
+        error = "No question_part folders found in app_data/consultations/test/inputs/"
         result = format_validation_error(error)
         assert result["type"] == "no_questions"
         assert "No question folders found" in result["message"]
 
     def test_invalid_json(self):
-        error = "Invalid JSON in app_data/test/inputs/question_part_1/question.json"
+        error = "Invalid JSON in app_data/consultations/test/inputs/question_part_1/question.json"
         result = format_validation_error(error)
         assert result["type"] == "invalid_format"
         assert "question.json" in result["message"]
         assert "invalid JSON format" in result["message"]
 
     def test_invalid_jsonl(self):
-        error = "Invalid JSONL in app_data/test/inputs/question_part_1/responses.jsonl"
+        error = (
+            "Invalid JSONL in app_data/consultations/test/inputs/question_part_1/responses.jsonl"
+        )
         result = format_validation_error(error)
         assert result["type"] == "invalid_format"
         assert "responses.jsonl" in result["message"]
         assert "invalid JSONL format" in result["message"]
 
     def test_empty_file(self):
-        error = "Empty file: app_data/test/inputs/question_part_1/responses.jsonl"
+        error = "Empty file: app_data/consultations/test/inputs/question_part_1/responses.jsonl"
         result = format_validation_error(error)
         assert result["type"] == "empty_file"
         assert "responses.jsonl" in result["message"]
         assert "empty" in result["message"]
 
     def test_file_not_found(self):
-        error = "Error checking app_data/test/file.json: An error occurred (404) when calling the HeadObject operation: Not Found"
+        error = "Error checking app_data/consultations/test/file.json: An error occurred (404) when calling the HeadObject operation: Not Found"
         result = format_validation_error(error)
         assert result["type"] == "file_not_found"
         assert "file.json" in result["message"]


### PR DESCRIPTION
## Context
We're now moving consultation data from `app_data/[consultation_name]/` to `app_data/consultations/[consultation_name]` in S3.

## Changes proposed in this pull request
* Update consultation S3 download paths to pull from the correct directory. 
* Updates tests and fixture data

## Guidance to review
Go to `http://localhost:8000/support/consultations/import-consultation/` while signed in via `aws-vault`. You should see 4 consultations in the 'Select consultation folder' dropdown; pick one, add the correct mapping folder and import. All data should import as expected

## Link to Trello ticket
https://trello.com/c/SZjoU4Ap/499-make-sure-that-the-ingest-reads-from-within-the-consultations-folder

## Things to check
- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo