### PR TITLE
Fixes for Respondent Detail Page

### DIFF
--- a/frontend/src/components/dashboard/AnswerCard/AnswerCard.svelte
+++ b/frontend/src/components/dashboard/AnswerCard/AnswerCard.svelte
@@ -168,7 +168,7 @@
                   location.href = getRespondentDetailUrl(
                     consultationId,
                     respondentId,
-                  ) + `?themefinder_id=${respondentDisplayId}`;
+                  ) + `?themefinder_id=${respondentDisplayId}&question_id=${questionId}`;
                 }}
               >
                 <MaterialIcon color="fill-neutral-500" size="0.8rem">

--- a/frontend/src/components/screens/RespondentDetail.svelte
+++ b/frontend/src/components/screens/RespondentDetail.svelte
@@ -8,6 +8,7 @@
     getApiConsultationRespondentUrl,
     getApiConsultationRespondentsUrl,
     getApiConsultationUrl,
+    getQuestionDetailUrl,
     getQuestionsByRespondentUrl,
     getRespondentDetailUrl,
   } from "../../global/routes.ts";
@@ -34,11 +35,12 @@
 
   interface Props {
     consultationId: string;
+    questionId: string;
     respondentId: string;
     themefinderId: number;
   }
 
-  let { consultationId = "", respondentId = "", themefinderId = 1 }: Props = $props();
+  let { consultationId = "", questionId = "", respondentId = "", themefinderId = 1 }: Props = $props();
 
   const {
     load: loadRespondents,
@@ -115,6 +117,7 @@
   <RespondentTopbar
     title={`Respondent ${themefinderId || "not found"}`}
     backText={"Back to Analysis"}
+    onClickBack={() => location.href = getQuestionDetailUrl(consultationId, questionId)}
   >
     <Button
       size="xs"
@@ -123,7 +126,7 @@
         (location.href = getRespondentDetailUrl(
           consultationId,
           prevRespondent.id,
-        ) + `?themefinder_id=${themefinderId - 1}`)}
+        ) + `?themefinder_id=${themefinderId - 1}&question_id=${questionId}`)}
     >
       <div class="rotate-180">
         <MaterialIcon color="fill-neutral-700">
@@ -141,7 +144,7 @@
         (location.href = getRespondentDetailUrl(
           consultationId,
           nextRespondent.id,
-        ) + `?themefinder_id=${themefinderId + 1}`)}
+        ) + `?themefinder_id=${themefinderId + 1}&question_id=${questionId}`)}
     >
       <span class="ml-2 my-[0.1rem]">Next Respondent</span>
 

--- a/frontend/src/pages/consultations/[consultationId]/respondent/[respondentId].astro
+++ b/frontend/src/pages/consultations/[consultationId]/respondent/[respondentId].astro
@@ -6,6 +6,7 @@ import Section from "../../../../components/Section/Section.svelte";
 
 const { consultationId, respondentId } = Astro.params;
 const themefinderId = Astro.url.searchParams.get("themefinder_id");
+const questionId = Astro.url.searchParams.get("question_id");
 
 function parseThemefinderId(themefinderId: string | null): number {
   const parsedId = parseInt(themefinderId || "");
@@ -17,6 +18,7 @@ function parseThemefinderId(themefinderId: string | null): number {
         <RespondentDetail
           client:load
           consultationId={consultationId}
+          questionId={questionId}
           respondentId={respondentId}
           themefinderId={parseThemefinderId(themefinderId)}
         />


### PR DESCRIPTION
## Context

## Changes proposed in this pull request
This PR:
- Sets the back url on back to analysis button so it always points to the question detail of origin even when user navigates through respondents with prev/next buttons.

## Guidance to review
Go to dashboard, click on id of a respondent to go to respondent page:
- confirm back to analysis goes back to analysis
- confirm back to analysis still goes back to analysis even after clicking on prev/next respondent buttons

## Link to Trello ticket

<!-- e.g. https://trello.com/c/PHi7K23V/27-django-data-models-mvp-v1 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo