### PR TITLE
Redirect logged-in users to consultations page

### DIFF
--- a/frontend/src/components/Header/Header.svelte
+++ b/frontend/src/components/Header/Header.svelte
@@ -58,21 +58,24 @@
                     "before:-skew-x-[30deg]",
                     "before:w-32",
                 ])}>
-                    <a href="/" class={clsx([
-                        "flex",
-                        "justify-center",
-                        "items-center",
-                        "relative",
-                        "left-4",
-                        "h-full",
-                        "w-full",
-                        "px-0",
-                        "pr-2",
-                        "pl-8",
-                        "text-white",
-                        "text-2xl",
-                        "no-underline",
-                    ])}>
+                    <a
+                        href={isSignedIn ? Routes.Consultations : Routes.Home}
+                        class={clsx([
+                            "flex",
+                            "justify-center",
+                            "items-center",
+                            "relative",
+                            "left-4",
+                            "h-full",
+                            "w-full",
+                            "px-0",
+                            "pr-2",
+                            "pl-8",
+                            "text-white",
+                            "text-2xl",
+                            "no-underline",
+                        ])}
+                    >
                         Consult
                     </a>
                 </div>

--- a/frontend/src/components/MagicLinkButton/MagicLinkButton.svelte
+++ b/frontend/src/components/MagicLinkButton/MagicLinkButton.svelte
@@ -30,7 +30,7 @@
                 return;
             }
 
-            window.location.href = Routes.Home;
+            window.location.href = Routes.Consultations;
         } catch(err: any) {
             error = err.message;
         } finally {


### PR DESCRIPTION
## Context
Following recent changes, logged in users no longer get redirected to consultations page when they navigate to home page.

## Changes proposed in this pull request
This PR changes the header Consult logo href to consultations page for logged-in users, so they can still see the home page if they need to but is easy to navigate to the consultations page.

It also updates the sign in redirect to consultations page since home page will no longer handle the redirect.

## Guidance to review

Confirm successful sign in redirects to consultations page and header Consult logo navigates to consultations page if logged in, home page if not.

## Link to Trello ticket

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo