### PR TITLE
Improve AWS Batch AI pipeline efficiency

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import boto3
 import tiktoken
+from botocore.exceptions import ClientError
 from django.conf import settings
 from django.contrib.postgres.search import SearchVector
 from django_rq import get_queue
@@ -101,7 +102,7 @@ def validate_consultation_structure(
         "respondents": f"{inputs_path}respondents.jsonl",
     }
 
-    required_outputs = ["themes.json", "mapping.jsonl", "sentiment.jsonl", "detail_detection.jsonl"]
+    required_outputs = ["themes.json", "mapping.jsonl", "detail_detection.jsonl"]
 
     try:
         # Check if respondents file exists
@@ -248,20 +249,29 @@ def import_response_annotations(question: Question, output_folder: str):
     sentiment_file_key = f"{output_folder}sentiment.jsonl"
     evidence_file_key = f"{output_folder}detail_detection.jsonl"
     s3_client = boto3.client("s3")
-    sentiment_response = s3_client.get_object(
-        Bucket=settings.AWS_BUCKET_NAME, Key=sentiment_file_key
-    )
+    
+    # Check if sentiment file exists and process it
     sentiment_dict = {}
-    for line in sentiment_response["Body"].iter_lines():
-        sentiment = json.loads(line.decode("utf-8"))
-        sentiment_value = sentiment.get("sentiment", "UNCLEAR").upper()
+    try:
+        s3_client.head_object(Bucket=settings.AWS_BUCKET_NAME, Key=sentiment_file_key)
+        sentiment_response = s3_client.get_object(
+            Bucket=settings.AWS_BUCKET_NAME, Key=sentiment_file_key
+        )
+        for line in sentiment_response["Body"].iter_lines():
+            sentiment = json.loads(line.decode("utf-8"))
+            sentiment_value = sentiment.get("sentiment", "UNCLEAR").upper()
 
-        if sentiment_value == "AGREEMENT":
-            sentiment_dict[sentiment["themefinder_id"]] = ResponseAnnotation.Sentiment.AGREEMENT
-        elif sentiment_value == "DISAGREEMENT":
-            sentiment_dict[sentiment["themefinder_id"]] = ResponseAnnotation.Sentiment.DISAGREEMENT
+            if sentiment_value == "AGREEMENT":
+                sentiment_dict[sentiment["themefinder_id"]] = ResponseAnnotation.Sentiment.AGREEMENT
+            elif sentiment_value == "DISAGREEMENT":
+                sentiment_dict[sentiment["themefinder_id"]] = ResponseAnnotation.Sentiment.DISAGREEMENT
+            else:
+                sentiment_dict[sentiment["themefinder_id"]] = ResponseAnnotation.Sentiment.UNCLEAR
+    except ClientError as e:
+        if e.response['Error']['Code'] == '404':
+            logger.info(f"Sentiment file not found: {sentiment_file_key}, using default UNCLEAR sentiment")
         else:
-            sentiment_dict[sentiment["themefinder_id"]] = ResponseAnnotation.Sentiment.UNCLEAR
+            raise
 
     evidence_response = s3_client.get_object(Bucket=settings.AWS_BUCKET_NAME, Key=evidence_file_key)
     evidence_dict = {}
@@ -345,7 +355,10 @@ def import_responses(question: Question, responses_file_key: str):
                 free_text = free_text[:1000]
                 token_count = len(encoding.encode(free_text))
 
-            if total_tokens + token_count > max_total_tokens or len(responses_to_save) >= max_batch_size:
+            if (
+                total_tokens + token_count > max_total_tokens
+                or len(responses_to_save) >= max_batch_size
+            ):
                 embedded_responses_to_save = _embed_responses(responses_to_save)
                 Response.objects.bulk_create(embedded_responses_to_save)
                 responses_to_save = []

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/import_consultation.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/import_consultation.html
@@ -21,19 +21,19 @@
         {% for error in validation_errors %}
         <li>
           {% if error.type == 'missing_file' %}
-            <strong>Missing file:</strong> {{ error.message }}
+          <strong>Missing file:</strong> {{ error.message }}
           {% elif error.type == 'missing_output' %}
-            <strong>Missing AI output:</strong> {{ error.message }}
+          <strong>Missing AI output:</strong> {{ error.message }}
           {% elif error.type in ['invalid_format', 'empty_file'] %}
-            <strong>File format issue:</strong> {{ error.message }}
+          <strong>File format issue:</strong> {{ error.message }}
           {% elif error.type == 'no_questions' %}
-            <strong>Structure issue:</strong> {{ error.message }}
+          <strong>Structure issue:</strong> {{ error.message }}
           {% elif error.type == 'file_not_found' %}
-            <strong>File not found:</strong> {{ error.message }}
+          <strong>File not found:</strong> {{ error.message }}
           {% elif error.type == 'system_error' %}
-            <strong>System error:</strong> {{ error.message }}
+          <strong>System error:</strong> {{ error.message }}
           {% else %}
-            {{ error.message }}
+          {{ error.message }}
           {% endif %}
         </li>
         {% endfor %}
@@ -84,7 +84,8 @@
 <p class="govuk-body">This will import both the consultation data (questions, respondents, responses) and AI analysis
   results (themes, sentiment, evidence) sequentially.</p>
 
-<p class="govuk-body">Data should be saved in: <code>{{ bucket_name }}/app_data/consultations/[CONSULTATION FOLDER]</code></p>
+<p class="govuk-body">Data should be saved in:
+  <code>{{ bucket_name }}/app_data/consultations/[CONSULTATION FOLDER]</code></p>
 
 {{ govukDetails({
 'summaryText': 'Expected S3 Structure',
@@ -103,12 +104,12 @@
         └── &lt;timestamp&gt;/
             ├── question_part_1/
             │   ├── themes.json
-            │   ├── sentiment.jsonl
+            │   ├── sentiment.jsonl [optional]
             │   ├── detail_detection.jsonl
             │   └── mapping.jsonl
             └── question_part_2/
                 ├── themes.json
-                ├── sentiment.jsonl
+                ├── sentiment.jsonl [optional]
                 ├── detail_detection.jsonl
                 └── mapping.jsonl</code></pre>
 '

--- a/pipeline-mapping/mapping_script.py
+++ b/pipeline-mapping/mapping_script.py
@@ -142,7 +142,6 @@ async def process_consultation(consultation_dir: str = "test_consultation") -> s
                     responses_df,
                     llm,
                     question=question,
-                    concurrency=1,
                 )
                 detail_df = detail_df[["response_id", "evidence_rich"]]
                 detail_df = detail_df.rename(columns={"response_id": "themefinder_id"})
@@ -155,7 +154,6 @@ async def process_consultation(consultation_dir: str = "test_consultation") -> s
                     llm,
                     refined_themes_df=themes_df[["topic_id", "topic"]],
                     question=question,
-                    concurrency=1,
                 )
                 mapped_df = mapped_df[["response_id", "labels", "stances"]]
                 mapped_df = mapped_df.rename(

--- a/pipeline-mapping/mapping_script.py
+++ b/pipeline-mapping/mapping_script.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import boto3
 import pandas as pd
 from langchain_openai import AzureChatOpenAI
-from themefinder import detail_detection, sentiment_analysis, theme_mapping
+from themefinder import detail_detection, theme_mapping
 
 # Configure logging
 logging.basicConfig(
@@ -137,19 +137,6 @@ async def process_consultation(consultation_dir: str = "test_consultation") -> s
                     logger.info("Created outputs directory at: %s", question_output_dir)
 
                 question, responses_df, themes_df = load_question(consultation_dir, question_dir)
-                sentiment_df, _ = await sentiment_analysis(
-                    responses_df,
-                    llm,
-                    question=question,
-                    concurrency=1,
-                )
-                sentiment_df = sentiment_df[["response_id", "position"]]
-                sentiment_df = sentiment_df.rename(
-                    columns={"response_id": "themefinder_id", "position": "sentiment"}
-                )
-                sentiment_df.to_json(
-                    question_output_dir / "sentiment.jsonl", orient="records", lines=True
-                )
 
                 detail_df, _ = await detail_detection(
                     responses_df,

--- a/pipeline-sign-off/sign_off_script.py
+++ b/pipeline-sign-off/sign_off_script.py
@@ -11,7 +11,6 @@ import boto3
 import pandas as pd
 from langchain_openai import AzureChatOpenAI
 from themefinder import (
-    sentiment_analysis,
     theme_condensation,
     theme_generation,
     theme_mapping,
@@ -118,17 +117,7 @@ async def generate_themes(question: str, responses_df: pd.DataFrame) -> pd.DataF
     Returns:
         pd.DataFrame: DataFrame containing refined themes
     """
-    sentiment_df, _ = await sentiment_analysis(
-        responses_df,
-        llm,
-        question=question,
-    )
-
-    theme_df, _ = await theme_generation(
-        sentiment_df,
-        llm,
-        question=question,
-    )
+    theme_df, _ = await theme_generation(responses_df, llm, question=question, partition_key=None)
 
     condensed_theme_df, _ = await theme_condensation(
         theme_df,


### PR DESCRIPTION
The AWS Batch pipelines that Dheeraj set up were running slowly. He has confirmed that each project in i.ai is in it's own queue, so we should not be getting any interference from that caddy job. This PR implements a couple of changes that should speed up the Batch pipelines and make them more usable:

- It increases concurrency in the mapping script (this was set low for development)
- It removes the sentiment analysis task from both pipelines, as we don't need it. I have updated the ingestion code to make sentiment optional (previously no `sentiment.jsonl` would have broken the import)