### PR TITLE
feature/redirect-un-authenticated-users-to-sign-in

### DIFF
--- a/consultation_analyser/middleware.py
+++ b/consultation_analyser/middleware.py
@@ -1,5 +1,6 @@
-from django.contrib.auth.middleware import LoginRequiredMiddleware
+from django.conf import settings
 from django.http import Http404
+from django.shortcuts import redirect
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 
@@ -37,20 +38,16 @@ class SupportAppStaffRequiredMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        response = self.get_response(request)
         if request.path.startswith("/support/"):
+            if not request.user.is_authenticated:
+                return redirect(settings.SIGNIN_URL)
+
             # Must already be logged in from login required middleware.
             # Sign-out is excepted as we don't want to 404 on sign-out.
             if (not request.user.is_staff) and (not request.path.startswith("/support/sign-out/")):
                 raise Http404
+        response = self.get_response(request)
         return response
-
-
-class LoginRequiredMiddleware404(LoginRequiredMiddleware):
-    """Require login, 404 if no access."""
-
-    def handle_no_permission(self, request, view_func):
-        raise Http404
 
 
 class CSRFExemptMiddleware:

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -80,7 +80,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "waffle.middleware.WaffleMiddleware",
-    "consultation_analyser.middleware.LoginRequiredMiddleware404",
     "consultation_analyser.middleware.SupportAppStaffRequiredMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
 ]
@@ -122,6 +121,7 @@ AUTH_USER_MODEL = "authentication.User"
 CSRF_TRUSTED_ORIGINS = [
     "http://localhost:3000",
     "https://consult.ai.cabinetoffice.gov.uk",
+    "https://consult-preprod.ai.cabinetoffice.gov.uk",
     "https://consult-dev.ai.cabinetoffice.gov.uk",
 ]
 

--- a/consultation_analyser/settings/local.py
+++ b/consultation_analyser/settings/local.py
@@ -11,3 +11,5 @@ STORAGES["default"] = {  # noqa
         "location": BASE_DIR / "tmp"  # noqa
     },
 }
+
+SIGNIN_URL = "http://" + DOMAIN_NAME + ":3000" + LOGIN_URL  # noqa: F405

--- a/consultation_analyser/settings/production.py
+++ b/consultation_analyser/settings/production.py
@@ -84,3 +84,5 @@ LOGGER = StructuredLogger(
         "log_format": LogOutputFormat.JSON,
     },
 )
+
+SIGNIN_URL = "https://" + DOMAIN_NAME + LOGIN_URL  # noqa: F405

--- a/consultation_analyser/settings/test.py
+++ b/consultation_analyser/settings/test.py
@@ -21,3 +21,5 @@ for queueConfig in RQ_QUEUES.values():  # noqa
 
 # Use memory email backend for tests
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+SIGNIN_URL = "http://" + DOMAIN_NAME + LOGIN_URL  # noqa: F405

--- a/tests/integration/test_navigation.py
+++ b/tests/integration/test_navigation.py
@@ -15,15 +15,6 @@ def assert_expected_menu_items(django_app, endpoint, menu_items):
         assert menu_item in response_header
 
 
-def test_not_authenticated_navigation(django_app):
-    expected_menu_items = ["How it works", "Data sharing", "Get involved", "Sign in"]
-
-    assert_expected_menu_items(django_app, "/", expected_menu_items)
-
-    with pytest.raises(AppError):
-        assert_expected_menu_items(django_app, SUPPORT_ROUTE, expected_menu_items)
-
-
 # Non-staff user
 @pytest.mark.django_db
 def test_authenticated_navigation(django_app):

--- a/tests/request/test_support_pages.py
+++ b/tests/request/test_support_pages.py
@@ -12,4 +12,4 @@ def test_no_login_support_pages(client, consultation):
     for url in support_urls:
         full_url = f"/support/{url}"
         response = client.get(full_url)
-        assert response.status_code == 404  # No access - 404
+        assert response.status_code == 302  # No access - 404

--- a/tests/request/test_support_pages.py
+++ b/tests/request/test_support_pages.py
@@ -12,4 +12,5 @@ def test_no_login_support_pages(client, consultation):
     for url in support_urls:
         full_url = f"/support/{url}"
         response = client.get(full_url)
-        assert response.status_code == 302  # No access - 404
+        assert response.status_code == 302  # Redirect
+        assert response.url.endswith("/sign-in/")

--- a/tests/views/test_support_urls.py
+++ b/tests/views/test_support_urls.py
@@ -10,6 +10,7 @@ def test_support_url_access(client):
     # Check anonymous user
     response = client.get(url)
     assert response.status_code == 302
+    assert response.url.endswith("/sign-in/")
 
     # Check normal non-staff user can't access
     user = factories.UserFactory()

--- a/tests/views/test_support_urls.py
+++ b/tests/views/test_support_urls.py
@@ -9,7 +9,7 @@ def test_support_url_access(client):
     url = reverse("users")
     # Check anonymous user
     response = client.get(url)
-    assert response.status_code == 404
+    assert response.status_code == 302
 
     # Check normal non-staff user can't access
     user = factories.UserFactory()


### PR DESCRIPTION
## Context

As a user I want to be re-directed to the sign in page when I am logged out rather than get a 404 so that I know what action to take

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

log yourself out and attempt to add a protected page like /support/, previously you would get a 404 and now you get redirected to the sign-in page

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo