### PR TITLE
Add pipeline ADRs

### DIFF
--- a/docs/architecture/decisions/0007-consolidate-job-processing-onto-sqs.md
+++ b/docs/architecture/decisions/0007-consolidate-job-processing-onto-sqs.md
@@ -1,0 +1,115 @@
+# 7. Consolidate job processing onto SQS
+
+Date: 2026-03-30
+
+## Status
+
+Accepted
+
+## Context
+
+The consult data pipeline requires redesign to support the Data Setup project, Finalising Themes V2 project, and the tests we have defined for finding themes. Its current organic growth has created operational complexity that hinders local development, debugging, and maintenance.
+
+The existing architecture is composed of two job systems plus an S3-based bridge:
+
+- Redis Queue (RQ) handles database sync jobs.
+- AWS Batch with Fargate runs finding themes and assigning themes.
+- EventBridge rules detect batch completion and Lambda functions enqueue database sync back into RQ.
+- S3 is used as the cross-system data store, meaning every pipeline run depends on S3 reads/writes.
+
+This creates several problems:
+
+- Dual processing system: independent failure domains across RQ, Batch, EventBridge, and Lambda.
+- S3 as orchestration backbone: a separate sync step reads AI output from S3 and writes it back to the database.
+- Per consultation processing: finding themes and assigning themes run at consultation scope, so a single failure forces a full rerun.
+- No local development path: AWS Batch prevents end-to-end local pipeline execution.
+- Two-pass theme assignment: users cannot review themes and see response assignments in one coherent pipeline run.
+
+This decision is informed by the Data Pipeline Architecture Brief, Data Pipeline documentation, ADR 0006, and the Data Setup and Finalising Themes V2 project goals.
+
+## Decision
+
+We will move the new AI pipeline submission path to SQS while keeping the existing RQ system unchanged for current async work. Existing RQ continues to service ingest, clone, dummy-data, embedding creation, and import-of-batch-output jobs. Only the new find-themes / assign-themes pipeline submission path is moved to SQS, and the two systems will coexist during migration.
+
+The decision includes:
+
+- Replace AWS Batch, EventBridge, and Lambda for the pipeline path with an SQS-based job queue.
+- Maintain the existing `default` RQ queue and current RQ workers for existing jobs.
+- Add a new SQS queue for AI pipeline jobs and a dedicated SQS worker service with a larger task definition and longer timeout.
+- Enqueue new AI pipeline jobs from Django to SQS.
+- Use PostgreSQL as the single source of truth for pipeline reads and writes.
+- Store snapshot and raw pipeline output in PostgreSQL instead of relying on S3; the DB owns run data and traceability.
+- Process each question as an independent pipeline job, matching the Finalising Themes V2 question-by-question experience.
+- Combine finding themes and assigning themes into a single per-question job, with carry-forward delta logic for unchanged, edited, and user-created themes.
+- Introduce the `jobs` table to capture run metadata and make pipeline execution auditable.
+- Extend the existing `Question.status` lifecycle with `finding_themes` and `assigning_themes`.
+
+## Database Changes
+
+### 5.1 Jobs
+
+A new `jobs` table tracks each pipeline execution, recording one row per question per run.
+
+| Column | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| `id` | UUID PK | no | Primary key |
+| `question_id` | UUID FK → `Question` | no | Links the pipeline execution to a question |
+| `type` | VARCHAR(16) | no | `candidate` or `final` |
+| `status` | VARCHAR(16) | no | `queued`, `running`, `completed`, or `failed` |
+| `external_id` | VARCHAR(64) | yes | Queue job ID (provider-agnostic) |
+| `context` | JSONB | yes | Error messages, model versions, metrics, optional traceability data |
+| `started_at` | TIMESTAMP | yes | When the worker picked up the job |
+| `completed_at` | TIMESTAMP | yes | When the job finished |
+| `created_at` | TIMESTAMP | no | Auto-generated timestamp |
+| `modified_at` | TIMESTAMP | no | Auto-generated timestamp |
+
+### 5.2 Existing Tables Changes
+
+| Table | Change | Details |
+| --- | --- | --- |
+| `Question` | Add `finding_themes` and `assigning_themes` to the existing `status` field | Two new lifecycle values: `draft` → `configured` → `finding_themes` → `assigning_themes` → `finalising_themes` → `confirmed_themes` |
+| `CandidateTheme` | Add `representative_responses` column | JSONField, nullable; list of response UUIDs that represent the most relevant responses for this theme in the review UI |
+
+## Consequences
+
+Positive consequences:
+
+- Simpler architecture: a single queue system reduces cross-service failure points.
+- Better local development: the pipeline can run locally against Redis and PostgreSQL.
+- Fault isolation: failures are contained to individual questions rather than whole consultations.
+- Faster feedback: per-question status allows the frontend to show progress and error states in real time.
+- No S3 dependency: raw pipeline output and snapshots are stored in PostgreSQL rather than in S3.
+- Better observability: the `jobs` table captures status, attempts, error details, timing, and token usage.
+
+Negative consequences and risks:
+
+- The new SQS pipeline worker becomes a scaling dependency; its ECS service must be sized and autoscaled carefully.
+- A new ECS service and autoscaling policy are required for the `pipeline` queue.
+- The migration is non-trivial: new tables and fields must be introduced without breaking existing Batch-based flows.
+- Storing raw pipeline output in PostgreSQL requires schema design, retention policy, and careful indexing to avoid table bloat.
+
+## Review
+
+This architectural review confirms that the consolidated pipeline design is aligned with the project goals:
+
+- It supports self-serve data setup by reading consultation data directly from PostgreSQL.
+- It enables the Finalising Themes V2 experience through per-question jobs and explicit `Question.status` lifecycle tracking.
+- It resolves the current two-pass theme assignment problem by producing candidate themes and response mappings in one combined run.
+- It improves traceability by storing raw pipeline run data in PostgreSQL keyed by consultation/question/run.
+
+The following areas still require validation during implementation:
+
+- SQS worker autoscaling and queue-length monitoring for large pipeline workloads.
+- Behaviour when pipeline output writes to PostgreSQL fail: the database remains authoritative, but observability and retry paths must be solid.
+- Migration for existing consultations and selected themes that were created before the new pipeline metadata model was introduced.
+- Coexistence during rollout: keep the current RQ/Batch path available and unchanged until the new SQS pipeline is fully validated.
+
+## Related
+
+- `docs/architecture/decisions/0006-database-redesign-for-self-serve-data-setup.md`
+- Data Pipeline Architecture Brief
+- Data Pipeline documentation
+- [Data Pipeline Design](https://incubatorforartificialintelligence.atlassian.net/wiki/spaces/Consult/pages/147357714/Data+Pipeline+Design)
+- Data Setup - Project Overview
+- Finalising Themes V2 - Project Overview
+- Defining tests for assessing Finding Themes

--- a/docs/architecture/decisions/0008-per-question-pipeline-with-db-source-of-truth.md
+++ b/docs/architecture/decisions/0008-per-question-pipeline-with-db-source-of-truth.md
@@ -1,0 +1,145 @@
+# 8. Per-question pipeline with DB as source of truth
+
+Date: 2026-03-30
+
+## Status
+
+Accepted
+
+## Context
+
+The current consult pipeline processes each consultation as a unit and relies on S3 as a shared orchestration layer. That design adds complexity, reduces fault isolation, and makes local debugging difficult.
+
+The Data Setup and Finalising Themes V2 work requires:
+
+- a question-by-question workflow that fits the user experience of stepping through free-text questions one at a time
+- a single source of truth for pipeline state and outputs
+- better visibility into pipeline progress and failures
+- the ability to retry or rerun individual questions without rerunning the whole consultation
+
+The existing architecture is therefore being redesigned to move per-question processing onto a new pipeline, with PostgreSQL as the authoritative store and S3 removed from the critical path.
+
+## Decision
+
+We will adopt a per-question pipeline model with the database as the primary source of truth.
+
+Key decisions:
+
+- Process pipeline work at the level of individual questions instead of entire consultations.
+- Store all pipeline read/write state in PostgreSQL, not S3, for critical path processing and traceability.
+- Use the existing `Question.status` field and extend it with new pipeline lifecycle states.
+- Record every pipeline execution in a dedicated `jobs` table.
+- Persist intermediate pipeline metadata and annotations through the database, using existing candidate theme and response annotation structures where possible.
+- Use the database to capture raw pipeline output, metrics, and metadata, rather than writing those artifacts to S3.
+- Rate limit concurrent question processing to protect the backend, the LLM service, and downstream database writes.
+
+### Per-question processing
+
+Each free-text question is treated as a separate pipeline job. The pipeline should:
+
+- read responses for the target question from PostgreSQL
+- generate candidate themes and assign responses in the same job
+- write pipeline outputs back to PostgreSQL in a transaction
+- update `Question.status` to reflect the current stage
+
+This allows:
+
+- fault isolation for failed questions
+- parallel processing across questions when capacity allows
+- more granular UI progress reporting
+- smaller retries and faster recovery
+
+### DB as source of truth
+
+PostgreSQL is the authoritative datastore for:
+
+- question pipeline status
+- pipeline run metadata
+- candidate theme mappings
+- response annotations
+- raw pipeline output and metrics
+
+S3 is removed from the critical path. If S3 is retained for off-line audit or archival purposes, it is strictly a secondary store and optional.
+
+### Question lifecycle
+
+A question lifecycle is stored on `Question.status` and moves through the following stages:
+
+- `draft`
+- `configured`
+- `finding_themes`
+- `assigning_themes`
+- `finalising_themes`
+- `confirmed_themes`
+- `error`
+
+This lifecycle supports the Finalising Themes V2 user journey and provides a stable boundary for retries and reprocessing.
+
+### Jobs table
+
+The `jobs` table tracks one execution per question per pipeline run.
+
+| Column | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| `id` | UUID PK | no | Primary key |
+| `question_id` | UUID FK → `Question` | no | Associates the job with a question |
+| `type` | VARCHAR(16) | no | `candidate` or `final` |
+| `status` | VARCHAR(16) | no | `queued`, `running`, `completed`, or `failed` |
+| `external_id` | VARCHAR(64) | yes | Queue job ID (provider-agnostic) |
+| `context` | JSONB | yes | Error messages, model versions, metrics, optional traceability data |
+| `attempts` | integer | yes | Retry attempt count |
+| `started_at` | TIMESTAMP | yes | When the worker picked up the job |
+| `completed_at` | TIMESTAMP | yes | When the job finished |
+| `parameters_json` | JSONB | yes | Pipeline inputs and configuration |
+| `metrics_json` | JSONB | yes | Usage and performance metrics |
+| `output_json` | JSONB | yes | Raw pipeline output or final payloads |
+
+Using a dedicated `jobs` table makes the pipeline auditable, enables retries, and keeps run metadata available for debugging and reporting.
+
+### Rate limiting strategy
+
+The pipeline must avoid overloading downstream systems and the LLM API. This requires a rate limiting strategy for concurrent question jobs:
+
+- limit the number of in-flight question jobs per consultation
+- limit the total number of concurrent pipeline jobs across the service
+- enforce backpressure via SQS queue visibility and worker concurrency settings
+- use configurable thresholds so the rate limiting policy can be tuned in staging and production
+
+This ensures that busy consultations do not monopolise compute, and that the system can degrade gracefully when the LLM or database is under pressure.
+
+## Consequences
+
+Positive consequences:
+
+- simpler pipeline semantics: per-question jobs are smaller and easier to reason about
+- better failure isolation and retry granularity
+- more accurate progress tracking in the UI
+- reduced coupling between pipeline orchestration and S3
+- a single authoritative store for pipeline state and output
+
+Negative consequences and risks:
+
+- the database schema becomes more complex and must support additional pipeline run payloads
+- raw pipeline output persisted in PostgreSQL will require retention and storage management
+- concurrent question execution must be controlled carefully to avoid overwhelming the database or LLM
+- migration of existing consultation data and pipeline state is required
+- `CandidateTheme` requires a new nullable `representative_responses` JSONField for review UI support
+
+## Review
+
+This ADR defines a stronger alignment between the data setup user journey and the underlying pipeline architecture. By moving the pipeline to question-level granularity and storing state in PostgreSQL, we improve visibility, local debugging, and fault isolation.
+
+The implementation needs to validate:
+
+- that `Question.status` supports the expected UI workflow
+- that `PipelineRun` captures enough metadata for debugging and metrics
+- that per-question concurrency limits are effective in practice
+- that existing consultations can be migrated without data loss or workflow disruption
+
+## Related
+
+- `docs/architecture/decisions/0006-database-redesign-for-self-serve-data-setup.md`
+- `docs/architecture/decisions/0007-consolidate-job-processing-onto-sqs.md`
+- [Data Pipeline Design](https://incubatorforartificialintelligence.atlassian.net/wiki/spaces/Consult/pages/147357714/Data+Pipeline+Design)
+- Data Setup - Project Overview
+- Finalising Themes V2 - Project Overview


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

- Add ADR `docs/architecture/decisions/0008-per-question-pipeline-with-db-source-of-truth.md` describing the new per-question AI pipeline and database source-of-truth model.
- Add ADR `docs/architecture/decisions/0007-consolidate-job-processing-onto-sqs.md` describing the SQS-based pipeline submission path and the new `jobs` table.

<!-- If there are UI changes, please include Before and After screenshots. -->


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
