### PR TITLE
DRAFT: Feature/import multi choice responses

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -394,12 +394,7 @@ def import_multiple_choice_responses(question: Question, multichoice_file_key: s
             themefinder_id = response_data["themefinder_id"]
             chosen_options = response_data.get("chosen_options", [])
 
-            responses_to_save.append(
-                dict(
-                    respondent=respondent_dict[themefinder_id],
-                    question=question,
-                    chosen_options = chosen_options
-                ))
+            responses_to_save.append(Response(respondent=respondent_dict[themefinder_id], question=question, chosen_options=chosen_options))
 
             if len(responses_to_save) >= DEFAULT_BATCH_SIZE:
                 Response.objects.bulk_create(responses_to_save, update_conflicts=True, update_fields=["chosen_options", "question"], unique_fields=["id"])

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -132,7 +132,7 @@ def validate_consultation_structure(
                 question_data = json.loads(response["Body"].read())
                 has_free_text = question_data.get("has_free_text", True)
                 multiple_choice_options = question_data.get("options", [])
-                has_multiple_choice = (True if multiple_choice_options else False)
+                has_multiple_choice = True if multiple_choice_options else False
             except s3.exceptions.NoSuchKey:
                 errors.append(f"Missing {question_file}")
                 has_free_text = True
@@ -427,9 +427,19 @@ def import_multiple_choice_responses(question: Question, multichoice_file_key: s
                     )
                 )
 
-        # TODO - batch bulk updates/creates
-        Response.objects.bulk_create(responses_to_create)
-        Response.objects.bulk_update(responses_to_update, fields=["chosen_options"])
+            if (
+                len(responses_to_create) >= DEFAULT_BATCH_SIZE
+                or len(responses_to_update) >= DEFAULT_BATCH_SIZE
+            ):
+                Response.objects.bulk_create(responses_to_create)
+                Response.objects.bulk_update(responses_to_update, fields=["chosen_options"])
+                responses_to_create = []
+                responses_to_update = []
+
+        # Handle any remaining responses
+        if responses_to_create or responses_to_update:
+            Response.objects.bulk_create(responses_to_create)
+            Response.objects.bulk_update(responses_to_update, fields=["chosen_options"])
 
     except Exception as e:
         logger.error(

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -345,7 +345,10 @@ def import_responses(question: Question, responses_file_key: str):
                 free_text = free_text[:1000]
                 token_count = len(encoding.encode(free_text))
 
-            if total_tokens + token_count > max_total_tokens or len(responses_to_save) >= max_batch_size:
+            if (
+                total_tokens + token_count > max_total_tokens
+                or len(responses_to_save) >= max_batch_size
+            ):
                 embedded_responses_to_save = _embed_responses(responses_to_save)
                 Response.objects.bulk_create(embedded_responses_to_save)
                 responses_to_save = []
@@ -386,22 +389,36 @@ def import_multiple_choice_responses(question: Question, multichoice_file_key: s
 
     try:
         respondents = Respondent.objects.filter(consultation=question.consultation)
+        themefinder_ids_for_existing_responses = Response.objects.filter(
+            question=question
+        ).values_list("respondent__themefinder_id", flat=True)
         respondent_dict = {r.themefinder_id: r for r in respondents}
 
-        responses_to_save = []
+        responses_to_update = []
+        responses_to_create = []
         for i, line in enumerate(multichoice_data["Body"].iter_lines()):
             response_data = json.loads(line.decode("utf-8"))
             themefinder_id = response_data["themefinder_id"]
             chosen_options = response_data.get("chosen_options", [])
 
-            responses_to_save.append(Response(respondent=respondent_dict[themefinder_id], question=question, chosen_options=chosen_options))
+            if themefinder_id in themefinder_ids_for_existing_responses:
+                response = Response.objects.get(
+                    respondent=respondent_dict[themefinder_id], question=question
+                )
+                response.chosen_options = chosen_options
+                responses_to_update.append(response)
+            else:
+                responses_to_create.append(
+                    Response(
+                        respondent=respondent_dict[themefinder_id],
+                        question=question,
+                        chosen_options=chosen_options,
+                    )
+                )
 
-            if len(responses_to_save) >= DEFAULT_BATCH_SIZE:
-                Response.objects.bulk_create(responses_to_save, update_conflicts=True, update_fields=["chosen_options", "question"], unique_fields=["id"])
-                responses_to_save = []
-                logger.info("saved %s Responses for question %s", i + 1, question.number)
-
-        Response.objects.bulk_create(responses_to_save, update_conflicts=True, update_fields=["chosen_options", "question"], unique_fields=["id"])
+        # TODO - batch bulk updates/creates
+        Response.objects.bulk_create(responses_to_create)
+        Response.objects.bulk_update(responses_to_update, fields=["chosen_options"])
 
     except Exception as e:
         logger.error(

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -385,25 +385,28 @@ def import_multiple_choice_responses(question: Question, multichoice_file_key: s
     )
 
     try:
-        # Get respondents
         respondents = Respondent.objects.filter(consultation=question.consultation)
+        respondent_dict = {r.themefinder_id: r for r in respondents}
 
-        # Second pass: create responses
+        responses_to_save = []
         for i, line in enumerate(multichoice_data["Body"].iter_lines()):
             response_data = json.loads(line.decode("utf-8"))
             themefinder_id = response_data["themefinder_id"]
             chosen_options = response_data.get("chosen_options", [])
-            respondent = respondents.get(themefinder_id=themefinder_id)
-            Response.objects.update_or_create(
-                respondent=respondent,
-                question=question,
-                defaults={
-                    "respondent": respondent,
-                    "question": question,
-                    "chosen_options": chosen_options,
-                },
-            )
-            # How can we do this with bulk update/create?
+
+            responses_to_save.append(
+                dict(
+                    respondent=respondent_dict[themefinder_id],
+                    question=question,
+                    chosen_options = chosen_options
+                ))
+
+            if len(responses_to_save) >= DEFAULT_BATCH_SIZE:
+                Response.objects.bulk_create(responses_to_save, update_conflicts=True, update_fields=["chosen_options", "question"], unique_fields=["id"])
+                responses_to_save = []
+                logger.info("saved %s Responses for question %s", i + 1, question.number)
+
+        Response.objects.bulk_create(responses_to_save, update_conflicts=True, update_fields=["chosen_options", "question"], unique_fields=["id"])
 
     except Exception as e:
         logger.error(

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -474,10 +474,10 @@ def import_questions(
                 multiple_choice_options=multiple_choice_options,
             )
 
-            responses_file_key = f"{question_folder}responses.jsonl"
-            responses = queue.enqueue(import_responses, question, responses_file_key)
-
             if question.has_free_text:
+                responses_file_key = f"{question_folder}responses.jsonl"
+                responses = queue.enqueue(import_responses, question, responses_file_key)
+
                 output_folder = f"{outputs_path}question_part_{question_num_str}/"
                 themes = queue.enqueue(import_themes, question, output_folder, depends_on=responses)
                 response_annotations = queue.enqueue(
@@ -489,6 +489,11 @@ def import_questions(
                     output_folder,
                     depends_on=response_annotations,
                 )
+
+            if question.has_multiple_choice:
+                multichoice_file_key = f"{question_folder}multi_choice.jsonl"
+                queue.enqueue(import_multiple_choice_responses, question, multichoice_file_key)
+
 
     except Exception as e:
         logger.error(f"Error importing question data for {consultation_code}: {str(e)}")

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -378,6 +378,30 @@ def import_responses(question: Question, responses_file_key: str):
         raise
 
 
+def import_multiple_choice_responses(question: Question, multichoice_file_key: str):
+    s3_client = boto3.client("s3")
+    multichoice_data = s3_client.get_object(Bucket=settings.AWS_BUCKET_NAME, Key=multichoice_file_key)
+
+    try:
+        # Get respondents
+        respondents = Respondent.objects.filter(consultation=question.consultation)
+
+        # Second pass: create responses
+        for i, line in enumerate(multichoice_data["Body"].iter_lines()):
+            response_data = json.loads(line.decode("utf-8"))
+            themefinder_id = response_data["themefinder_id"]
+            chosen_options = response_data.get("chosen_options", [])
+            respondent = respondents.get(themefinder_id=themefinder_id)
+            Response.objects.update_or_create(respondent=respondent, create_defaults={"respondent": respondent, "chosen_options": chosen_options})
+            # How can we do this with bulk update/create?
+
+    except Exception as e:
+        logger.error(
+            f"Error importing responses for consultation {question.consultation.title}, question {question.number}: {str(e)}"
+        )
+        raise
+
+
 def import_themes(question: Question, output_folder: str):
     s3_client = boto3.client("s3")
     themes_file_key = f"{output_folder}themes.json"


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to be able to import multiple choice data. This will run the import.

The existing code already imports the options from the question data. This PR also imports it from the responses.

The question data should be of the format (as existing):
```
{"question_text": "What do you think?", "has_free_text": true, "options": ["a", "b", "c"]}
```

The multiple choice data should be in a file called `multi_choice.jsonl` - each row should be of the form:
```
{"themefinder_id": 1, "chosen_options": ["x", "y", "z"]}
```

This code needs to be tested - especially with a large dataset.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A