### PR TITLE
Redirect to home on sign out

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -8,7 +8,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
 
     // 404 if not logged in
     const protectedRoutes = [
-        /^\/sign-out[\/]?$/,
+        // /^\/sign-out[\/]?$/,
         /^\/consultations.*/,
         /^\/design.*/,
     ];

--- a/frontend/src/pages/sign-out.astro
+++ b/frontend/src/pages/sign-out.astro
@@ -3,6 +3,9 @@ import Layout from '../layouts/Layout.astro';
 import Section from '../components/Section/Section.svelte';
 import Title from '../components/Title.svelte';
 
+import { Routes } from '../global/routes';
+
+
 ["access", "sessionId"].forEach(cookie => {
     Astro.cookies.set(cookie, "", {
         path: "/",
@@ -10,6 +13,8 @@ import Title from '../components/Title.svelte';
         expires: new Date(0),
     })
 })
+
+return Astro.redirect(Routes.Home);
 ---
 <Layout>
 	<Section>


### PR DESCRIPTION
## Context
Currently, for logged out users the sign out page returns 404. They need to be redirected to home instead.

## Changes proposed in this pull request
This PR removes sign out from protected routes and adds redirect to home page after tokens are cleared.

## Guidance to review
Confirm sign out flow redirects to home page and clears tokens as expected.

## Link to Trello ticket

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo