### PR TITLE
Add options for sorting themes in different ways.

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -31,7 +31,7 @@ class FilterParams(TypedDict, total=False):
     sentiment_list: list[str]
     theme_list: list[str]
     evidence_rich: bool
-    search_value: str
+    search_value: str # TODO - remove when v1 dash deleted
     demographic_filters: dict[
         str, list[str]
     ]  # e.g. {"individual": ["true"], "region": ["north", "south"]}
@@ -51,13 +51,13 @@ def parse_filters_from_request(request: HttpRequest) -> FilterParams:
     if theme_filters:
         filters["theme_list"] = theme_filters.split(",")
 
-    themes_sort_direction = request.GET.get("themeSortDirection", "")
+    themes_sort_direction = request.GET.get("themesSortDirection", "")
     if themes_sort_direction in ["ascending", "descending"]:
         filters["themes_sort_direction"] = themes_sort_direction
 
-    themes_sort_type = request.GET.get("themeSortType", "")
+    themes_sort_type = request.GET.get("themesSortType", "")
     if themes_sort_type in ["frequency", "alphabetical"]:
-        filters["themes_sort_type"] == themes_sort_type
+        filters["themes_sort_type"] = themes_sort_type
 
     # TODO - remove once v1 of the dashboard is removed
     evidence_rich_filter = request.GET.get("evidenceRichFilter")

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -163,7 +163,7 @@ def get_theme_summary_optimized(
 
     if filters:
         # Apply theme filtering with AND logic if needed
-        if filters.get("theme_list"):
+        for theme in filters.get("theme_list", []):
             # Create subqueries for each theme
             for theme_id in filters["theme_list"]:
                 theme_exists = models.ResponseAnnotationTheme.objects.filter(

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -31,7 +31,7 @@ class FilterParams(TypedDict, total=False):
     sentiment_list: list[str]
     theme_list: list[str]
     evidence_rich: bool
-    search_value: str # TODO - remove when v1 dash deleted
+    search_value: str  # TODO - remove when v1 dash deleted
     demographic_filters: dict[
         str, list[str]
     ]  # e.g. {"individual": ["true"], "region": ["north", "south"]}

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -35,6 +35,9 @@ class FilterParams(TypedDict, total=False):
     demographic_filters: dict[
         str, list[str]
     ]  # e.g. {"individual": ["true"], "region": ["north", "south"]}
+    themes_sort_type: str # "frequency" or "alphabetical"
+    themes_sort_direction: str # "ascending" or "descending"
+
 
 
 def parse_filters_from_request(request: HttpRequest) -> FilterParams:
@@ -49,10 +52,24 @@ def parse_filters_from_request(request: HttpRequest) -> FilterParams:
     if theme_filters:
         filters["theme_list"] = theme_filters.split(",")
 
+    themes_sort_direction = request.GET.get("themeSortDirection", "")
+    if themes_sort_direction in ["ascending", "descending"]:
+        filters["themes_sort_direction"] = themes_sort_direction
+
+    themes_sort_type = request.GET.get("themeSortType", "")
+    if themes_sort_type in ["frequency", "alphabetical"]:
+        filters["themes_sort_type"] == themes_sort_type
+
+    # TODO - remove once v1 of the dashboard is removed
     evidence_rich_filter = request.GET.get("evidenceRichFilter")
     if evidence_rich_filter == "evidence-rich":
         filters["evidence_rich"] = True
 
+    evidence_rich_filter = request.GET.get("evidenceRich")
+    if evidence_rich_filter:
+        filters["evidence_rich"] = True
+
+    # TODO - remove this when v1 of dashboard is removed
     search_value = request.GET.get("searchValue")
     if search_value:
         filters["search_value"] = search_value

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -35,9 +35,8 @@ class FilterParams(TypedDict, total=False):
     demographic_filters: dict[
         str, list[str]
     ]  # e.g. {"individual": ["true"], "region": ["north", "south"]}
-    themes_sort_type: str # "frequency" or "alphabetical"
-    themes_sort_direction: str # "ascending" or "descending"
-
+    themes_sort_type: str  # "frequency" or "alphabetical"
+    themes_sort_direction: str  # "ascending" or "descending"
 
 
 def parse_filters_from_request(request: HttpRequest) -> FilterParams:
@@ -185,7 +184,6 @@ def get_theme_summary_optimized(
         .values("id", "name", "description", "response_count")
         .order_by(f"{direction}{order_by_field_name}")
     )
-
 
     return [
         {

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -252,8 +252,7 @@ def test_get_theme_summary_optimized_with_responses(question, theme, theme2):
     assert our_theme["theme__name"] == theme.name
     assert our_theme["count"] == 2
 
-    # Now test with filters
-    # Theme B assigned to 1 response, Theme A assigned to 2 responses
+    # Now test with filters - Theme B assigned to 1 response, Theme A assigned to 2 responses
     filters = FilterParams(themes_sort_type="frequency", themes_sort_direction="ascending")
     theme_summary = get_theme_summary_optimized(question=question, filters=filters)
     theme_summary[0]["theme__name"] = theme2.name
@@ -262,9 +261,13 @@ def test_get_theme_summary_optimized_with_responses(question, theme, theme2):
     theme_summary = get_theme_summary_optimized(question=question, filters=filters)
     theme_summary[0]["theme__name"] = theme.name
 
-    filters = FilterParams(themes_sort_type="alphabetic", themes_sort_direction="ascending")
+    filters = FilterParams(themes_sort_type="alphabetical", themes_sort_direction="ascending")
     theme_summary = get_theme_summary_optimized(question=question, filters=filters)
-    theme_summary[0]["theme__name"] = theme.name
+    theme_summary[1]["theme__name"] = theme2.name
+
+    filters = FilterParams(themes_sort_type="alphabetical", themes_sort_direction="descending")
+    theme_summary = get_theme_summary_optimized(question=question, filters=filters)
+    theme_summary[0]["theme__name"] = theme2.name
 
 
 @pytest.mark.django_db

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -796,49 +796,47 @@ def test_get_demographic_aggregations_from_responses():
     # Create test data
     consultation = ConsultationFactory()
     question = QuestionFactory(consultation=consultation)
-    
+
     # Create respondents with different demographic data
     respondent1 = RespondentFactory(
         consultation=consultation,
-        demographics={"gender": "male", "age_group": "25-34", "region": "north"}
+        demographics={"gender": "male", "age_group": "25-34", "region": "north"},
     )
     respondent2 = RespondentFactory(
         consultation=consultation,
-        demographics={"gender": "female", "age_group": "25-34", "region": "south"}
+        demographics={"gender": "female", "age_group": "25-34", "region": "south"},
     )
     respondent3 = RespondentFactory(
         consultation=consultation,
-        demographics={"gender": "male", "age_group": "35-44", "region": "north"}
+        demographics={"gender": "male", "age_group": "35-44", "region": "north"},
     )
     respondent4 = RespondentFactory(
         consultation=consultation,
-        demographics={"gender": "female", "age_group": "25-34", "region": "north"}
+        demographics={"gender": "female", "age_group": "25-34", "region": "north"},
     )
     # Create one respondent with empty demographics
-    respondent5 = RespondentFactory(
-        consultation=consultation,
-        demographics={}
-    )
-    
+    respondent5 = RespondentFactory(consultation=consultation, demographics={})
+
     # Create responses for each respondent
     ResponseFactory(respondent=respondent1, question=question)
     ResponseFactory(respondent=respondent2, question=question)
     ResponseFactory(respondent=respondent3, question=question)
     ResponseFactory(respondent=respondent4, question=question)
     ResponseFactory(respondent=respondent5, question=question)
-    
+
     # Get all responses as a queryset
     from consultation_analyser.consultations.models import Response
+
     filtered_responses = Response.objects.filter(question=question)
-    
+
     # Test the aggregation function
     result = get_demographic_aggregations_from_responses(filtered_responses)
-    
+
     # Verify the aggregations
     assert result == {
         "gender": {"male": 2, "female": 2},
         "age_group": {"25-34": 3, "35-44": 1},
-        "region": {"north": 3, "south": 1}
+        "region": {"north": 3, "south": 1},
     }
 
 
@@ -847,35 +845,33 @@ def test_get_demographic_aggregations_from_responses_with_boolean_values():
     # Test with boolean demographic values
     consultation = ConsultationFactory()
     question = QuestionFactory(consultation=consultation)
-    
+
     # Create respondents with boolean demographic data
     respondent1 = RespondentFactory(
-        consultation=consultation,
-        demographics={"is_individual": True, "has_disability": False}
+        consultation=consultation, demographics={"is_individual": True, "has_disability": False}
     )
     respondent2 = RespondentFactory(
-        consultation=consultation,
-        demographics={"is_individual": True, "has_disability": True}
+        consultation=consultation, demographics={"is_individual": True, "has_disability": True}
     )
     respondent3 = RespondentFactory(
-        consultation=consultation,
-        demographics={"is_individual": False, "has_disability": False}
+        consultation=consultation, demographics={"is_individual": False, "has_disability": False}
     )
-    
+
     # Create responses
     ResponseFactory(respondent=respondent1, question=question)
     ResponseFactory(respondent=respondent2, question=question)
     ResponseFactory(respondent=respondent3, question=question)
-    
+
     # Get responses and test aggregation
     from consultation_analyser.consultations.models import Response
+
     filtered_responses = Response.objects.filter(question=question)
     result = get_demographic_aggregations_from_responses(filtered_responses)
-    
+
     # Verify boolean values are converted to strings
     assert result == {
         "is_individual": {"True": 2, "False": 1},
-        "has_disability": {"False": 2, "True": 1}
+        "has_disability": {"False": 2, "True": 1},
     }
 
 
@@ -883,12 +879,13 @@ def test_get_demographic_aggregations_from_responses_with_boolean_values():
 def test_get_demographic_aggregations_from_responses_empty_queryset():
     # Test with empty queryset
     question = QuestionFactory()
-    
+
     from consultation_analyser.consultations.models import Response
+
     filtered_responses = Response.objects.filter(question=question)
-    
+
     result = get_demographic_aggregations_from_responses(filtered_responses)
-    
+
     # Should return empty dict for empty queryset
     assert result == {}
 
@@ -898,33 +895,31 @@ def test_get_demographic_aggregations_from_responses_partial_demographics():
     # Test when some respondents have partial demographic data
     consultation = ConsultationFactory()
     question = QuestionFactory(consultation=consultation)
-    
+
     # Create respondents with varying demographic fields
     respondent1 = RespondentFactory(
         consultation=consultation,
-        demographics={"gender": "male", "age_group": "25-34"}  # has both
+        demographics={"gender": "male", "age_group": "25-34"},  # has both
     )
     respondent2 = RespondentFactory(
         consultation=consultation,
-        demographics={"gender": "female"}  # only has gender
+        demographics={"gender": "female"},  # only has gender
     )
     respondent3 = RespondentFactory(
         consultation=consultation,
-        demographics={"age_group": "35-44"}  # only has age_group
+        demographics={"age_group": "35-44"},  # only has age_group
     )
-    
+
     # Create responses
     ResponseFactory(respondent=respondent1, question=question)
     ResponseFactory(respondent=respondent2, question=question)
     ResponseFactory(respondent=respondent3, question=question)
-    
+
     # Get responses and test aggregation
     from consultation_analyser.consultations.models import Response
+
     filtered_responses = Response.objects.filter(question=question)
     result = get_demographic_aggregations_from_responses(filtered_responses)
-    
+
     # Verify aggregations handle partial data correctly
-    assert result == {
-        "gender": {"male": 1, "female": 1},
-        "age_group": {"25-34": 1, "35-44": 1}
-    }
+    assert result == {"gender": {"male": 1, "female": 1}, "age_group": {"25-34": 1, "35-44": 1}}

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -110,8 +110,6 @@ def test_parse_filters_from_request_all_filters(request_factory):
     )
     filters = parse_filters_from_request(request)
 
-    print(filters)
-
     assert filters["sentiment_list"] == ["AGREEMENT", "DISAGREEMENT"]
     assert filters["theme_list"] == ["1", "2", "3"]
     assert filters["evidence_rich"]

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -8,6 +8,7 @@ from django.test import RequestFactory
 from consultation_analyser.constants import DASHBOARD_ACCESS
 from consultation_analyser.consultations.models import DemographicOption
 from consultation_analyser.consultations.views.answers import (
+    FilterParams,
     build_respondent_data,
     build_response_filter_query,
     get_demographic_aggregations_from_responses,
@@ -15,7 +16,6 @@ from consultation_analyser.consultations.views.answers import (
     get_filtered_responses_with_themes,
     get_theme_summary_optimized,
     parse_filters_from_request,
-    FilterParams
 )
 from consultation_analyser.factories import (
     ConsultationFactory,
@@ -111,7 +111,7 @@ def test_parse_filters_from_request_all_filters(request_factory):
             "demographicFilters[individual]": "true,false",
             "demographicFilters[region]": "north,south",
             "themesSortDirection": "ascending",
-            "themesSortType": "frequency"
+            "themesSortType": "frequency",
         },
     )
     filters = parse_filters_from_request(request)
@@ -245,7 +245,6 @@ def test_get_theme_summary_optimized_with_responses(question, theme, theme2):
     annotation2 = ResponseAnnotationFactoryNoThemes(response=response2)
     annotation2.add_original_ai_themes([theme, theme2])
 
-
     theme_summary = get_theme_summary_optimized(question)
     # Find our specific theme in the results
     our_theme = next((t for t in theme_summary if t["theme__id"] == theme.id), None)
@@ -266,7 +265,6 @@ def test_get_theme_summary_optimized_with_responses(question, theme, theme2):
     filters = FilterParams(themes_sort_type="alphabetic", themes_sort_direction="ascending")
     theme_summary = get_theme_summary_optimized(question=question, filters=filters)
     theme_summary[0]["theme__name"] = theme.name
-
 
 
 @pytest.mark.django_db

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -67,8 +67,9 @@ def test_parse_filters_from_request_empty(request_factory):
     assert filters == {}
 
 
+# TODO - remove these filters and test when v1 of dashboard is deleted
 @pytest.mark.django_db
-def test_parse_filters_from_request_all_filters(request_factory):
+def test_parse_filters_from_request_all_filters_v1(request_factory):
     """Test parsing all types of filters from request"""
     request = request_factory.get(
         "/",
@@ -89,6 +90,36 @@ def test_parse_filters_from_request_all_filters(request_factory):
     assert filters["search_value"] == "test search"
     assert filters["demographic_filters"]["individual"] == ["true", "false"]
     assert filters["demographic_filters"]["region"] == ["north", "south"]
+
+
+@pytest.mark.django_db
+def test_parse_filters_from_request_all_filters(request_factory):
+    """Test parsing all types of filters from request"""
+    request = request_factory.get(
+        "/",
+        {
+            "sentimentFilters": "AGREEMENT,DISAGREEMENT",
+            "themeFilters": "1,2,3",
+            "evidenceRich": "true",
+            "searchValue": "test search",
+            "demographicFilters[individual]": "true,false",
+            "demographicFilters[region]": "north,south",
+            "themesSortDirection": "ascending",
+            "themesSortType": "frequency"
+        },
+    )
+    filters = parse_filters_from_request(request)
+
+    print(filters)
+
+    assert filters["sentiment_list"] == ["AGREEMENT", "DISAGREEMENT"]
+    assert filters["theme_list"] == ["1", "2", "3"]
+    assert filters["evidence_rich"]
+    assert filters["search_value"] == "test search"
+    assert filters["demographic_filters"]["individual"] == ["true", "false"]
+    assert filters["demographic_filters"]["region"] == ["north", "south"]
+    assert filters["themes_sort_direction"] == "ascending"
+    assert filters["themes_sort_type"] == "frequency"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
For the new design of the dashboard we want more options for filtering and querying the responses and themes.

This PR: 
* Adds `evidenceRich` as an option (Boolean) to filter the responses
* Adds `themesSortDirection` (ascending/descending) and `themesSortType` (frequency/alphabetical) to filter the theme summary

This PR does not:
* Consider changes to the demographic filters (to be done in the next PR)
* Remove the filters that are needed for v1 dashboard (`evidenceRichFilter`, `searchValue`) - these can be removed once v1 dashboard is removed 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A