### PR TITLE
feature/query-themefinder-range

### DIFF
--- a/consultation_analyser/consultations/api/views.py
+++ b/consultation_analyser/consultations/api/views.py
@@ -99,7 +99,7 @@ class ThemeViewSet(ReadOnlyModelViewSet):
 class RespondentViewSet(ModelViewSet):
     serializer_class = RespondentSerializer
     permission_classes = [HasDashboardAccess, CanSeeConsultation]
-    filterset_fields = ["themefinder_id"]
+    filterset_fields = {"themefinder_id": ["exact", "gte", "lte"]}
     http_method_names = ["get", "patch"]
 
     def get_queryset(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,6 +390,20 @@ def respondent_2(consultation):
 
 
 @pytest.fixture
+def respondent_3(consultation):
+    respondent = Respondent.objects.create(consultation=consultation, themefinder_id=3)
+    yield respondent
+    respondent.delete()
+
+
+@pytest.fixture
+def respondent_4(consultation):
+    respondent = Respondent.objects.create(consultation=consultation, themefinder_id=4)
+    yield respondent
+    respondent.delete()
+
+
+@pytest.fixture
 def free_text_response(free_text_question, respondent_1):
     response = Response.objects.create(question=free_text_question, respondent=respondent_1)
     yield response

--- a/tests/unit/api/test_views.py
+++ b/tests/unit/api/test_views.py
@@ -1357,6 +1357,33 @@ def test_get_respondent_query_themefinder_id(
 
 
 @pytest.mark.django_db
+def test_get_respondent_query_themefinder_range(
+    client,
+    consultation,
+    respondent_1,
+    respondent_2,
+    respondent_3,
+    respondent_4,
+    consultation_user_token,
+):
+    url = reverse(
+        "respondent-list",
+        kwargs={"consultation_pk": consultation.id},
+    )
+
+    response = client.get(
+        url,
+        query_params={"themefinder_id__gte": 2, "themefinder_id__lte": 4},
+        headers={"Authorization": f"Bearer {consultation_user_token}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["count"] == 3
+    actual_respondents = {x["id"] for x in response.json()["results"]}
+    expected_respondents = {str(respondent_2.id), str(respondent_3.id), str(respondent_4.id)}
+    assert actual_respondents == expected_respondents
+
+
+@pytest.mark.django_db
 def test_get_respondent_detail(
     client, consultation, respondent_1, respondent_2, consultation_user_token
 ):


### PR DESCRIPTION
## Context

As a frontend engineer I want to be able to query for a range of themefinder_ids so that I can see previous and next respondents like:

`api/consultations/<id>/respondents/?themefinder_id__gte=4& themefinder_id__lte=6` will return respondents with themefinder_ids 4, 5, & 6.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo