### PR TITLE
Fix Path Join and Remove Duplicate Skip Srray

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,3 +1,5 @@
+import path from "path";
+
 import type { MiddlewareHandler } from "astro";
 import { getBackendUrl } from "./global/utils";
 
@@ -22,7 +24,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   }
 
   const backendUrl = getBackendUrl(url.hostname);
-  const fullBackendUrl = backendUrl + url.pathname + url.search;
+  const fullBackendUrl = path.join(backendUrl, url.pathname) + url.search;
 
   // skip as new pages are moved to astro
   const toSkip = [
@@ -75,29 +77,6 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
 
     // Create headers object properly
     const headersToSend = new Headers();
-
-    // skip as new pages are moved to astro
-    const toSkip = [
-      /^\/$/,
-      /^\/sign-in[\/]?$/,
-      /^\/sign-out[\/]?$/,
-      /^\/magic-link\/[A-Za-z0-9\-]*[\/]?$/,
-      /^\/api\/astro\/.*/,
-      /^\/api\/health[\/]?$/,
-      /^\/health[\/]?$/,
-      /^\/.well-known\/.*/,
-      /^\/consultations.*/,
-      // /^\/evaluations.*/,
-      /^\/design.*/,
-      /^\/stories.*/,
-      /^\/_astro.*/,
-    ];
-
-    for (const skipPattern of toSkip) {
-      if (skipPattern.test(context.url.pathname)) {
-        return next();
-      }
-    }
 
     // Copy all original headers
     for (const [key, value] of context.request.headers.entries()) {


### PR DESCRIPTION
## Context
In the Astro middleware, path is formed by concatenating strings, requiring a specific env setup. Also toSkip array is duplicated in two places.

## Changes proposed in this pull request
This PR uses path.join to form the url so forward slashes are handled properly. Also removes the unnecessary toSkip array.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo