### PR TITLE
Move consultation delete job to async and on worker container

### DIFF
--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -79,7 +79,28 @@ class ConsultationViewSet(ModelViewSet):
         return [permission() for permission in permission_classes]
 
     def perform_destroy(self, instance):
-        delete_consultation_job(instance)
+        """
+        Enqueue consultation deletion job to worker container
+        """
+        delete_consultation_job.delay(instance.id)
+
+    def destroy(self, request, *args, **kwargs):
+        """
+        Delete consultation asynchronously via worker.
+
+        Returns 202 Accepted to indicate the deletion has been queued
+        and will be processed asynchronously.
+        """
+        instance = self.get_object()
+        self.perform_destroy(instance)
+
+        return Response(
+            {
+                "message": f"Deletion of consultation '{instance.title}' has been queued",
+                "consultation_id": str(instance.id),
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )
 
     @action(
         detail=True,

--- a/backend/ingest/jobs.py
+++ b/backend/ingest/jobs.py
@@ -100,17 +100,30 @@ def delete_responses_in_batches(consultation_id: UUID, batch_size: int = 1000):
                 break
 
 
-@job("default", timeout=3_600)
-def delete_consultation_job(consultation: models.Consultation):
+@job("default", timeout=28_800)  # 8 hours
+def delete_consultation_job(consultation_id: UUID):
+    """
+    RQ job to delete a consultation and all related data.
+
+    This job is executed asynchronously on the worker container.
+
+    Args:
+        consultation_id: UUID of the consultation to delete
+    """
     logger.refresh_context()
 
-    consultation_id = consultation.id
-    consultation_title = consultation.title
+    try:
+        # Fetch the consultation from database
+        consultation = models.Consultation.objects.get(id=consultation_id)
+        consultation_title = consultation.title
+    except models.Consultation.DoesNotExist:
+        logger.error(
+            "Consultation {consultation_id} not found, may have already been deleted",
+            consultation_id=consultation_id,
+        )
+        return
 
     try:
-        # Re-fetch the consultation to ensure we have a fresh DB connection
-        consultation = models.Consultation.objects.get(id=consultation_id)
-
         # Delete related objects in order to avoid foreign key constraints
         logger.info(
             "Deleting consultation '{consultation_title}' (ID: {consultation_id})",

--- a/backend/tests/unit/api/views/test_consultation_views.py
+++ b/backend/tests/unit/api/views/test_consultation_views.py
@@ -357,14 +357,31 @@ class TestConsultationViewSet:
 
     def test_delete_consultation(self, client, consultation, staff_user_token):
         """test that a user can delete their own consultation"""
+        from unittest.mock import patch
+
         url = reverse("consultations-detail", kwargs={"pk": consultation.id})
-        response = client.delete(
-            url,
-            headers={"Authorization": f"Bearer {staff_user_token}"},
-        )
-        assert response.status_code == 204
-        assert not response.content
-        assert not Consultation.objects.filter(pk=consultation.pk).exists()
+
+        # Mock the job enqueueing
+        with patch("ingest.jobs.delete_consultation_job.delay") as mock_delay:
+            response = client.delete(
+                url,
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+            # Verify API returned 202 Accepted
+            assert response.status_code == 202
+
+            # Verify response contains expected message
+            response_data = response.json()
+            assert "message" in response_data
+            assert "queued" in response_data["message"]
+            assert "consultation_id" in response_data
+
+            # Verify job was enqueued with correct parameter
+            mock_delay.assert_called_once_with(consultation.id)
+
+        # Consultation should still exist (worker will delete it)
+        assert Consultation.objects.filter(pk=consultation.pk).exists()
 
     def test_delete_consultation_fail(self, client, consultation, non_staff_user_token):
         """test that a user cannot delete a consultation they do not own"""

--- a/backend/tests/unit/test_delete_consultation.py
+++ b/backend/tests/unit/test_delete_consultation.py
@@ -128,7 +128,7 @@ def test_delete_consultation_cascading():
     assert MultiChoiceAnswer.objects.count() == 3
 
     # Delete the consultation
-    delete_consultation_job(consultation)
+    delete_consultation_job(consultation.id)
 
     # Verify cascading deletion
     assert Consultation.objects.count() == 0
@@ -186,7 +186,7 @@ def test_delete_consultation_job_success(mock_connection):
     ).exists()
 
     # Run the delete job
-    delete_consultation_job(consultation)
+    delete_consultation_job(consultation.id)
 
     # Verify all objects are deleted
     assert not Consultation.objects.filter(id=consultation_id).exists()
@@ -206,7 +206,7 @@ def test_delete_consultation_job_handles_database_connection(mock_connection):
     consultation = Consultation.objects.create(title="Test Consultation")
 
     # Run the delete job
-    delete_consultation_job(consultation)
+    delete_consultation_job(consultation.id)
 
 
 @pytest.mark.django_db
@@ -225,7 +225,7 @@ def test_delete_consultation_job_handles_exceptions(mock_logger, mock_connection
         side_effect=Exception("Database error"),
     ):
         with pytest.raises(Exception) as exc_info:
-            delete_consultation_job(consultation)
+            delete_consultation_job(consultation.id)
 
         assert "Database error" in str(exc_info.value)
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
