### PR TITLE
Add a new demoFilters endpoint

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -96,6 +96,7 @@ def parse_filters_from_request(request: HttpRequest) -> FilterParams:
         for pair in pairs:
             key, value = pair.split(":")
             filters_dict[key] = value
+        filters["demo_filters"] = filters_dict
 
     return filters
 

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -131,14 +131,13 @@ def build_response_filter_query(filters: FilterParams, question: models.Question
     if demo_filters:
         for field, value in demo_filters.items():
             field_query = Q()
-            for value in values:
-                # Handle boolean values
-                if value.lower() in ["true", "false"]:
-                    bool_value = value.lower() == "true"
-                    field_query |= Q(**{f"respondent__demographics__{field}": bool_value})
-                else:
-                    # Handle string values
-                    field_query |= Q(**{f"respondent__demographics__{field}": value})
+            # Handle boolean values
+            if value.lower() in ["true", "false"]:
+                bool_value = value.lower() == "true"
+                field_query |= Q(**{f"respondent__demographics__{field}": bool_value})
+            else:
+                # Handle string values
+                field_query |= Q(**{f"respondent__demographics__{field}": value})
             query &= field_query
 
     return query

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -91,7 +91,7 @@ def parse_filters_from_request(request: HttpRequest) -> FilterParams:
     # Expected format - `demoFilters=age:18,country:england`
     demo_filters = request.GET.get("demoFilters")
     if demo_filters:
-        filters_dict = {}
+        filters_dict = dict(pair.split(":") for pair in demo_filters.split(","))
         pairs = demo_filters.split(",")
         for pair in pairs:
             key, value = pair.split(":")

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -128,7 +128,7 @@ def build_response_filter_query(filters: FilterParams, question: models.Question
             query &= field_query
 
     demo_filters = filters.get("demo_filters")
-    if demo_filters:
+    if demo_filters:=filters.get("demo_filters"):
         for field, value in demo_filters.items():
             field_query = Q()
             # Handle boolean values

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -108,7 +108,7 @@ def test_parse_filters_from_request_all_filters(request_factory):
             "themeFilters": "1,2,3",
             "evidenceRich": "true",
             "searchValue": "test search",
-            "demographicFilters[individual]": "true,false",
+            "demoFilters": "individual:true,region:south",
             "demographicFilters[region]": "north,south",
             "themesSortDirection": "ascending",
             "themesSortType": "frequency",
@@ -120,8 +120,8 @@ def test_parse_filters_from_request_all_filters(request_factory):
     assert filters["theme_list"] == ["1", "2", "3"]
     assert filters["evidence_rich"]
     assert filters["search_value"] == "test search"
-    assert filters["demographic_filters"]["individual"] == ["true", "false"]
-    assert filters["demographic_filters"]["region"] == ["north", "south"]
+    assert filters["demo_filters"]["individual"] == 'true'
+    assert filters["demo_filters"]["region"] == "south"
     assert filters["themes_sort_direction"] == "ascending"
     assert filters["themes_sort_type"] == "frequency"
 

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -120,7 +120,7 @@ def test_parse_filters_from_request_all_filters(request_factory):
     assert filters["theme_list"] == ["1", "2", "3"]
     assert filters["evidence_rich"]
     assert filters["search_value"] == "test search"
-    assert filters["demo_filters"]["individual"] == 'true'
+    assert filters["demo_filters"]["individual"] == "true"
     assert filters["demo_filters"]["region"] == "south"
     assert filters["themes_sort_direction"] == "ascending"
     assert filters["themes_sort_type"] == "frequency"


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Adding demoFilters endpoint for filtering demographic information.

Specification as discussed here: https://i-dot-ai.slack.com/archives/C07ENSAN01E/p1752075809680479?thread_ts=1751985586.296879&cid=C07ENSAN01E
i.e. looks like `demoFilters=age:18,country:england` (at the moment, just selecting one option to fit with current FE code and design).

The old demographicFilters code will be deleted when v1 of dashboard is deleted.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->



## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A