### PR TITLE
bugfix/stop-creating-duplicate-themes

### DIFF
--- a/consultation_analyser/support_console/ingest.py
+++ b/consultation_analyser/support_console/ingest.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 from django.contrib.postgres.search import SearchVector
 from django_rq import get_queue
+from simple_history.utils import bulk_create_with_history
 
 from consultation_analyser.consultations.models import (
     Consultation,
@@ -271,7 +272,9 @@ def import_response_annotation_themes(question: Question, output_folder: str):
                 )
             )
             if len(objects_to_save) >= DEFAULT_BATCH_SIZE:
-                ResponseAnnotationTheme.objects.bulk_create(objects_to_save, ignore_conflicts=True)
+                bulk_create_with_history(
+                    objects_to_save, ResponseAnnotationTheme, ignore_conflicts=True
+                )
                 objects_to_save = []
                 logger.info(
                     "saved {i} ResponseAnnotationTheme for question {question_number}",
@@ -279,7 +282,7 @@ def import_response_annotation_themes(question: Question, output_folder: str):
                     question_number=question.number,
                 )
 
-    ResponseAnnotationTheme.objects.bulk_create(objects_to_save, ignore_conflicts=True)
+    bulk_create_with_history(objects_to_save, ResponseAnnotationTheme, ignore_conflicts=True)
 
 
 def import_response_annotations(question: Question, output_folder: str):
@@ -325,7 +328,7 @@ def import_response_annotations(question: Question, output_folder: str):
         )
         annotations_to_save.append(annotation)
         if len(annotations_to_save) >= DEFAULT_BATCH_SIZE:
-            ResponseAnnotation.objects.bulk_create(annotations_to_save)
+            bulk_create_with_history(annotations_to_save, ResponseAnnotation)
             annotations_to_save = []
             logger.info(
                 "saved {i} ResponseAnnotations for question {question_number}",
@@ -333,7 +336,7 @@ def import_response_annotations(question: Question, output_folder: str):
                 question_number=question.number,
             )
 
-    ResponseAnnotation.objects.bulk_create(annotations_to_save)
+    bulk_create_with_history(annotations_to_save, ResponseAnnotation)
 
 
 def read_response_file(responses_file_key: str) -> dict[str, str]:

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -296,6 +296,9 @@ class TestImportConsultationFullFlow:
         )
         assert annotations.count() == 3
 
+        for annotation in annotations:
+            assert annotation.history.count() == 1
+
 
 @pytest.mark.django_db
 class TestRespondentsImport:


### PR DESCRIPTION
## Context

We use:
* django bulk_create to speed up the ingest 
* django-simple-history to store a history of changes

However these packages conflict https://django-simple-history.readthedocs.io/en/latest/common_issues.html 


## Changes proposed in this pull request

We have switched from  `bulk_create` to `bulk_create_with_history` for the models with history:
* `ResponseAnnotation`
* `ResponseAnnotationTheme`



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo