### PR TITLE
chore/back-populate_history

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,5 +4,6 @@ venv/bin/django-admin migrate
 venv/bin/django-admin collectstatic --noinput
 venv/bin/django-admin compress --force --engine jinja2
 venv/bin/django-admin createadminusers
+venv/bin/django-admin populate_history --auto --batchsize 1000
 
 exec venv/bin/gunicorn -c ./consultation_analyser/gunicorn.py consultation_analyser.wsgi


### PR DESCRIPTION
## Context

As a user I want the history back-populated so that the Edited flag works consistently

https://django-simple-history.readthedocs.io/en/stable/quick_start.html#existing-projects

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo