### PR TITLE
bugfix/hypenate action paths

### DIFF
--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -67,7 +67,7 @@ class QuestionViewSet(ReadOnlyModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=["get"], url_name="demographic_aggregations")
+    @action(detail=True, methods=["get"], url_path="demographic-aggregations")
     def demographic_aggregations(self, request, pk=None, consultation_pk=None):
         """Get demographic aggregations for filtered responses"""
         # Get the question object with consultation in one query
@@ -101,7 +101,7 @@ class QuestionViewSet(ReadOnlyModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=["get"], url_name="themes")
+    @action(detail=True, methods=["get"])
     def themes(self, request, pk=None, consultation_pk=None):
         """Get all theme information for a question"""
         # Get the question object with consultation in one query
@@ -115,7 +115,7 @@ class QuestionViewSet(ReadOnlyModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=["get"], url_name="theme_aggregations")
+    @action(detail=True, methods=["get"], url_path="theme-aggregations")
     def theme_aggregations(self, request, pk=None, consultation_pk=None):
         """Get theme aggregations for filtered responses"""
 
@@ -152,7 +152,7 @@ class QuestionViewSet(ReadOnlyModelViewSet):
 
         return Response(serializer.data)
 
-    @action(detail=True, methods=["get"], url_name="filtered_responses")
+    @action(detail=True, methods=["get"], url_path="filtered-responses")
     def filtered_responses(self, request, pk=None, consultation_pk=None):
         """Get paginated filtered responses with orjson optimization"""
         question = self.get_object()


### PR DESCRIPTION
## Context

This is a bug, the frontend is looking for hyphenated urls, but DRF is serving underscores by default `/theme_aggregations` rather than `/theme-aggregations`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo