### PR TITLE
Add ...i.ai.gov.uk to the trusted origins for POST requests

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -97,16 +97,16 @@ WSGI_APPLICATION = "wsgi.application"
 AUTH_USER_MODEL = "authentication.User"
 
 # Local and testing origin
-TRUSTED_ORIGIN = ["http://localhost:3000"]
+TRUSTED_ORIGINS = ["http://localhost:3000"]
 
 if ENVIRONMENT.lower() == "prod":
-    TRUSTED_ORIGIN = ["https://consult.ai.cabinetoffice.gov.uk", "https://consult.i.ai.gov.uk"]
+    TRUSTED_ORIGINS = ["https://consult.ai.cabinetoffice.gov.uk", "https://consult.i.ai.gov.uk"]
 if ENVIRONMENT.lower() == "dev":
-    TRUSTED_ORIGIN = ["https://consult-dev.ai.cabinetoffice.gov.uk", "https://consult.dev.i.ai.gov.uk"]
+    TRUSTED_ORIGINS = ["https://consult-dev.ai.cabinetoffice.gov.uk", "https://consult.dev.i.ai.gov.uk"]
 if ENVIRONMENT.lower() == "preprod":
-    TRUSTED_ORIGIN = ["https://consult-preprod.ai.cabinetoffice.gov.uk", "https://consult.preprod.i.ai.gov.uk"]
+    TRUSTED_ORIGINS = ["https://consult-preprod.ai.cabinetoffice.gov.uk", "https://consult.preprod.i.ai.gov.uk"]
 
-CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGIN
+CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGINS
 
 # Database with Connection Pooling
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -97,16 +97,16 @@ WSGI_APPLICATION = "wsgi.application"
 AUTH_USER_MODEL = "authentication.User"
 
 # Local and testing origin
-TRUSTED_ORIGIN = "http://localhost:3000"
+TRUSTED_ORIGIN = ["http://localhost:3000"]
 
 if ENVIRONMENT.lower() == "prod":
-    TRUSTED_ORIGIN = "https://consult.ai.cabinetoffice.gov.uk"
+    TRUSTED_ORIGIN = ["https://consult.ai.cabinetoffice.gov.uk", "https://consult.i.ai.gov.uk"]
 if ENVIRONMENT.lower() == "dev":
-    TRUSTED_ORIGIN = "https://consult-dev.ai.cabinetoffice.gov.uk"
+    TRUSTED_ORIGIN = ["https://consult-dev.ai.cabinetoffice.gov.uk", "https://consult.dev.i.ai.gov.uk"]
 if ENVIRONMENT.lower() == "preprod":
-    TRUSTED_ORIGIN = "https://consult-preprod.ai.cabinetoffice.gov.uk"
+    TRUSTED_ORIGIN = ["https://consult-preprod.ai.cabinetoffice.gov.uk", "https://consult.preprod.i.ai.gov.uk"]
 
-CSRF_TRUSTED_ORIGINS = [TRUSTED_ORIGIN]
+CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGIN
 
 # Database with Connection Pooling
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -6,8 +6,7 @@ from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 
 from settings.base import *  # noqa
 
-# Extend CSRF_TRUSTED_ORIGINS from base.py with the DOMAIN_NAME
-CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGIN + ["https://" + env("DOMAIN_NAME")]  # noqa: F405
+CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGINS + ["https://" + env("DOMAIN_NAME")]  # noqa: F405
 
 
 SENTRY_DSN = env("SENTRY_DSN")  # noqa: F405

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -6,7 +6,8 @@ from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 
 from settings.base import *  # noqa
 
-CSRF_TRUSTED_ORIGINS = ["https://" + env("DOMAIN_NAME")]  # noqa: F405
+# Extend CSRF_TRUSTED_ORIGINS from base.py with the DOMAIN_NAME
+CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGIN + ["https://" + env("DOMAIN_NAME")]  # noqa: F405
 
 
 SENTRY_DSN = env("SENTRY_DSN")  # noqa: F405


### PR DESCRIPTION
## Context

POST requests are being blocked with a 403 in the backend on i.ai.gov.uk.

## Changes proposed in this pull request

- Added i.ai.gov.uk domains to django base settings for trusted origins

## Guidance to review

- Deploy this branch and test cloning a consultation on i.ai.gov.uk domain
