### PR TITLE
Feature/dont-throw-error-if-file-doesnt-exist

### DIFF
--- a/consultation_analyser/support_console/file_models.py
+++ b/consultation_analyser/support_console/file_models.py
@@ -1,17 +1,25 @@
 from typing import Any, Literal
 
 from botocore.exceptions import ClientError
+from django.conf import settings
 from pydantic import BaseModel, computed_field, field_validator
 
 from consultation_analyser.consultations.models import ResponseAnnotation
 
-def read_from_s3(model, client, bucket: str, key: str, raise_error_if_file_missing: bool=False):
+logger = settings.LOGGER
+
+
+def read_from_s3(model, client, bucket: str, key: str, raise_error_if_file_missing: bool = True):
     try:
         s3_obj = client.get_object(Bucket=bucket, Key=key)
     except ClientError:
-        if raise_error_if_file_missing is True:
-            raise StopIteration
-        raise
+        if raise_error_if_file_missing is False:
+            return  # early return as no data found
+
+        logger.error("file not found, bucket={bucket}, key={key}", bucket=bucket, key=key)
+        msg = f"file not found {bucket}/{key}"
+        raise ValueError(msg)
+
     for line in s3_obj["Body"].iter_lines():
         yield model.model_validate_json(line.decode("utf-8"))
 

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -291,13 +291,21 @@ def import_response_annotations(question: Question, output_folder: str):
     # Check if sentiment file exists and process it
     sentiment_dict = {}
     for sentiment in read_from_s3(
-        SentimentRecord, s3_client, settings.AWS_BUCKET_NAME, sentiment_file_key
+        SentimentRecord,
+        s3_client,
+        settings.AWS_BUCKET_NAME,
+        sentiment_file_key,
+        raise_error_if_file_missing=False,
     ):
         sentiment_dict[sentiment.themefinder_id] = sentiment.sentiment_enum
 
     evidence_dict = {}
     for evidence in read_from_s3(
-        DetailDetection, s3_client, settings.AWS_BUCKET_NAME, evidence_file_key
+        DetailDetection,
+        s3_client,
+        settings.AWS_BUCKET_NAME,
+        evidence_file_key,
+        raise_error_if_file_missing=False,
     ):
         evidence_dict[evidence.themefinder_id] = evidence.evidence_rich_bool
 

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from consultation_analyser.consultations.models import (
     Consultation,
@@ -11,6 +12,7 @@ from consultation_analyser.consultations.models import (
     ResponseAnnotation,
     Theme,
 )
+from consultation_analyser.support_console.file_models import SentimentRecord, read_from_s3
 from consultation_analyser.support_console.ingest import (
     create_consultation,
     get_consultation_codes,
@@ -70,6 +72,37 @@ def get_object_side_effect(Bucket, Key):
         return {"Body": Mock(iter_lines=Mock(return_value=evidence_data.split(b"\n")))}
     else:
         return None
+
+
+def test_read_from_s3_file_missing_raises_error():
+    mock_boto3 = Mock()
+    mock_boto3.get_object.side_effect = ClientError(
+        error_response={"Error": {"Code": "NoSuchKey"}}, operation_name="GetObject"
+    )
+    with pytest.raises(ValueError) as e:
+        list(
+            read_from_s3(
+                SentimentRecord,
+                mock_boto3,
+                "my-bucket",
+                "my-file",
+                raise_error_if_file_missing=True,
+            )
+        )
+    assert e.value.args[0] == "file not found my-bucket/my-file"
+
+
+def test_read_from_s3_file_missing_returns_empty():
+    mock_boto3 = Mock()
+    mock_boto3.get_object.side_effect = ClientError(
+        error_response={"Error": {"Code": "NoSuchKey"}}, operation_name="GetObject"
+    )
+    result = list(
+        read_from_s3(
+            SentimentRecord, mock_boto3, "my-bucket", "my-file", raise_error_if_file_missing=False
+        )
+    )
+    assert result == []
 
 
 class TestGetQuestionFolders:


### PR DESCRIPTION
## Context

As a User I want the ingest not to fail if certain files dont exist

Previously if the `sentiment.jsonl` or `detail_detection.jsonl` were missing this would cause the annotation ingest to fail

## Changes proposed in this pull request

`read_from_s3` now has a new optional arg `raise_error_if_file_missing=True` which, if false, will yield an  empty list instead of raising an error

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo