### PR TITLE
Import multiple-choice questions

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -416,7 +416,7 @@ def import_questions(
                 slug=f"question-{question_number}",
                 number=question_number,
                 has_free_text=question_data.get("has_free_text", True),
-                has_multiple_choice=(True if multiple_choice_options else False),
+                has_multiple_choice=bool(multiple_choice_options),
                 multiple_choice_options=multiple_choice_options,
             )
 

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -124,7 +124,9 @@ def validate_consultation_structure(
             responses_file = f"{folder}responses.jsonl"
 
             try:
-                s3.head_object(Bucket=bucket_name, Key=question_file)
+                response = s3.get_object(Bucket=bucket_name, Key=question_file)
+                question_data = json.loads(response["Body"].read())
+                has_free_text = question_data.get("has_free_text", True)
             except s3.exceptions.NoSuchKey:
                 errors.append(f"Missing {question_file}")
             except Exception as e:
@@ -137,16 +139,17 @@ def validate_consultation_structure(
             except Exception as e:
                 errors.append(f"Error checking {responses_file}: {str(e)}")
 
-            # Check output files for this question part
-            output_folder = f"{outputs_path}{question_num}/"
-            for output_file in required_outputs:
-                output_key = f"{output_folder}{output_file}"
-                try:
-                    s3.head_object(Bucket=bucket_name, Key=output_key)
-                except s3.exceptions.NoSuchKey:
-                    errors.append(f"Missing output file: {output_key}")
-                except Exception as e:
-                    errors.append(f"Error checking {output_key}: {str(e)}")
+            # Check output files for this question part, if it is a free-text question
+            if has_free_text:
+                output_folder = f"{outputs_path}{question_num}/"
+                for output_file in required_outputs:
+                    output_key = f"{output_folder}{output_file}"
+                    try:
+                        s3.head_object(Bucket=bucket_name, Key=output_key)
+                    except s3.exceptions.NoSuchKey:
+                        errors.append(f"Missing output file: {output_key}")
+                    except Exception as e:
+                        errors.append(f"Error checking {output_key}: {str(e)}")
 
         # Validate JSON/JSONL files are parseable (spot check first question part)
         if question_folders and not errors:
@@ -420,17 +423,18 @@ def import_questions(
             responses_file_key = f"{question_folder}responses.jsonl"
             responses = queue.enqueue(import_responses, question, responses_file_key)
 
-            output_folder = f"{outputs_path}question_part_{question_num_str}/"
-            themes = queue.enqueue(import_themes, question, output_folder, depends_on=responses)
-            response_annotations = queue.enqueue(
-                import_response_annotations, question, output_folder, depends_on=themes
-            )
-            queue.enqueue(
-                import_response_annotation_themes,
-                question,
-                output_folder,
-                depends_on=response_annotations,
-            )
+            if question.has_free_text:
+                output_folder = f"{outputs_path}question_part_{question_num_str}/"
+                themes = queue.enqueue(import_themes, question, output_folder, depends_on=responses)
+                response_annotations = queue.enqueue(
+                    import_response_annotations, question, output_folder, depends_on=themes
+                )
+                queue.enqueue(
+                    import_response_annotation_themes,
+                    question,
+                    output_folder,
+                    depends_on=response_annotations,
+                )
 
     except Exception as e:
         logger.error(f"Error importing question data for {consultation_code}: {str(e)}")

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -403,6 +403,7 @@ def import_questions(
             question_data = json.loads(response["Body"].read())
 
             question_text = question_data.get("question_text", "")
+            multiple_choice_options = question_data.get("options", [])
             if not question_text:
                 raise ValueError(f"Question text is required for question {question_number}")
 
@@ -411,9 +412,9 @@ def import_questions(
                 text=question_text,
                 slug=f"question-{question_number}",
                 number=question_number,
-                has_free_text=True,  # Default for now
-                has_multiple_choice=False,  # Default for now
-                multiple_choice_options=None,
+                has_free_text=question_data.get("has_free_text", True),
+                has_multiple_choice=(True if multiple_choice_options else False),
+                multiple_choice_options=multiple_choice_options,
             )
 
             responses_file_key = f"{question_folder}responses.jsonl"

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -27,7 +27,7 @@ def get_object_side_effect(Bucket, Key):
     respondents_data = b'{"themefinder_id": 1, "demographic_data": {"location": "Wales"}}\n{"themefinder_id": 2, "demographic_data": {"location": "Scotland"}}'
 
     # Mock question file
-    question_data = b'{"question_text": "What do you think?"}'
+    question_data = b'{"question_text": "What do you think?", "has_free_text": true, "options": ["a", "b", "c"]}'
 
     # Mock responses file
     responses_data = (
@@ -333,6 +333,9 @@ class TestQuestionsImport:
         questions = Question.objects.filter(consultation=consultation)
         assert questions.count() == 1
         assert questions.first().text == "What do you think?"
+        assert questions.first().has_free_text
+        assert questions.first().has_multiple_choice
+        assert questions.first().multiple_choice_options == ["a", "b", "c"]
 
         themes = Theme.objects.filter(question__consultation=consultation)
         assert themes.count() == 1

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -30,9 +30,7 @@ def get_object_side_effect(Bucket, Key):
     question_data = b'{"question_text": "What do you think?", "has_free_text": true, "options": ["a", "b", "c"]}'
 
     # Mock responses file
-    responses_data = (
-        b'{"themefinder_id": 1, "text": "Good idea"}\n{"themefinder_id": 2, "text": "Bad idea"}'
-    )
+    responses_data = b'{"themefinder_id": 1, "text": "Good idea", "chosen_options": ["a"]}\n{"themefinder_id": 2, "text": "Bad idea", "chosen_options": ["b", "c"]}'
 
     # Mock themes file
     themes_data = (


### PR DESCRIPTION
## Context
Some of our consultation questions have multiple-choice options that need importing

## Changes proposed in this pull request
Adds multiple-choice options to the consultation ingest; makes sure only to trigger annotation import tasks for questions with a free-text part.

## Guidance to review
Does it work locally? (use the consultation folder `small_consultation_multi_choice` and the mapping date `2025-05-14` for a small multiple-choice consultation)

Worth testing on dev, once the semantic search has been tested.

## Link to Trello ticket
https://trello.com/c/GgeVR8ch/492-incorporate-multiple-choice-questions-including-in-import

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo