### PR TITLE
Added horizontal flex to sign in form

### DIFF
--- a/frontend/src/components/screens/SignInForm.svelte
+++ b/frontend/src/components/screens/SignInForm.svelte
@@ -60,15 +60,6 @@
   class={clsx(["flex", "flex-col", "gap-4"])}
   on:submit|preventDefault={handleSubmit}
 >
-  <TextInput
-    id={"email-input"}
-    label={"Email address"}
-    hideLabel={true}
-    placeholder={"Your email"}
-    value={email}
-    setValue={setEmail}
-  />
-
   {#if error}
     <small class="text-sm text-red-500" transition:slide={{ duration: 300 }}>
       {error}
@@ -89,7 +80,20 @@
     </small>
   {/if}
 
-  <Button variant="primary" handleClick={handleSubmit} disabled={sending}>
-    {sending ? "Sending..." : "Continue"}
-  </Button>
+  <div class="flex flex-wrap justify-start items-center gap-4">
+    <div class="grow max-w-[30ch]">
+      <TextInput
+        id={"email-input"}
+        label={"Email address"}
+        hideLabel={true}
+        placeholder={"Your email"}
+        value={email}
+        setValue={setEmail}
+      />
+    </div>
+
+    <Button variant="primary" handleClick={handleSubmit} disabled={sending}>
+      {sending ? "Sending..." : "Continue"}
+    </Button>
+  </div>
 </form>

--- a/frontend/src/pages/sign-in.astro
+++ b/frontend/src/pages/sign-in.astro
@@ -5,7 +5,7 @@ import Title from '../components/Title.svelte';
 import SignInForm from '../components/screens/SignInForm.svelte';
 ---
 <Layout>
-	<Section narrow>
+	<Section>
 		<Title level={1} context="public" text="Sign in" />
 
         <p class="my-4 text-md text-gray-500">


### PR DESCRIPTION
## Context

## Changes proposed in this pull request


<img width="872" height="486" alt="image" src="https://github.com/user-attachments/assets/a79cb313-29ed-4c64-ac24-1126da93c228" />

<img width="544" height="562" alt="image" src="https://github.com/user-attachments/assets/f274ba82-c4a8-4a84-85ab-4f695de7fd9b" />


## Guidance to review

## Link to Trello ticket

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo