### PR TITLE
feature/multiple-values-for-same-demographic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,15 @@ def individual_demographic_option(consultation):
 
 
 @pytest.fixture()
+def group_demographic_option(consultation):
+    do = DemographicOption.objects.create(
+        consultation=consultation, field_name="individual", field_value=False
+    )
+    yield do
+    do.delete()
+
+
+@pytest.fixture()
 def no_disability_demographic_option(consultation):
     do = DemographicOption.objects.create(
         consultation=consultation, field_name="has_disability", field_value=False
@@ -323,6 +332,15 @@ def no_disability_demographic_option(consultation):
 def north_demographic_option(consultation):
     do = DemographicOption.objects.create(
         consultation=consultation, field_name="region", field_value="north"
+    )
+    yield do
+    do.delete()
+
+
+@pytest.fixture()
+def south_demographic_option(consultation):
+    do = DemographicOption.objects.create(
+        consultation=consultation, field_name="region", field_value="south"
     )
     yield do
     do.delete()


### PR DESCRIPTION
## Context

As a User I want to want the backend to accept multiple values for the same demographic so that I can filter on region = north & south.

Previously only the last value was accepted.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo