### PR TITLE
feature/response-annoation-is_edited

### DIFF
--- a/consultation_analyser/consultations/api/serializers.py
+++ b/consultation_analyser/consultations/api/serializers.py
@@ -169,6 +169,7 @@ class ResponseSerializer(serializers.ModelSerializer):
     sentiment = serializers.CharField(source="annotation.sentiment")
     human_reviewed = serializers.BooleanField(source="annotation.human_reviewed")
     is_flagged = serializers.BooleanField(read_only=True)
+    is_edited = serializers.BooleanField(source="annotation.is_edited")
 
     def get_demographic_data(self, obj) -> dict[str, Any] | None:
         return {d.field_name: d.field_value for d in obj.respondent.demographics.all()}
@@ -213,4 +214,5 @@ class ResponseSerializer(serializers.ModelSerializer):
             "sentiment",
             "human_reviewed",
             "is_flagged",
+            "is_edited",
         ]

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -315,6 +315,18 @@ class ResponseAnnotation(UUIDPrimaryKeyModel, TimeStampedModel):
     # History tracking
     history = HistoricalRecords()
 
+    @property
+    def is_edited(self) -> bool:
+        """has this annotation ever been changed?"""
+        if self.history.count() > 1:
+            return True
+
+        # have associated themes every changed?
+        return ResponseAnnotationTheme.history.filter(
+            response_annotation=self,
+            assigned_by__isnull=False,
+        ).exists()
+
     class Meta(UUIDPrimaryKeyModel.Meta, TimeStampedModel.Meta):
         indexes = [
             models.Index(fields=["human_reviewed"]),


### PR DESCRIPTION
## Context

As a FrontEnd Engineer I want `is_edited` to be added to the response serializer so that I can inform the User if the response has been changed in anyway

## Changes proposed in this pull request

The Django-Simple-History table for `ResponseAnnotation` and `ResponseAnnotationTheme` are queried to see if a history of relevant changes exist.

## Guidance to review

Do the tests make sense?

## Link to Trello ticket

https://trello.com/c/pYjKopOV/508-edit-themes-and-evidence-rich

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo