### PR TITLE
feature/sessionId-endpoint

### DIFF
--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -12,7 +12,7 @@ from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
-from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.tokens import RefreshToken, AccessToken
 
 from .. import models
 from ..views.sessions import send_magic_link_if_email_exists
@@ -274,15 +274,18 @@ def verify_magic_link(request) -> HttpResponse:
     try:
         link.validate()
         link.authorize(request.user)
-        refresh = RefreshToken.for_user(link.user)
+        token = AccessToken.for_user(link.user)
     except (PermissionDenied, InvalidLink) as ex:
         link.audit(request, error=ex)
         return JsonResponse(data={"detail": str(ex.args[0])}, status=403)
     else:
         link.audit(request)
+        # Ensure session is created if it doesn't exist
+        if not request.session.session_key:
+            request.session.save()
         return JsonResponse(
             {
-                "access": str(refresh.access_token),
-                "refresh": str(refresh),
+                "access": str(token),
+                "sessionId": request.session.session_key,
             }
         )

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -68,5 +68,4 @@ urlpatterns = [
     # JWT
     path("api/magic-link/", generate_magic_link, name="token-magic-link"),
     path("api/token/", verify_magic_link, name="create-token"),
-    path("api/token/refresh/", TokenRefreshView.as_view(), name="refresh-token"),
 ]

--- a/tests/views/test_api_auth.py
+++ b/tests/views/test_api_auth.py
@@ -1,9 +1,10 @@
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
 from django.urls import reverse
 from magic_link.models import MagicLink
-from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.tokens import RefreshToken, AccessToken
 
 from tests.utils import build_url
 
@@ -30,8 +31,8 @@ def test_create_token(client, dashboard_user):
     url = reverse("create-token")
     response = client.post(url, data={"token": link.token})
     assert response.status_code == 200
-    assert "access" in response.json()
-    assert "refresh" in response.json()
+    assert response.json()["access"]
+    assert response.json()["sessionId"]
 
 
 @pytest.mark.django_db
@@ -89,12 +90,14 @@ def test_api_urls_permission_required(
 
 
 @pytest.mark.django_db
-def test_refresh(client, dashboard_user):
-    refresh = RefreshToken.for_user(dashboard_user)
-    url = reverse("refresh-token")
+def test_token_expired(client, dashboard_user):
+    token = AccessToken.for_user(dashboard_user)
+    token.set_exp(lifetime=timedelta(seconds=-1))
 
-    response = client.post(url, data={"refresh": str(refresh)})
-    assert response.status_code == 200, response.content
-    assert set(response.json()) == {"access"}
+    url = reverse("consultations-list")
 
-    assert response.json()["access"] != str(refresh.token)
+    response = client.post(url, headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 401
+    assert response.json()["messages"][0]["message"] == "Token is expired"
+


### PR DESCRIPTION
## Context

As a front engineer I want the `api/token/` endpoint to return the `sessionId` as well as the `access` token so that I can access the backend whilst we migrate the frontend code to the frontend app

## Changes proposed in this pull request

1. `sessionId` added to the response payload
2. `refresh` removed
3. test for expiry added

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo