### PR TITLE
Update worker number of tasks to 3 and runtime to 24h

### DIFF
--- a/backend/data_pipeline/jobs.py
+++ b/backend/data_pipeline/jobs.py
@@ -14,7 +14,7 @@ logger = settings.LOGGER
 DEFAULT_TIMEOUT_SECONDS = 3_600
 
 
-@job("default", timeout=28800)
+@job("default", timeout=86400)  # 1 day
 def import_consultation(
     consultation_name: str,
     consultation_code: str,

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -198,7 +198,8 @@ module "worker" {
     port                = 8000
   }
 
-  autoscaling_maximum_target = 1
+  autoscaling_minimum_target = 3
+  autoscaling_maximum_target = 3
 
   additional_execution_role_tags = {
     "RolePassableByRunner" = "True"


### PR DESCRIPTION
## Context

Consultations are taking a very long time to run, and block the worker when running.

## Changes proposed in this pull request

- Up the runtime of a single worker task to 24h to allow the largest ones to complete
- Up the number of worker tasks to 3 so these large consultation runs don't completely block the pipeline