### PR TITLE
Remove old and unused files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,54 +26,18 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
 # Unit test / coverage reports
 htmlcov/
-.tox/
-.nox/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
-.hypothesis/
 .pytest_cache/
 cover/
 
-# Translations
-*.mo
-*.pot
-
 # Django stuff:
 *.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
@@ -87,37 +51,12 @@ ipython_config.py
 #   intended to run in multiple environments; otherwise, check them in:
 # .python-version
 
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
 # uv
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #   https://docs.astral.sh/uv/concepts/projects/#project-lockfile
 #uv.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/#use-with-ide
-.pdm.toml
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -143,15 +82,6 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
@@ -159,16 +89,7 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
-# Frontend
-node_modules
-legacy-frontend/CACHE
-frontend/govuk-assets
-frontend/iai-assets
-frontend/admin
-frontend/django_extensions
-
 # Other
-.env
 .DS_Store
 .vscode
 !.vscode/settings.json
@@ -195,7 +116,6 @@ tmp
 
 lambda/build/
 lambda/**/*.zip
-lambda/**/celery/
 lambda/**/redis/
 lambda/**/__pycache__/
 


### PR DESCRIPTION
## Context
I noticed I had a lot of old assets files (e.g. old govuk design system assets) saved in my Consult directory. Similarly, the .gitignore file has a lot of references to old directories, plus a couple of boilerplate references.

## Changes proposed in this pull request
Remove unused items from the .gitignore. Engineers who have been working on the project for some time may need to delete old directories as a result of these changes.

## Guidance to review
* Have I removed anything that we still need in the project?
* Have I removed anything that might be used by individual engineers? (e.g. specific CLI settings files)
* Is there anything else remaining that can be removed?

## Things to check

- [x] ~I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo~
