### PR TITLE
Further monolith optimisations

### DIFF
--- a/consultation_analyser/consultations/export_user_theme.py
+++ b/consultation_analyser/consultations/export_user_theme.py
@@ -99,6 +99,7 @@ def get_theme_mapping_rows(question: Question) -> list[dict]:
         Response.objects.filter(question=question, free_text__isnull=False, free_text__gt="")
         .select_related("respondent", "annotation", "annotation__reviewed_by")
         .prefetch_related("annotation__themes", "annotation__responseannotationtheme_set__theme")
+        .order_by("respondent__themefinder_id")
     )
 
     for response in response_qs:

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -125,6 +125,14 @@ def get_filtered_responses_with_themes(
         models.Response.objects.filter(response_filter)
         .select_related("respondent", "annotation")
         .prefetch_related("annotation__themes")
+        .only(
+            # Response fields
+            "id", "respondent_id", "question_id", "free_text", "chosen_options", "created_at",
+            # Respondent fields  
+            "respondent__id", "respondent__themefinder_id", "respondent__demographics",
+            # Annotation fields
+            "annotation__id", "annotation__sentiment", "annotation__evidence_rich"
+        )
         .defer("embedding", "search_vector")
     )
 

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -155,7 +155,7 @@ def get_filtered_responses_with_themes(
                 .order_by("-distance")
             )
 
-    return queryset.distinct().order_by("created_at")  # Consistent ordering for pagination
+    return queryset.order_by("created_at")  # Consistent ordering for pagination
 
 
 def get_theme_summary_optimized(
@@ -181,7 +181,7 @@ def get_theme_summary_optimized(
     # This shows ALL themes that appear in responses matching the filter criteria
     theme_data = (
         models.Theme.objects.filter(responseannotation__response__in=filtered_responses)
-        .annotate(response_count=Count("responseannotation__response", distinct=True))
+        .annotate(response_count=Count("responseannotation__response"))
         .values("id", "name", "description", "response_count")
         .order_by(f"{direction}{order_by_field_name}")
     )
@@ -304,9 +304,7 @@ def question_responses_json(
 
     # Efficient counting using database aggregation
     filtered_total = respondent_qs.count()
-    all_respondents_count = models.Response.objects.filter(question=question).aggregate(
-        count=Count("respondent_id", distinct=True)
-    )["count"]
+    all_respondents_count = models.Response.objects.filter(question=question).count()
 
     # Get demographic options for this consultation
     demographic_options = get_demographic_options(question.consultation)

--- a/consultation_analyser/consultations/views/answers.py
+++ b/consultation_analyser/consultations/views/answers.py
@@ -127,11 +127,20 @@ def get_filtered_responses_with_themes(
         .prefetch_related("annotation__themes")
         .only(
             # Response fields
-            "id", "respondent_id", "question_id", "free_text", "chosen_options", "created_at",
-            # Respondent fields  
-            "respondent__id", "respondent__themefinder_id", "respondent__demographics",
+            "id",
+            "respondent_id",
+            "question_id",
+            "free_text",
+            "chosen_options",
+            "created_at",
+            # Respondent fields
+            "respondent__id",
+            "respondent__themefinder_id",
+            "respondent__demographics",
             # Annotation fields
-            "annotation__id", "annotation__sentiment", "annotation__evidence_rich"
+            "annotation__id",
+            "annotation__sentiment",
+            "annotation__evidence_rich",
         )
         .defer("embedding", "search_vector")
     )
@@ -208,9 +217,7 @@ def get_theme_summary_optimized(
 def build_respondent_data(response: models.Response) -> dict:
     """Extract respondent data building to separate function"""
     data = {
-        "id": f"response-{response.respondent.identifier}",
         "identifier": str(response.respondent.identifier),
-        "sentiment_position": "",
         "free_text_answer_text": response.free_text or "",
         "demographic_data": response.respondent.demographics or {},
         "themes": [],
@@ -221,9 +228,6 @@ def build_respondent_data(response: models.Response) -> dict:
     if hasattr(response, "annotation") and response.annotation:
         annotation = response.annotation
 
-        if annotation.sentiment:
-            data["sentiment_position"] = annotation.sentiment
-
         if annotation.evidence_rich == models.ResponseAnnotation.EvidenceRich.YES:
             data["evidenceRich"] = True
 
@@ -231,7 +235,6 @@ def build_respondent_data(response: models.Response) -> dict:
         data["themes"] = [
             {
                 "id": theme.id,
-                "stance": None,  # Stance is no longer stored in new models
                 "name": theme.name,
                 "description": theme.description,
             }
@@ -334,7 +337,6 @@ def question_responses_json(
         )
         theme_mappings = [
             {
-                "inputId": f"themesfilter-{i}",
                 "value": str(theme.get("theme__id", "")),
                 "label": theme.get("theme__name", ""),
                 "description": theme.get("theme__description", ""),
@@ -353,7 +355,7 @@ def question_responses_json(
     paginator = Paginator(full_qs, page_size, allow_empty_first_page=True)
     page_obj = paginator.page(page_num)
     page_qs = page_obj.object_list
-    
+
     # Only count when necessary (first page or when specifically needed)
     if page_num == DEFAULT_PAGE:
         filtered_total = respondent_qs.count()

--- a/tests/views/test_answers.py
+++ b/tests/views/test_answers.py
@@ -826,13 +826,11 @@ def test_build_respondent_data():
 
     actual = build_respondent_data(response=response)
     expected = {
-        "id": "response-5",
-        "identifier": "5",
-        "sentiment_position": "AGREEMENT",
+        "identifier": str(respondent.identifier),
         "free_text_answer_text": "Response 1",
         "demographic_data": respondent.demographics or {},
         "themes": [
-            {"id": theme.id, "stance": None, "name": "Theme A", "description": theme.description}
+            {"id": theme.id, "name": "Theme A", "description": theme.description}
         ],
         "multiple_choice_answer": [],
         "evidenceRich": True,


### PR DESCRIPTION
Further endpoint optimisations:

- remove distincts (we have max one response_id per question)
- Use only to specify fields in query
- switch to inbuilt lazy pagination
- remove unused fields from the payload, smaller data = quicker transfer
- remove inefficient exists from theme filtering