### PR TITLE
feature/move-respondent-filter-to-responses

### DIFF
--- a/consultation_analyser/consultations/api/filters.py
+++ b/consultation_analyser/consultations/api/filters.py
@@ -6,7 +6,7 @@ from django_filters.rest_framework import BaseInFilter, BooleanFilter, CharFilte
 from pgvector.django import CosineDistance
 from rest_framework.filters import SearchFilter
 
-from consultation_analyser.consultations.models import Question, Response
+from consultation_analyser.consultations.models import Response
 from consultation_analyser.embeddings import embed_text
 
 
@@ -21,17 +21,6 @@ def safe_json_encode(txt: str):
             return txt
 
 
-class QuestionFilter(FilterSet):
-    # has_free_text = CharFilter()
-    respondent_id = UUIDFilter(field_name="response__respondent_id")
-
-    class Meta:
-        model = Question
-        fields = [
-            "has_free_text",
-        ]
-
-
 class ResponseFilter(FilterSet):
     # TODO: adjust the frontend to match sensible DRF defaults
     sentimentFilters = BaseInFilter(field_name="annotation__sentiment", lookup_expr="in")
@@ -40,6 +29,7 @@ class ResponseFilter(FilterSet):
     demoFilters = CharFilter(method="filter_demographics")
     is_flagged = BooleanFilter()
     multiple_choice_answer = BaseInFilter(field_name="chosen_options", lookup_expr="in")
+    respondent_id = UUIDFilter()
 
     def filter_themes(self, queryset, name, value):
         if not value:

--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -18,7 +18,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 
 from .. import models
 from ..views.sessions import send_magic_link_if_email_exists
-from .filters import HybridSearchFilter, QuestionFilter, ResponseFilter
+from .filters import HybridSearchFilter, ResponseFilter
 from .permissions import CanSeeConsultation, HasDashboardAccess
 from .serializers import (
     ConsultationSerializer,
@@ -111,7 +111,7 @@ class RespondentViewSet(ModelViewSet):
 class QuestionViewSet(ReadOnlyModelViewSet):
     serializer_class = QuestionSerializer
     permission_classes = [HasDashboardAccess, CanSeeConsultation]
-    filterset_class = QuestionFilter
+    filterset_fields = ["has_free_text"]
 
     def get_queryset(self):
         consultation_uuid = self.kwargs["consultation_pk"]

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -1249,27 +1249,27 @@ def test_filter(client, consultation_user, consultation, has_free_text):
 
 
 @pytest.mark.django_db
-def test_get_question_filtered_by_respondent(
+def test_get_responses_filtered_by_respondent(
     client,
     consultation,
     free_text_question,
-    multi_choice_question,
     respondent_1,
     respondent_2,
     consultation_user_token,
 ):
     """
-    Given two questions with two different responses by two different respondents
+    Given two responses by two different respondents
     when I query by one of the respondent_ids
-    I expect only the question that they have responded to, to be returned
+    I expect only the relevant responses to be returned
     """
-    ResponseFactory(respondent=respondent_1, question=free_text_question)
-    ResponseFactory(respondent=respondent_2, question=multi_choice_question)
+    response_1 = ResponseFactory(respondent=respondent_1, question=free_text_question)
+    _response_2 = ResponseFactory(respondent=respondent_2, question=free_text_question)
 
     url = reverse(
-        "question-list",
+        "response-list",
         kwargs={
             "consultation_pk": consultation.id,
+            "question_pk": free_text_question.id,
         },
     )
 
@@ -1281,8 +1281,10 @@ def test_get_question_filtered_by_respondent(
     )
 
     assert response.status_code == 200, response.json()
-    assert response.json()["count"] == 1
-    assert response.json()["results"][0]["id"] == str(free_text_question.id)
+    assert response.json()["respondents_total"] == 2
+    assert response.json()["filtered_total"] == 1
+    assert response.json()["all_respondents"][0]["id"] == str(response_1.id)
+    assert response.json()["all_respondents"][0]["respondent_id"] == str(respondent_1.id)
 
 
 @override_settings(GIT_SHA="00000000-0000-0000-0000-000000000000")


### PR DESCRIPTION
## Context

Responses filtered by respondent should live on the response endpoint not questions!

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo