### PR TITLE
bugfix/delete-consultations

### DIFF
--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -37,8 +37,10 @@ def import_consultation_job(
 
 
 def delete_question_related_table(table: str, consultation_id: UUID):
+    logger.info("Deleting records from table={table}", table=table)
+
     with connection.cursor() as cursor:
-        sql = f"""  
+        sql = f"""
         DELETE FROM {table}
         WHERE question_id IN (
             SELECT id FROM consultations_question
@@ -51,7 +53,7 @@ def delete_response_related_table(table: str, consultation_id: UUID):
     logger.info("Deleting records from table={table}", table=table)
 
     with connection.cursor() as cursor:
-        sql = f"""  
+        sql = f"""
         DELETE FROM {table}
         WHERE response_id IN (
             SELECT r.id from consultations_response r
@@ -61,10 +63,10 @@ def delete_response_related_table(table: str, consultation_id: UUID):
         cursor.execute(sql, [consultation_id])
 
 
-
 def delete_consultation_related_table(table: str, consultation_id: UUID):
     """Delete records from a table that directly references consultation_id"""
     logger.info("Deleting records from table={table}", table=table)
+
     with connection.cursor() as cursor:
         cursor.execute(
             f"DELETE FROM {table} WHERE consultation_id = %s",  # nosec B608
@@ -75,8 +77,9 @@ def delete_consultation_related_table(table: str, consultation_id: UUID):
 def delete_respondent_related_table(table: str, consultation_id: UUID):
     """Delete records from a table that references respondent_id"""
     logger.info("Deleting records from table={table}", table=table)
+
     with connection.cursor() as cursor:
-        sql = f"""  
+        sql = f"""
         DELETE FROM {table}
         WHERE respondent_id IN (
             SELECT id FROM consultations_respondent

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -80,6 +80,19 @@ def delete_consultation_job(consultation: models.Consultation):
                 [consultation_id],
             )
 
+        logger.info("Deleting response chosen_options...")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+            DELETE FROM consultations_response_chosen_options
+            WHERE response_id IN (
+                SELECT r.id from consultations_response r
+                JOIN consultations_question q ON r.question_id = q.id
+                WHERE q.consultation_id = %s
+            )""",
+                [consultation_id],
+            )
+
         logger.info("Deleting responses...")
         while True:
             with connection.cursor() as cursor:
@@ -120,6 +133,18 @@ def delete_consultation_job(consultation: models.Consultation):
                 DELETE FROM consultations_question
                 WHERE consultation_id = %s
             """,
+                [consultation_id],
+            )
+
+        logger.info("Deleting respondent_demographics...")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                DELETE FROM consultations_respondent_demographics
+                WHERE respondent_id IN (
+                    SELECT id FROM consultations_respondent
+                    WHERE consultation_id = %s
+                )""",
                 [consultation_id],
             )
 


### PR DESCRIPTION
## Context

The deletion code was failing for multi choice consultations

Specifically, the `delete_consultation_job` function was failing with a foreign key constraint violation when deleting consultations that contain multiple choice questions. The function was attempting to delete Question records before deleting the MultiChoiceAnswer records that reference them, causing PostgreSQL to reject the operation.

Errors:
```
django.db.utils.IntegrityError: update or delete on table "consultations_respondent" violates foreign key constraint "consultations_respon_respondent_id_b9e95c3d_fk_consultat" on table "consultations_respondent_demographics"
DETAIL:  Key (id)=(346ee92c-bcc2-4ade-aa5d-e542e0edd626) is still referenced from table "consultations_respondent_demographics".
```
```
django.db.utils.IntegrityError: update or delete on table "consultations_response" violates foreign key constraint "consultations_respon_response_id_e79e4a55_fk_consultat" on table "consultations_response_chosen_options"
DETAIL:  Key (id)=(957f96c3-b8a0-4d44-b2be-2ff0ce6de7b5) is still referenced from table "consultations_response_chosen_options".
```



## Changes proposed in this pull request

  1. Fixed Deletion Order

  - Before: Questions were deleted before MultiChoiceAnswers
  - After: MultiChoiceAnswers are deleted before Questions

  The correct deletion order is now:
  1. Response annotation themes
  2. Response annotations
  3. Response chosen options
  4. Responses (in batches)
  5. Themes
  6. MultiChoiceAnswers ← Fixed: moved before questions
  7. Questions ← Fixed: moved after MultiChoiceAnswers
  8. Respondent demographics
  9. Respondents
  10. Consultation

  2. Function Refactoring

  Extracted repetitive SQL deletion patterns into reusable helper functions:

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo