### PR TITLE
count the number of (non-zero) responses properly

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/consultations/show.html
+++ b/consultation_analyser/consultations/jinja2/consultations/consultations/show.html
@@ -36,12 +36,7 @@
               id: "{{ question_dict.question.id }}",
               title: "{{ question_dict.question.text }}",
               url: "{{ url('question_responses', kwargs={'consultation_slug': consultation.slug, 'question_slug': question_dict.question.slug}) }}",
-              numResponses:
-                {% if question_dict.free_text_count %}
-                  "{{ question_dict.free_text_count }}"
-                {% else %}
-                  "0"
-                {% endif %},
+              numResponses: "{{ question_dict.number_responses }}",
               status: "Open",
             },
           {% endfor %}

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -128,7 +128,7 @@ def build_response_filter_query(filters: FilterParams, question: models.Question
             query &= field_query
 
     demo_filters = filters.get("demo_filters")
-    if demo_filters:=filters.get("demo_filters"):
+    if demo_filters := filters.get("demo_filters"):
         for field, value in demo_filters.items():
             field_query = Q()
             # Handle boolean values

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -35,9 +35,14 @@ def show(request: HttpRequest, consultation_slug: str) -> HttpResponse:
         # Handle free text questions
         if question.has_free_text:
             question_dict["free_text_question_part"] = question  # For template compatibility
-            question_dict["free_text_count"] = models.Response.objects.filter(
-                question=question, free_text__isnull=False
-            ).count()
+
+        non_null_responses_count = (
+            models.Response.objects.filter(question=question)
+            .exclude(free_text__isnull=True)
+            .exclude(chosen_options__isnull=True)
+            .count()
+        )
+        question_dict["number_responses"] = non_null_responses_count
 
         # Handle multiple choice questions
         if question.has_multiple_choice:


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Make sure the number of responses shows properly whether or not it's a multi choice question.

Continue with the assumption that we count non-null responses.

This is when they are displaying on the dashboard page showing all questions (`http://localhost:8000/consultations/<consultation-slug>/`)


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A