### PR TITLE
Make stories sidebar sticky

### DIFF
--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -96,7 +96,7 @@
 </script>
 
 <div class="grid grid-cols-4 gap-8">
-  <aside class="col-span-1">
+  <aside class="sticky top-4 col-span-1 h-[80vh]">
     <Panel border={true} bg={false}>
       <ul class="flex flex-col gap-2">
         {#each categories as category (category)}


### PR DESCRIPTION
## Context
The sidebar on stories page currently has unlimited height.

## Changes proposed in this pull request
This PR limits the sidebar height to viewport height and makes it sticky for tall components.

## Guidance to review
View on stories route.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
