### PR TITLE
feature/git-sha-api

### DIFF
--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+from django.conf import settings
 from django.contrib.auth import login
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Exists, OuterRef
@@ -277,3 +278,8 @@ def verify_magic_link(request) -> HttpResponse:
                 "sessionId": request.session.session_key,
             }
         )
+
+
+@api_view(["GET"])
+def get_git_sha(_request) -> Response:
+    return Response({"sha": settings.GIT_SHA})

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -10,6 +10,7 @@ from .api.views import (
     ThemeViewSet,
     generate_magic_link,
     get_current_user,
+    get_git_sha,
     verify_magic_link,
 )
 from .views import answers, pages, questions, root, sessions
@@ -67,4 +68,5 @@ urlpatterns = [
     # JWT
     path("api/magic-link/", generate_magic_link, name="token-magic-link"),
     path("api/token/", verify_magic_link, name="create-token"),
+    path("git-sha/", get_git_sha, name="git-sha"),
 ]

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import orjson
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 
 from consultation_analyser.consultations.models import ResponseAnnotation, ResponseAnnotationTheme
@@ -1242,3 +1243,13 @@ def test_filter(client, consultation_user, consultation, has_free_text):
         # should return just one question
         assert len(results) == 1
         assert results[0]["has_free_text"] == has_free_text
+
+
+@pytest.mark.django_db
+@override_settings(GIT_SHA="00000000-0000-0000-0000-000000000000")
+def test_git_sha(client):
+    url = reverse("git-sha")
+
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.json() == {"sha": "00000000-0000-0000-0000-000000000000"}

--- a/tests/views/test_login_required.py
+++ b/tests/views/test_login_required.py
@@ -5,13 +5,7 @@ from consultation_analyser import factories
 from consultation_analyser.consultations.urls import urlpatterns
 from tests.utils import build_url
 
-PUBLIC_URL_NAMES = [
-    "root",
-    "how_it_works",
-    "data_sharing",
-    "get_involved",
-    "privacy",
-]
+PUBLIC_URL_NAMES = ["root", "how_it_works", "data_sharing", "get_involved", "privacy", "git-sha"]
 AUTHENTICATION_URL_NAMES = [
     "sign_in",
     "sign_out",


### PR DESCRIPTION
## Context

As a frontend engineer i want the git sha to be made available on an endpoint so that I can display it on the frontend so that a user can see which version they are looking at

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo