### PR TITLE
Feature/add respondent id filter

### DIFF
--- a/consultation_analyser/consultations/api/serializers.py
+++ b/consultation_analyser/consultations/api/serializers.py
@@ -100,6 +100,7 @@ class FilterSerializer(serializers.Serializer):
     themeFilters = serializers.CharField(required=False, allow_blank=True)
     demoFilters = serializers.ListField(child=serializers.CharField(), required=False)
     evidenceRich = serializers.BooleanField(required=False)
+    respondent_id = serializers.UUIDField(required=False)
     searchValue = serializers.CharField(required=False)
     searchMode = serializers.ChoiceField(choices=["semantic", "keyword"], required=False)
 

--- a/consultation_analyser/consultations/api/serializers.py
+++ b/consultation_analyser/consultations/api/serializers.py
@@ -98,13 +98,10 @@ class FilterSerializer(serializers.Serializer):
 
     sentimentFilters = serializers.CharField(required=False, allow_blank=True)
     themeFilters = serializers.CharField(required=False, allow_blank=True)
+    demoFilters = serializers.ListField(child=serializers.CharField(), required=False)
     evidenceRich = serializers.BooleanField(required=False)
     searchValue = serializers.CharField(required=False)
     searchMode = serializers.ChoiceField(choices=["semantic", "keyword"], required=False)
-    demoFilters = serializers.ListField(child=serializers.CharField(), required=False)
-    # Pagination parameters
-    page = serializers.IntegerField(required=False, default=1, min_value=1)
-    page_size = serializers.IntegerField(required=False, default=50, min_value=1, max_value=100)
 
 
 class ThemeSerializer2(serializers.ModelSerializer):

--- a/consultation_analyser/consultations/api/utils.py
+++ b/consultation_analyser/consultations/api/utils.py
@@ -13,7 +13,6 @@ class FilterParams(TypedDict, total=False):
     theme_list: list[str]
     evidence_rich: bool
     demo_filters: dict[str, str]
-    respondent_id: UUID
     search_mode: str
     search_value: str
 
@@ -32,9 +31,6 @@ def parse_filters_from_serializer(validated_data: dict) -> FilterParams:
 
     if validated_data.get("evidenceRich"):
         filters["evidence_rich"] = True
-
-    if respondent_id:=validated_data.get("respondent_id"):
-        filters["respondent_id"] = respondent_id
 
     if "searchValue" in validated_data:
         filters["search_value"] = validated_data["searchValue"]
@@ -75,9 +71,6 @@ def build_response_filter_query(filters: FilterParams) -> Q:
 
     if evidence_rich := filters.get("evidence_rich"):
         query &= Q(annotation__evidence_rich=evidence_rich)
-
-    if respondent_id := filters.get("respondent_id"):
-        query &= Q(respondent_id=respondent_id)
 
     # Handle demographic filters
     if demo_filters := filters.get("demo_filters"):

--- a/consultation_analyser/consultations/api/utils.py
+++ b/consultation_analyser/consultations/api/utils.py
@@ -1,4 +1,5 @@
 from typing import TypedDict
+from uuid import UUID
 
 from django.db.models import Count, Q, QuerySet
 from pgvector.django import CosineDistance
@@ -11,8 +12,9 @@ class FilterParams(TypedDict, total=False):
     sentiment_list: list[str]
     theme_list: list[str]
     evidence_rich: bool
-    search_mode: str
     demo_filters: dict[str, str]
+    respondent_id: UUID
+    search_mode: str
     search_value: str
 
 
@@ -30,6 +32,9 @@ def parse_filters_from_serializer(validated_data: dict) -> FilterParams:
 
     if validated_data.get("evidenceRich"):
         filters["evidence_rich"] = True
+
+    if respondent_id:=validated_data.get("respondent_id"):
+        filters["respondent_id"] = respondent_id
 
     if "searchValue" in validated_data:
         filters["search_value"] = validated_data["searchValue"]
@@ -70,6 +75,9 @@ def build_response_filter_query(filters: FilterParams) -> Q:
 
     if evidence_rich := filters.get("evidence_rich"):
         query &= Q(annotation__evidence_rich=evidence_rich)
+
+    if respondent_id := filters.get("respondent_id"):
+        query &= Q(respondent_id=respondent_id)
 
     # Handle demographic filters
     if demo_filters := filters.get("demo_filters"):

--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -245,6 +245,8 @@ class ResponseViewSet(ReadOnlyModelViewSet):
     serializer_class = ResponseSerializer
     permission_classes = [HasDashboardAccess, CanSeeConsultation]
     pagination_class = BespokeResultsSetPagination
+    filterset_fields = ["respondent_id"]
+
 
     def get_queryset(self):
         question_uuid = self.kwargs["question_pk"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,11 @@ def non_consultation_user():
     yield user
     user.delete()
 
+@pytest.fixture
+def consultation_user_token(consultation_user):
+    refresh = RefreshToken.for_user(consultation_user)
+    yield str(refresh.access_token)
+
 
 @pytest.fixture
 def dashboard_user_token(dashboard_user):

--- a/tests/unit/api/test_serializers.py
+++ b/tests/unit/api/test_serializers.py
@@ -191,7 +191,7 @@ class TestFilterSerializer:
         data = {}
         serializer = FilterSerializer(data=data)
         assert serializer.is_valid()
-        assert serializer.validated_data == {"page": 1, "page_size": 50}  # defaults
+        assert serializer.validated_data == {}
 
     def test_all_valid_filters(self):
         """Test filter serializer with all valid filter types"""
@@ -204,8 +204,6 @@ class TestFilterSerializer:
             "searchValue": "test search",
             "searchMode": "semantic",
             "demoFilters": ["individual:true", "region:north"],
-            "page": 2,
-            "page_size": 25,
         }
         serializer = FilterSerializer(data=data)
         assert serializer.is_valid()
@@ -217,8 +215,6 @@ class TestFilterSerializer:
         assert validated["searchValue"] == "test search"
         assert validated["searchMode"] == "semantic"
         assert validated["demoFilters"] == ["individual:true", "region:north"]
-        assert validated["page"] == 2
-        assert validated["page_size"] == 25
 
     def test_invalid_search_mode(self):
         """Test filter serializer with invalid search mode"""
@@ -227,25 +223,6 @@ class TestFilterSerializer:
         assert not serializer.is_valid()
         assert "searchMode" in serializer.errors
 
-    def test_invalid_pagination_parameters(self):
-        """Test filter serializer with invalid pagination parameters"""
-        # Test page too small
-        data = {"page": 0}
-        serializer = FilterSerializer(data=data)
-        assert not serializer.is_valid()
-        assert "page" in serializer.errors
-
-        # Test page_size too small
-        data = {"page_size": 0}
-        serializer = FilterSerializer(data=data)
-        assert not serializer.is_valid()
-        assert "page_size" in serializer.errors
-
-        # Test page_size too large
-        data = {"page_size": 200}
-        serializer = FilterSerializer(data=data)
-        assert not serializer.is_valid()
-        assert "page_size" in serializer.errors
 
     def test_boolean_evidence_rich_conversion(self):
         """Test that evidenceRich is properly converted to boolean"""

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -506,6 +506,45 @@ class TestFilteredResponsesAPIView:
         assert len(data["all_respondents"]) == 1
         assert data["all_respondents"][0]["identifier"] == str(respondent1.identifier)
 
+    def test_get_filtered_responses_with_respondent_filters(
+        self, client, consultation_user, free_text_question, theme, theme2, consultation_user_token
+    ):
+        """Test API endpoint with theme filtering using AND logic"""
+        # Create responses with different theme combinations
+        respondent1 = RespondentFactory(consultation=free_text_question.consultation)
+        respondent2 = RespondentFactory(consultation=free_text_question.consultation)
+
+        _ = ResponseFactory(
+            question=free_text_question, respondent=respondent1, free_text="Response 1"
+        )
+        _ = ResponseFactory(
+            question=free_text_question, respondent=respondent2, free_text="Response 2"
+        )
+
+
+        client.force_login(consultation_user)
+        url = reverse(
+            "response-list",
+            kwargs={
+                "consultation_pk": free_text_question.consultation.id,
+                "question_pk": free_text_question.id,
+            },
+        )
+
+        # Filter by respondent1 - should only return response1
+        response = client.get(
+            url + f"?respondent_id={respondent1.id}",
+            headers={"Authorization": f"Bearer {consultation_user_token}"},
+        )
+
+        assert response.status_code == 200
+
+        data = response.json()
+
+        assert data["respondents_total"] == 2  # Total respondents
+        assert data["filtered_total"] == 1  # Only response1
+        assert len(data["all_respondents"]) == 1
+        assert data["all_respondents"][0]["identifier"] == str(respondent1.identifier)
 
 
 

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -506,26 +506,7 @@ class TestFilteredResponsesAPIView:
         assert len(data["all_respondents"]) == 1
         assert data["all_respondents"][0]["identifier"] == str(respondent1.identifier)
 
-    def test_get_filtered_responses_invalid_parameters(
-        self, client, consultation_user, free_text_question
-    ):
-        """Test API endpoint handles invalid parameters"""
-        client.force_login(consultation_user)
-        url = reverse(
-            "response-list",
-            kwargs={
-                "consultation_pk": free_text_question.consultation.id,
-                "question_pk": free_text_question.id,
-            },
-        )
 
-        # Test invalid page_size (too large)
-        response = client.get(url + "?page_size=200")
-        assert response.status_code == 400
-
-        # Test invalid page number
-        response = client.get(url + "?page=0")
-        assert response.status_code == 400
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context

As a FrontEnd Engineer I want to be able to filter the responses by `respondent_id`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo