### PR TITLE
feature/dont-duplicate-embeddings

### DIFF
--- a/consultation_analyser/consultations/admin.py
+++ b/consultation_analyser/consultations/admin.py
@@ -16,14 +16,18 @@ from consultation_analyser.consultations.models import (
     ResponseAnnotationTheme,
     Theme,
 )
-from consultation_analyser.support_console.ingest import DEFAULT_TIMEOUT_SECONDS, create_embeddings
+from consultation_analyser.support_console.ingest import (
+    DEFAULT_TIMEOUT_SECONDS,
+    create_embeddings_for_question,
+)
 
 
 @admin.action(description="(Re)Embed selected Consultations")
 def update_embeddings_admin(modeladmin, request, queryset):
     queue = get_queue(default_timeout=DEFAULT_TIMEOUT_SECONDS)
     for consultation in queryset:
-        queue.enqueue(create_embeddings, consultation.id)
+        for question in consultation.question_set.all():
+            queue.enqueue(create_embeddings_for_question, question.id)
 
     modeladmin.message_user(request, f"Processing {queryset.count()} consultations")
 

--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -220,10 +220,8 @@ def validate_consultation_structure(
     return is_valid, errors
 
 
-def create_embeddings(consultation_id: UUID):
-    queryset = Response.objects.filter(
-        question__consultation_id=consultation_id, free_text__isnull=False
-    )
+def create_embeddings_for_question(question_id: UUID):
+    queryset = Response.objects.filter(question_id=question_id, free_text__isnull=False)
     total = queryset.count()
     batch_size = 1_000
 
@@ -572,7 +570,7 @@ def import_questions(
             responses = queue.enqueue(
                 import_responses, question, responses_file_key, multiple_choice_file
             )
-            queue.enqueue(create_embeddings, question.consultation.id, depends_on=responses)
+            queue.enqueue(create_embeddings_for_question, question.id, depends_on=responses)
 
             if s3_key_exists(multiple_choice_file) and not s3_key_exists(responses_file_key):
                 logger.info("not importing output-mappings")


### PR DESCRIPTION
## Context

Previously we were embedding all embeddings in the consultation for every response, this change ensures that we only embed the responses for a given question.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo