### PR TITLE
refactored stories display component to avoid needing to reload the page

### DIFF
--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -33,6 +33,7 @@ export default defineConfig([
           argsIgnorePattern: "^_",
         },
       ],
+      "svelte/prefer-writable-derived": ["warn"],
     },
   },
   {

--- a/frontend/src/components/Progress/ProgressStory.svelte.ts
+++ b/frontend/src/components/Progress/ProgressStory.svelte.ts
@@ -7,7 +7,7 @@ export default {
     { name: "value", value: 40, type: "number" },
     {
       name: "thickness",
-      value: 40,
+      value: 2,
       type: "select",
       options: [
         { value: 1, label: "1" },

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import clsx from "clsx";
 
-  import { createRawSnippet } from "svelte";
+  import { createRawSnippet, onDestroy, onMount } from "svelte";
 
   import CodeMirror from "svelte-codemirror-editor";
   import { json } from "@codemirror/lang-json";
@@ -18,8 +18,17 @@
 
   import stories from "./stories.ts";
 
-  let { selected = "" } = $props();
-  let currStory = $state(stories.find((story) => story.name === selected));
+  const getSelectedUrlParam = () => {
+    return Object.fromEntries(new URLSearchParams(window.location.search)).selected;
+  }
+
+  const updateSelected = () => {
+    const newSelected = getSelectedUrlParam();
+    selected = newSelected;
+  }
+
+  let selected = $derived(getSelectedUrlParam());
+  let currStory = $derived(stories.find((story) => story.name === selected));
   let componentProps: unknown = $derived.by(() => {
     let props: unknown = {};
     currStory?.props.forEach((prop) => {
@@ -28,6 +37,14 @@
     return props;
   });
   let panel: HTMLElement;
+
+  onMount(() => {
+    window.addEventListener("popstate", updateSelected);
+  })
+
+  onDestroy(() => {
+    window.removeEventListener("popstate", updateSelected);
+  })
 
   const categories = [...new Set(stories.map((story) => story.category))];
 </script>
@@ -56,6 +73,12 @@
                   currStory?.name === story.name &&
                     "text-primary hover:text-pink-600",
                 ])}
+                onclick={(e) => {
+                  e.preventDefault();
+                  selected = story.name;
+                  var newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?selected=${story.name}`;
+                  window.history.pushState({path:newurl},'',newurl);
+                }}
               >
                 {story.name}
               </a>

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -279,6 +279,10 @@
             {/each}
           {/if}
         </div>
+      {:else}
+        <p class="text-center my-8 text-neutral-600">
+          Please select a component to view
+        </p>
       {/if}
     </Panel>
   </div>

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -280,7 +280,7 @@
           {/if}
         </div>
       {:else}
-        <p class="text-center my-8 text-neutral-600">
+        <p class="my-8 text-center text-neutral-600">
           Please select a component to view
         </p>
       {/if}

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -26,9 +26,8 @@
       .selected;
   };
 
-  const updateSelected = () => {
-    const newSelected = getSelectedUrlParam();
-    selected = newSelected;
+  const handlePopState = () => {
+    selected = getSelectedUrlParam();
   };
 
   let selected = $state(getSelectedUrlParam());
@@ -55,11 +54,11 @@
   let panel: HTMLElement;
 
   onMount(() => {
-    window.addEventListener("popstate", updateSelected);
+    window.addEventListener("popstate", handlePopState);
   });
 
   onDestroy(() => {
-    window.removeEventListener("popstate", updateSelected);
+    window.removeEventListener("popstate", handlePopState);
   });
 
   const categories = [...new Set(stories.map((story) => story.category))];

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -22,13 +22,14 @@
   import { queryClient } from "../../global/queryClient.ts";
 
   const getSelectedUrlParam = () => {
-    return Object.fromEntries(new URLSearchParams(window.location.search)).selected;
-  }
+    return Object.fromEntries(new URLSearchParams(window.location.search))
+      .selected;
+  };
 
   const updateSelected = () => {
     const newSelected = getSelectedUrlParam();
     selected = newSelected;
-  }
+  };
 
   let selected = $state(getSelectedUrlParam());
   let currStory = $state(stories.find((story) => story.name === selected));
@@ -39,7 +40,7 @@
     // prop values do not trigger reactive updates
     // therefore this effect rune is needed
     currStory = stories.find((story) => story.name === selected);
-  })
+  });
 
   let componentProps: unknown = $derived.by(() => {
     let props: unknown = {};
@@ -55,11 +56,11 @@
 
   onMount(() => {
     window.addEventListener("popstate", updateSelected);
-  })
+  });
 
   onDestroy(() => {
     window.removeEventListener("popstate", updateSelected);
-  })
+  });
 
   const categories = [...new Set(stories.map((story) => story.category))];
 
@@ -124,7 +125,7 @@
                   selected = story.name;
                   currStoryTab = "interactive";
                   var newurl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?selected=${story.name}`;
-                  window.history.pushState({path:newurl},'',newurl);
+                  window.history.pushState({ path: newurl }, "", newurl);
                 }}
               >
                 {story.name}

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -30,9 +30,16 @@
     selected = newSelected;
   }
 
-  let selected = $derived(getSelectedUrlParam());
-  let currStory = $derived(stories.find((story) => story.name === selected));
+  let selected = $state(getSelectedUrlParam());
+  let currStory = $state(stories.find((story) => story.name === selected));
   let currStoryTab = $state("interactive");
+
+  $effect(() => {
+    // if currStory is declared with derived instead of state
+    // prop values do not trigger reactive updates
+    // therefore this effect rune is needed
+    currStory = stories.find((story) => story.name === selected);
+  })
 
   let componentProps: unknown = $derived.by(() => {
     let props: unknown = {};


### PR DESCRIPTION
## Context
Component buttons on story page navigate away from the page, causing a full reload.

## Changes proposed in this pull request
This PR handles navigation within the state, allowing immediate navigation between components.

## Guidance to review
Navigate to stories page, confirm navigating between components works as intended. Also confirm browser back/forward actions are handles correctly.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
