### PR TITLE
Feature/add 2 week pypi package delay to uv

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
 ]
 
 [tool.uv]
-exclude-newer = "2 weeks"
+exclude-newer = "P14D"
 
 [tool.ruff]
 line-length = 100

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,6 +48,9 @@ dev = [
   "django-webtest>=1.9.14",
 ]
 
+[tool.uv]
+exclude-newer = "2 weeks"
+
 [tool.ruff]
 line-length = 100
 target-version = 'py312'

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 
+[options]
+exclude-newer = "2026-04-01T06:24:06.967684Z"
+exclude-newer-span = "P14D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
## Context

Attacks via packages seem to be getting more common, this will only install packges that are at least 2 weeks mature

## Changes proposed in this pull request

- Updated the pyproject.toml to restrict package installs to only those over 2 weeks old

## Guidance to review

- Update to the latest version of uv
- Run uv sync --refresh to regenerate the lockfile with a new date
