### PR TITLE
bugfix/fixed migration order

### DIFF
--- a/consultation_analyser/consultations/migrations/0072_remove_responseannotationtheme_unique_theme_assignment_and_more.py
+++ b/consultation_analyser/consultations/migrations/0072_remove_responseannotationtheme_unique_theme_assignment_and_more.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("consultations", "0070_historicalresponseannotation_and_more"),
+        ("consultations", "0071_responseannotation_flagged_by"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
## Context

migration must be linear, i.e. we can have two migration with the same parent

## Changes proposed in this pull request

The later migration 72 has been renamed 73 and made a dependant of the first

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo