### PR TITLE
feature/add-id-to-MultiChoiceAnswerCount

### DIFF
--- a/consultation_analyser/consultations/api/serializers.py
+++ b/consultation_analyser/consultations/api/serializers.py
@@ -131,7 +131,8 @@ class CrossCuttingThemeSerializer(serializers.ModelSerializer):
 
 
 class MultiChoiceAnswerCount(serializers.Serializer):
-    answer = serializers.CharField(source="chosen_options__text")
+    id = serializers.UUIDField(source="chosen_options__id")
+    text = serializers.CharField(source="chosen_options__text")
     response_count = serializers.IntegerField()
 
 

--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -123,9 +123,9 @@ class QuestionViewSet(ReadOnlyModelViewSet):
     )
     def multi_choice_response_count(self, request, pk=None, consultation_pk=None):
         question = self.get_object()
-        answer_count = question.response_set.values("chosen_options__text").annotate(
-            response_count=Count("id")
-        )
+        answer_count = question.response_set.values(
+            "chosen_options__id", "chosen_options__text"
+        ).annotate(response_count=Count("id"))
         serializer = self.get_serializer(instance=answer_count, many=True)
         return JsonResponse(data=serializer.data, safe=False)
 

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -1212,11 +1212,11 @@ def test_multi_choice_answer_count(
     response = client.get(url)
     assert response.status_code == 200
 
-    def sort_by_answer(payload):
-        return sorted(payload, key=lambda x: x["answer"])
-
-    expected = [{"answer": "blue", "response_count": 1}, {"answer": "red", "response_count": 2}]
-    assert sort_by_answer(response.json()) == sort_by_answer(expected)
+    for text, response_count in ("blue", 1), ("red", 2):
+        assert (
+            next(x["response_count"] for x in response.json() if x["text"] == text)
+            == response_count
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context

As a frontend engineer I need the multichoice-answer-id to be included in the `api/consultations/<id>/questions/<id>/multi-choice-response-count`

## Changes proposed in this pull request

1. the `id` has been added
2. `answer` has been renamed `text` for consistency with `api/consultations/<id>/questions/<id>`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo