### PR TITLE
bugfix/use-theme_id-not-association_id-in-payload

### DIFF
--- a/consultation_analyser/consultations/api/serializers.py
+++ b/consultation_analyser/consultations/api/serializers.py
@@ -129,14 +129,14 @@ class MultiChoiceAnswerCount(serializers.Serializer):
 
 
 class ResponseAnnotationThemeSerializer(serializers.ModelSerializer):
-    id = serializers.UUIDField()
+    id = serializers.UUIDField(source="theme.id")
     name = serializers.CharField(required=False, source="theme.name")
     description = serializers.CharField(required=False, source="theme.description")
     key = serializers.CharField(required=False, source="theme.key")
     assigned_by = serializers.SerializerMethodField()
 
     def to_internal_value(self, data):
-        pk = super().to_internal_value(data)["id"]
+        pk = super().to_internal_value(data)["theme"]["id"]
         try:
             return Theme.objects.get(pk=pk)
         except Theme.DoesNotExist:


### PR DESCRIPTION
## Context

This is a bug fix - we the response payload should be populated with the theme_id not the ephemeral association id

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo