### PR TITLE
bugfix/import_response_annotations-evidence_rich=null

### DIFF
--- a/consultation_analyser/support_console/file_models.py
+++ b/consultation_analyser/support_console/file_models.py
@@ -1,0 +1,45 @@
+from typing import Literal, Any
+
+from pydantic import BaseModel, computed_field, field_validator
+
+from consultation_analyser.consultations.models import ResponseAnnotation
+
+
+def read_from_s3(model, client, bucket: str, key: str):
+    s3_obj = client.get_object(Bucket=bucket, Key=key)
+    for line in s3_obj["Body"].iter_lines():
+        yield model.model_validate_json(line.decode("utf-8"))
+
+
+class DetailDetection(BaseModel):
+    themefinder_id: int
+    evidence_rich: Literal["YES", "NO"] = "NO"
+
+    @field_validator("evidence_rich", mode="before")
+    def coerce_null_evidence_rich(cls, v):
+        return "NO" if v is None else v
+
+    @computed_field # type:ignore
+    @property
+    def evidence_rich_bool(self) -> bool:
+        return self.evidence_rich == "YES"
+
+
+class SentimentRecord(BaseModel):
+    themefinder_id: int
+    sentiment: Literal["AGREEMENT", "DISAGREEMENT", "UNCLEAR"] = "UNCLEAR"
+
+    @field_validator("sentiment", mode="before")
+    def coerce_null_sentiment(cls, v):
+        return "UNCLEAR" if v is None else v
+
+    @computed_field  # type:ignore
+    @property
+    def sentiment_enum(self) -> Any:
+        match self.sentiment:
+            case "AGREEMENT":
+                return ResponseAnnotation.Sentiment.AGREEMENT # type:ignore
+            case "DISAGREEMENT":
+                return ResponseAnnotation.Sentiment.DISAGREEMENT# type:ignore
+            case _:
+                return ResponseAnnotation.Sentiment.UNCLEAR# type:ignore

--- a/consultation_analyser/support_console/file_models.py
+++ b/consultation_analyser/support_console/file_models.py
@@ -1,4 +1,4 @@
-from typing import Literal, Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, computed_field, field_validator
 
@@ -19,7 +19,7 @@ class DetailDetection(BaseModel):
     def coerce_null_evidence_rich(cls, v):
         return "NO" if v is None else v
 
-    @computed_field # type:ignore
+    @computed_field  # type:ignore
     @property
     def evidence_rich_bool(self) -> bool:
         return self.evidence_rich == "YES"
@@ -38,8 +38,8 @@ class SentimentRecord(BaseModel):
     def sentiment_enum(self) -> Any:
         match self.sentiment:
             case "AGREEMENT":
-                return ResponseAnnotation.Sentiment.AGREEMENT # type:ignore
+                return ResponseAnnotation.Sentiment.AGREEMENT  # type:ignore
             case "DISAGREEMENT":
-                return ResponseAnnotation.Sentiment.DISAGREEMENT# type:ignore
+                return ResponseAnnotation.Sentiment.DISAGREEMENT  # type:ignore
             case _:
-                return ResponseAnnotation.Sentiment.UNCLEAR# type:ignore
+                return ResponseAnnotation.Sentiment.UNCLEAR  # type:ignore

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -336,7 +336,7 @@ def import_response_annotations(question: Question, output_folder: str):
     evidence_dict = {}
     for line in evidence_response["Body"].iter_lines():
         evidence: DetailDetection = DetailDetection.model_validate_json(line.decode("utf-8"))
-        evidence_dict[evidence.themefinder_id] = evidence.evidence_rich
+        evidence_dict[evidence.themefinder_id] = evidence.evidence_rich == "YES"
 
     # Create annotations
     responses = Response.objects.filter(question=question).values_list(

--- a/tests/unit/support_console/test_file_models.py
+++ b/tests/unit/support_console/test_file_models.py
@@ -1,0 +1,72 @@
+import pytest
+
+from consultation_analyser.consultations.models import ResponseAnnotation
+from consultation_analyser.support_console.file_models import DetailDetection, SentimentRecord
+
+
+@pytest.mark.parametrize(
+    ("raw_json", "expected_output"),
+    [
+        (
+            '{"themefinder_id":1,"evidence_rich":"NO"}',
+            {"themefinder_id": 1, "evidence_rich": "NO", "evidence_rich_bool": False},
+        ),
+        (
+            '{"themefinder_id":2,"evidence_rich":"YES"}',
+            {"themefinder_id": 2, "evidence_rich": "YES", "evidence_rich_bool": True},
+        ),
+        (
+            '{"themefinder_id":3,"evidence_rich":null}',
+            {
+                "themefinder_id": 3,
+                "evidence_rich": "NO",
+                "evidence_rich_bool": False,
+            },
+        ),
+    ],
+)
+def test_DetailDetection(raw_json, expected_output):
+    obj = DetailDetection.model_validate_json(raw_json)
+    assert obj.model_dump() == expected_output
+
+
+@pytest.mark.parametrize(
+    ("raw_json", "expected_output"),
+    [
+        (
+            '{"themefinder_id":1,"sentiment":"AGREEMENT"}',
+            {
+                "themefinder_id": 1,
+                "sentiment": "AGREEMENT",
+                "sentiment_enum": ResponseAnnotation.Sentiment.AGREEMENT,
+            },
+        ),
+        (
+            '{"themefinder_id":2,"sentiment":"DISAGREEMENT"}',
+            {
+                "themefinder_id": 2,
+                "sentiment": "DISAGREEMENT",
+                "sentiment_enum": ResponseAnnotation.Sentiment.DISAGREEMENT,
+            },
+        ),
+        (
+            '{"themefinder_id":3,"sentiment":"UNCLEAR"}',
+            {
+                "themefinder_id": 3,
+                "sentiment": "UNCLEAR",
+                "sentiment_enum": ResponseAnnotation.Sentiment.UNCLEAR,
+            },
+        ),
+        (
+            '{"themefinder_id":4,"sentiment":null}',
+            {
+                "themefinder_id": 4,
+                "sentiment": "UNCLEAR",
+                "sentiment_enum": ResponseAnnotation.Sentiment.UNCLEAR,
+            },
+        ),
+    ],
+)
+def test_SentimentRecord(raw_json, expected_output):
+    obj = SentimentRecord.model_validate_json(raw_json)
+    assert obj.model_dump() == expected_output


### PR DESCRIPTION
## Context

This fixes the problem associated with records like: `{"themefinder_id":5970,"evidence_rich":null}`. Previously we were getting errors like: 

```
File "/usr/src/app/consultation_analyser/support_console/ingest.py", line 328, in import_response_annotations
    evidence_value = evidence.get("evidence_rich", "NO").upper() == "YES"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
```

## Changes proposed in this pull request

I have taken the opportunity to tighten up the file ingest logic by by using pydantic to validate the data. I have also included more testing

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo