### PR TITLE
Fix filters

### DIFF
--- a/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
+++ b/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
@@ -23,7 +23,7 @@
   import Alert from "../../Alert.svelte";
   import FilterAlt from "../../svg/material/FilterAlt.svelte";
 
-  import { themeFilters, demoFilters } from "../../../global/state.svelte.ts";
+  import { themeFilters, demoFilters, multiAnswerFilters } from "../../../global/state.svelte.ts";
   import NotFoundMessage from "../../NotFoundMessage/NotFoundMessage.svelte";
   import MultiChoice from "../MultiChoice/MultiChoice.svelte";
   import CsvDownload from "../../CsvDownload/CsvDownload.svelte";
@@ -127,7 +127,7 @@
             </div>
           </TitleRow>
 
-          {#if demoFilters.applied() || themeFilters.applied() || evidenceRich || searchValue}
+          {#if demoFilters.applied() || themeFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue}
             <div transition:fly={{ x: 300 }} class="my-4">
               <Alert>
                 <FilterAlt slot="icon" />

--- a/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
+++ b/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
@@ -23,7 +23,11 @@
   import Alert from "../../Alert.svelte";
   import FilterAlt from "../../svg/material/FilterAlt.svelte";
 
-  import { themeFilters, demoFilters, multiAnswerFilters } from "../../../global/state.svelte.ts";
+  import {
+    themeFilters,
+    demoFilters,
+    multiAnswerFilters,
+  } from "../../../global/state.svelte.ts";
   import NotFoundMessage from "../../NotFoundMessage/NotFoundMessage.svelte";
   import MultiChoice from "../MultiChoice/MultiChoice.svelte";
   import CsvDownload from "../../CsvDownload/CsvDownload.svelte";

--- a/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
+++ b/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
@@ -46,6 +46,7 @@
     searchValue: string;
     evidenceRich: boolean;
     setActiveTab: (newTab: TabNames) => void;
+    anyFilterApplied: boolean;
   }
   let {
     themesLoading = true,
@@ -60,6 +61,7 @@
     evidenceRich = false,
     sortAscending = true,
     setActiveTab = () => {},
+    anyFilterApplied = false,
   }: Props = $props();
 </script>
 
@@ -131,7 +133,7 @@
             </div>
           </TitleRow>
 
-          {#if demoFilters.applied() || themeFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue}
+          {#if anyFilterApplied}
             <div transition:fly={{ x: 300 }} class="my-4">
               <Alert>
                 <FilterAlt slot="icon" />

--- a/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
+++ b/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
@@ -19,7 +19,7 @@
     type ResponseTheme,
     type SearchableSelectOption,
   } from "../../../global/types";
-  import { themeFilters, demoFilters } from "../../../global/state.svelte";
+  import { themeFilters, demoFilters, multiAnswerFilters } from "../../../global/state.svelte";
 
   import Title from "../../Title.svelte";
   import TextInput from "../../inputs/TextInput/TextInput.svelte";
@@ -110,7 +110,7 @@
               <Title level={3} text="Search responses:" />
             </div>
 
-            {#if demoFilters.applied() || themeFilters.applied() || evidenceRich || searchValue}
+            {#if demoFilters.applied() || themeFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue}
               <div transition:fly={{ x: 300 }} class="my-4">
                 <Alert>
                   <FilterAlt slot="icon" />
@@ -254,12 +254,13 @@
               subtitle="All responses to this question"
             >
               <div slot="aside" class="flex gap-2 items-center flex-wrap">
-                {#if themeFilters.applied() || demoFilters.applied() || evidenceRich || searchValue}
+                {#if themeFilters.applied() || demoFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue}
                   <Button
                     size="sm"
                     handleClick={() => {
                       themeFilters.reset();
                       demoFilters.reset();
+                      multiAnswerFilters.reset();
                       setEvidenceRich(false);
                       setSearchValue("");
                     }}

--- a/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
+++ b/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
@@ -19,7 +19,11 @@
     type ResponseTheme,
     type SearchableSelectOption,
   } from "../../../global/types";
-  import { themeFilters, demoFilters, multiAnswerFilters } from "../../../global/state.svelte";
+  import {
+    themeFilters,
+    demoFilters,
+    multiAnswerFilters,
+  } from "../../../global/state.svelte";
 
   import Title from "../../Title.svelte";
   import TextInput from "../../inputs/TextInput/TextInput.svelte";

--- a/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
+++ b/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
@@ -64,6 +64,9 @@
   export let flaggedOnly: boolean = false;
   export let setFlaggedOnly = (value: boolean) => {};
 
+  export let anyFilterApplied: boolean = false;
+  export let resetFilters: () => void = () => {};
+
   const BASE_FLY_DELAY = 100;
 
   function getDelay(index: number): number {
@@ -114,7 +117,7 @@
               <Title level={3} text="Search responses:" />
             </div>
 
-            {#if demoFilters.applied() || themeFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue}
+            {#if anyFilterApplied}
               <div transition:fly={{ x: 300 }} class="my-4">
                 <Alert>
                   <FilterAlt slot="icon" />
@@ -258,15 +261,11 @@
               subtitle="All responses to this question"
             >
               <div slot="aside" class="flex gap-2 items-center flex-wrap">
-                {#if themeFilters.applied() || demoFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue}
+                {#if anyFilterApplied}
                   <Button
                     size="sm"
                     handleClick={() => {
-                      themeFilters.reset();
-                      demoFilters.reset();
-                      multiAnswerFilters.reset();
-                      setEvidenceRich(false);
-                      setSearchValue("");
+                      resetFilters();
                     }}
                   >
                     Clear filters

--- a/frontend/src/components/screens/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail.svelte
@@ -264,6 +264,7 @@
     multiAnswerFilters.reset();
     evidenceRich = false;
     searchValue = "";
+    flaggedOnly = false;
   };
 
   const anyFilterApplied = () => {
@@ -272,7 +273,8 @@
         demoFilters.applied() ||
         multiAnswerFilters.applied() ||
         evidenceRich ||
-        searchValue,
+        searchValue ||
+        flaggedOnly
     );
   };
 

--- a/frontend/src/components/screens/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail.svelte
@@ -274,7 +274,7 @@
         multiAnswerFilters.applied() ||
         evidenceRich ||
         searchValue ||
-        flaggedOnly
+        flaggedOnly,
     );
   };
 

--- a/frontend/src/components/screens/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail.svelte
@@ -264,11 +264,17 @@
     multiAnswerFilters.reset();
     evidenceRich = false;
     searchValue = "";
-  }
+  };
 
   const anyFilterApplied = () => {
-    return Boolean(themeFilters.applied() || demoFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue);
-  }
+    return Boolean(
+      themeFilters.applied() ||
+        demoFilters.applied() ||
+        multiAnswerFilters.applied() ||
+        evidenceRich ||
+        searchValue,
+    );
+  };
 
   const setEvidenceRich = (value: boolean) => (evidenceRich = value);
 

--- a/frontend/src/components/screens/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail.svelte
@@ -258,6 +258,18 @@
     hasMorePages = true;
   }
 
+  const resetFilters = () => {
+    themeFilters.reset();
+    demoFilters.reset();
+    multiAnswerFilters.reset();
+    evidenceRich = false;
+    searchValue = "";
+  }
+
+  const anyFilterApplied = () => {
+    return Boolean(themeFilters.applied() || demoFilters.applied() || multiAnswerFilters.applied() || evidenceRich || searchValue);
+  }
+
   const setEvidenceRich = (value: boolean) => (evidenceRich = value);
 
   $effect(() => {
@@ -408,6 +420,7 @@
         {searchValue}
         {sortAscending}
         setActiveTab={(newTab) => (activeTab = newTab)}
+        anyFilterApplied={anyFilterApplied()}
       />
     {:else if activeTab === TabNames.ResponseAnalysis}
       <ResponseAnalysis
@@ -437,6 +450,8 @@
         isThemesLoading={$isThemeAggrLoading}
         {flaggedOnly}
         setFlaggedOnly={(newValue) => (flaggedOnly = newValue)}
+        anyFilterApplied={anyFilterApplied()}
+        {resetFilters}
       />
     {/if}
   </TabView>


### PR DESCRIPTION
## Context
On the dashboard, currently filter alerts and clear filters button ignores multi choice answer filters.

## Changes proposed in this pull request
This PR includes multi-choice answer filters in the dashboard page filter logic.

## Guidance to review
Navigate to dashboard page, apply multi choice filters, confirm filter applied alerts and clear filters button appear. Confirm clear filters button clears multi-choice answer filters too.

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo