### PR TITLE
feature/make-filter-consistent-with-field-names 

### DIFF
--- a/consultation_analyser/consultations/api/filters.py
+++ b/consultation_analyser/consultations/api/filters.py
@@ -27,7 +27,7 @@ class ResponseFilter(FilterSet):
     themeFilters = BaseInFilter(method="filter_themes")
     demoFilters = CharFilter(method="filter_demographics")
     is_flagged = BooleanFilter()
-    chosen_options = BaseInFilter(lookup_expr="in")
+    multiple_choice_answer = BaseInFilter(field_name="chosen_options", lookup_expr="in")
 
     def filter_themes(self, queryset, name, value):
         if not value:

--- a/consultation_analyser/consultations/api/serializers.py
+++ b/consultation_analyser/consultations/api/serializers.py
@@ -22,10 +22,12 @@ class UserSerializer(serializers.ModelSerializer):
         fields = ["email", "has_dashboard_access"]
 
 
-class MultiChoiceAnswerSerializer(serializers.HyperlinkedModelSerializer):
+class MultiChoiceAnswerSerializer(serializers.ModelSerializer):
+    id = serializers.UUIDField(read_only=True)
+
     class Meta:
         model = MultiChoiceAnswer
-        fields = ["text"]
+        fields = ["id", "text"]
 
 
 class QuestionSerializer(serializers.HyperlinkedModelSerializer):

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -728,7 +728,7 @@ class TestFilteredResponsesAPIView:
         chosen_options_query = ",".join(str(x.pk) for x in _chosen_options)
 
         response = client.get(
-            url + f"?chosen_options={chosen_options_query}",
+            url + f"?multiple_choice_answer={chosen_options_query}",
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {consultation_user_token}",


### PR DESCRIPTION
## Context

As a frontend engineer I want the filter-name to be consistent with the object field `multiple_choice_answer` and for the multiple_choice_answer ids to be displayed to i know what to filter on

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo