### PR TITLE
Fix/wide sign in button

### DIFF
--- a/frontend/src/components/inputs/Button/Button.svelte
+++ b/frontend/src/components/inputs/Button/Button.svelte
@@ -16,7 +16,7 @@
   export let disabled: boolean = false;
   export let fullWidth: boolean = false;
   export let testId: string = "";
-  export let href: string | undefined;
+  export let href: string | undefined = undefined;
 </script>
 
 <svelte:element
@@ -39,7 +39,7 @@
     variant === "ghost" ? "border-transparent" : "border-gray-300",
     "transition-colors",
     "duration-300",
-"self-start",
+    "self-start",
     "inline-flex",
     "gap-1",
     "items-center",

--- a/frontend/src/components/inputs/Button/Button.svelte
+++ b/frontend/src/components/inputs/Button/Button.svelte
@@ -39,6 +39,7 @@
     variant === "ghost" ? "border-transparent" : "border-gray-300",
     "transition-colors",
     "duration-300",
+"self-start",
     "inline-flex",
     "gap-1",
     "items-center",

--- a/frontend/src/pages/sign-in.astro
+++ b/frontend/src/pages/sign-in.astro
@@ -5,7 +5,7 @@ import Title from '../components/Title.svelte';
 import SignInForm from '../components/screens/SignInForm.svelte';
 ---
 <Layout>
-	<Section>
+	<Section narrow>
 		<Title level={1} context="public" text="Sign in" />
 
         <p class="my-4 text-md text-gray-500">


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Ekin spotted that the sign-in button was taking up the full width of the screen.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

**Before**
<img width="1648" height="1440" alt="image" src="https://github.com/user-attachments/assets/8b3ac62a-11cc-417b-a5fa-9dd12c62a397" />

**After**
<img width="1648" height="1440" alt="image" src="https://github.com/user-attachments/assets/6b1d35a0-7909-4453-9eeb-4d1f93532ff8" />
