### PR TITLE
Feature/move to dynamic calculation of response count

### DIFF
--- a/consultation_analyser/consultations/api/serializers.py
+++ b/consultation_analyser/consultations/api/serializers.py
@@ -33,11 +33,10 @@ class QuestionSerializer(serializers.HyperlinkedModelSerializer):
         many=True, source="multichoiceanswer_set", read_only=True
     )
     proportion_of_audited_answers = serializers.ReadOnlyField()
-    total_responses = serializers.IntegerField(
-        read_only=True,
-        source="response_count",
-        required=False,
-    )
+    total_responses = serializers.SerializerMethodField()
+
+    def get_total_responses(self, obj) -> int:
+        return obj.response_set.count()
 
     class Meta:
         model = Question


### PR DESCRIPTION
## Context

As a FE Engineer I want to dynamically compute the the response-count whilst we still have legacy consultations where this isnt computed on ingest

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo