### PR TITLE
add demo filters in a different way

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -90,12 +90,10 @@ def parse_filters_from_request(request: HttpRequest) -> FilterParams:
     if demographic_filters:
         filters["demographic_filters"] = demographic_filters
 
-    # Expected format - `demoFilters=age:18,country:england`
-    demo_filters = request.GET.get("demoFilters")
-    print(demo_filters)
+    # Expected format - `demoFilters=age:18&country:england`
+    demo_filters = request.GET.getlist("demoFilters")
     if demo_filters:
-        demographics = demo_filters.split(",")
-        filters_dict = dict(demographic.split(":") for demographic in demographics)
+        filters_dict = dict(demo.split(":") for demo in demo_filters)
         filters["demo_filters"] = filters_dict
     return filters
 

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -90,7 +90,7 @@ def parse_filters_from_request(request: HttpRequest) -> FilterParams:
     if demographic_filters:
         filters["demographic_filters"] = demographic_filters
 
-    # Expected format - `demoFilters=age:18&country:england`
+    # Expected format - `demoFilters=age:18&demoFilters=country:england`
     demo_filters = request.GET.getlist("demoFilters")
     if demo_filters:
         filters_dict = dict(demo.split(":") for demo in demo_filters)

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -27,6 +27,10 @@ from consultation_analyser.factories import (
     ThemeFactory,
     UserFactory,
 )
+from django.urls import reverse
+
+from consultation_analyser import factories
+
 
 
 @pytest.fixture()
@@ -1008,3 +1012,23 @@ def test_get_demographic_aggregations_from_responses_partial_demographics():
 
     # Verify aggregations handle partial data correctly
     assert result == {"gender": {"male": 1, "female": 1}, "age_group": {"25-34": 1, "35-44": 1}}
+
+
+@pytest.mark.django_db
+def test_support_url_access(client):
+    url = reverse("users")
+    # Check anonymous user
+    response = client.get(url)
+    assert response.status_code == 404
+
+    # Check normal non-staff user can't access
+    user = factories.UserFactory()
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 404
+
+    # Check staff user can access
+    user = factories.UserFactory(is_staff=True)
+    client.force_login(user)
+    response = client.get(url)
+    assert response.status_code == 200

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -1013,22 +1013,3 @@ def test_get_demographic_aggregations_from_responses_partial_demographics():
     # Verify aggregations handle partial data correctly
     assert result == {"gender": {"male": 1, "female": 1}, "age_group": {"25-34": 1, "35-44": 1}}
 
-
-@pytest.mark.django_db
-def test_support_url_access(client):
-    url = reverse("users")
-    # Check anonymous user
-    response = client.get(url)
-    assert response.status_code == 404
-
-    # Check normal non-staff user can't access
-    user = factories.UserFactory()
-    client.force_login(user)
-    response = client.get(url)
-    assert response.status_code == 404
-
-    # Check staff user can access
-    user = factories.UserFactory(is_staff=True)
-    client.force_login(user)
-    response = client.get(url)
-    assert response.status_code == 200

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -27,10 +27,6 @@ from consultation_analyser.factories import (
     ThemeFactory,
     UserFactory,
 )
-from django.urls import reverse
-
-from consultation_analyser import factories
-
 
 
 @pytest.fixture()
@@ -1012,4 +1008,3 @@ def test_get_demographic_aggregations_from_responses_partial_demographics():
 
     # Verify aggregations handle partial data correctly
     assert result == {"gender": {"male": 1, "female": 1}, "age_group": {"25-34": 1, "35-44": 1}}
-

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -108,8 +108,7 @@ def test_parse_filters_from_request_all_filters(request_factory):
             "themeFilters": "1,2,3",
             "evidenceRich": "true",
             "searchValue": "test search",
-            "demoFilters": "individual:true,region:south",
-            "demographicFilters[region]": "north,south",
+            "demoFilters": ["individual:true", "UK region:south"],
             "themesSortDirection": "ascending",
             "themesSortType": "frequency",
         },
@@ -121,7 +120,7 @@ def test_parse_filters_from_request_all_filters(request_factory):
     assert filters["evidence_rich"]
     assert filters["search_value"] == "test search"
     assert filters["demo_filters"]["individual"] == "true"
-    assert filters["demo_filters"]["region"] == "south"
+    assert filters["demo_filters"]["UK region"] == "south"
     assert filters["themes_sort_direction"] == "ascending"
     assert filters["themes_sort_type"] == "frequency"
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Change the format we pass in the demographic filters to get data for the dashboard.

Query params look like: `demoFilters=age:18&demoFilters=country:england`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo