### PR TITLE
Speed up monolith endpoint

### DIFF
--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -125,6 +125,7 @@ def get_filtered_responses_with_themes(
         models.Response.objects.filter(response_filter)
         .select_related("respondent", "annotation")
         .prefetch_related("annotation__themes")
+        .defer("embedding", "search_vector")
     )
 
     # Handle theme filtering with AND logic

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -260,9 +260,9 @@ def derive_option_summary_from_responses(responses) -> list[dict]:
     return [option_counts] if option_counts else []
 
 
-def get_demographic_aggregations_from_responses(filtered_responses) -> dict[str, dict[str, int]]:
+def get_demographic_aggregations_from_responses(filtered_respondents) -> dict[str, dict[str, int]]:
     """Aggregate demographic data for filtered responses using efficient database queries"""
-    respondent_ids = filtered_responses.values_list("respondent_id", flat=True).distinct()
+    respondent_ids = filtered_respondents.values_list("respondent_id", flat=True).distinct()
 
     # Fetch all demographic data for these respondents in one query
     respondents_data = models.Respondent.objects.filter(id__in=respondent_ids).values_list(
@@ -300,15 +300,15 @@ def question_responses_json(
     # Parse filters from request
     filters = parse_filters_from_request(request)
 
-    # Get respondents with their filtered responses using the same logic as theme filtering
-    # First get the filtered responses using AND logic for themes
-    filtered_responses = get_filtered_responses_with_themes(question, filters)
+    # Get respondents with their filtered responses and produce a lightweight respondent queryset
+    full_qs = get_filtered_responses_with_themes(question, filters)
+    respondent_qs = full_qs.only("id", "respondent_id")
 
     # Then get respondents who have these filtered responses
     filtered_annotated_responses = filtered_responses.prefetch_related("annotation__themes")
 
     # Efficient counting using database aggregation
-    filtered_total = filtered_annotated_responses.count()
+    filtered_total = respondent_qs.count()
     all_respondents_count = models.Response.objects.filter(question=question).aggregate(
         count=Count("respondent_id", distinct=True)
     )["count"]
@@ -317,7 +317,7 @@ def question_responses_json(
     demographic_options = get_demographic_options(question.consultation)
 
     # Get demographic aggregations for filtered responses
-    demographic_aggregations = get_demographic_aggregations_from_responses(filtered_responses)
+    demographic_aggregations = get_demographic_aggregations_from_responses(respondent_qs)
 
     # Generate theme mappings
     theme_mappings = []
@@ -327,7 +327,7 @@ def question_responses_json(
         # Generate theme mappings using optimized database query
         theme_data = get_theme_summary_optimized(
             question=question,
-            filtered_responses=filtered_responses,
+            filtered_responses=respondent_qs,
             themes_sort_type=themes_sort_type,
             themes_sort_direction=themes_sort_direction,
         )
@@ -354,12 +354,12 @@ def question_responses_json(
 
     # Pagination
     if page_size:
-        pagination = Paginator(filtered_annotated_responses, page_size)
+        pagination = Paginator(full_qs, page_size)
         current_page = pagination.page(page)
         annotated_responses = current_page.object_list
         data["has_more_pages"] = current_page.has_next()
     else:
-        annotated_responses = filtered_annotated_responses
+        annotated_responses = full_qs
 
     # Build response data efficiently using prefetched data
     data["all_respondents"] = list(map(build_respondent_data, annotated_responses))

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -336,16 +336,6 @@ def question_responses_json(
             for i, theme in enumerate(theme_data)
         ]
 
-    data: DataDict = {
-        "all_respondents": [],
-        "has_more_pages": False,
-        "respondents_total": all_respondents_count,
-        "filtered_total": filtered_total,
-        "theme_mappings": theme_mappings,
-        "demographic_options": demographic_options,
-        "demographic_aggregations": demographic_aggregations,
-    }
-
     # Pagination
     DEFAULT_PAGE_SIZE = 50
     DEFAULT_PAGE = 1
@@ -357,8 +347,15 @@ def question_responses_json(
     page_obj = paginator.page(page_num)
     page_qs = page_obj.object_list
 
-    data["has_more_pages"] = page_obj.has_next()
-    data["all_respondents"] = [build_respondent_data(r) for r in page_qs]
+    data: DataDict = {
+        "all_respondents": [build_respondent_data(r) for r in page_qs],
+        "has_more_pages": page_obj.has_next(),
+        "respondents_total": all_respondents_count,
+        "filtered_total": filtered_total,
+        "theme_mappings": theme_mappings,
+        "demographic_options": demographic_options,
+        "demographic_aggregations": demographic_aggregations,
+    }
 
     return JsonResponse(data)
 

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -304,9 +304,6 @@ def question_responses_json(
     full_qs = get_filtered_responses_with_themes(question, filters)
     respondent_qs = full_qs.only("id", "respondent_id")
 
-    # Then get respondents who have these filtered responses
-    filtered_annotated_responses = filtered_responses.prefetch_related("annotation__themes")
-
     # Efficient counting using database aggregation
     filtered_total = respondent_qs.count()
     all_respondents_count = models.Response.objects.filter(question=question).aggregate(


### PR DESCRIPTION
A number of quick fixes to speed up the monolithic endpoint before we give dwp access, currently includes:

- Removing unneeded prefetch
- creating a lightweight qs using only response_id for aggregations
- default pagination behaviour

I have tested this locally on ~1,000 responses but we should deploy to dev to see how this scales