### PR TITLE
Enable Edit Panel

### DIFF
--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -72,6 +72,7 @@ class ConsultationViewSet(ReadOnlyModelViewSet):
 
         data = (
             models.Respondent.objects.filter(consultation_id=pk)
+            .order_by("demographics__field_name", "demographics__field_value")
             .values("demographics__field_name", "demographics__field_value")
             .annotate(count=Count("id"))
         )

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -318,10 +318,10 @@ class ResponseAnnotation(UUIDPrimaryKeyModel, TimeStampedModel):
     @property
     def is_edited(self) -> bool:
         """has this annotation ever been changed?"""
-        if self.history.count() > 1:
+        if self.history.exists():
             return True
 
-        # have associated themes every changed?
+        # have associated themes ever been changed by a human?
         return ResponseAnnotationTheme.history.filter(
             response_annotation=self,
             assigned_by__isnull=False,

--- a/frontend/src/components/dashboard/AnswerCard/AnswerCard.svelte
+++ b/frontend/src/components/dashboard/AnswerCard/AnswerCard.svelte
@@ -132,8 +132,7 @@
                         {isFlagged}
                     />
 
-                    <!-- Disabled temporarily -->
-                    <!-- <EditPanel
+                    <EditPanel
                         {consultationId}
                         {questionId}
                         {answerId}
@@ -142,7 +141,7 @@
                         {evidenceRich}
                         {resetData}
                         setEditing={(val: boolean) => editing = val}
-                    /> -->
+                    />
                 {/if}
 
                 <small

--- a/frontend/src/components/dashboard/EditPanel/EditPanel.svelte
+++ b/frontend/src/components/dashboard/EditPanel/EditPanel.svelte
@@ -50,6 +50,7 @@
         if (noChangesStaged()) {
             return;
         }
+
         await actualUpdateAnswer(getApiAnswerUrl(consultationId, questionId, answerId), "PATCH", {
             "themes": stagedThemes.map(theme => ({id: theme.id})),
             "evidenceRich": stagedEvidenceRich,
@@ -85,7 +86,7 @@
         evidenceRich = false,
         resetData = () => {},
         setEditing = () => {},
-        updateAnswerMock = async () => {},
+        updateAnswerMock,
     }: Props = $props();
 
     let stagedThemes: ResponseTheme[] = $state([]);

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -769,7 +769,7 @@ class TestFilteredResponsesAPIView:
         assert response.status_code == 200
         data = response.json()
         assert data["is_flagged"] == is_flagged
-        assert data["is_edited"] == is_flagged
+        assert data["is_edited"] is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
This PR re-enables the edit panel button on question detail page responses.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo