### PR TITLE
Added new RDS alarms, updated ECS alarms

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -3,10 +3,10 @@ locals {
   frontend_port = 3000
 
   base_env_vars = {
-    "ENVIRONMENT" = terraform.workspace
-    "DEBUG"       = var.env == "prod" ? false : true
-    "REPO"        = var.project_name
-    "AWS_ACCOUNT_ID"  = data.aws_caller_identity.current.account_id
+    "ENVIRONMENT"    = terraform.workspace
+    "DEBUG"          = var.env == "prod" ? false : true
+    "REPO"           = var.project_name
+    "AWS_ACCOUNT_ID" = data.aws_caller_identity.current.account_id
   }
 
   django_env_vars = {
@@ -30,7 +30,7 @@ module "backend" {
   # checkov:skip=CKV_SECRET_4:Skip secret check as these have to be used within the Github Action
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
-  source                        = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.0-ecs"
+  source                        = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.1-ecs"
   image_tag                     = var.image_tag
   ecr_repository_uri            = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/consult-backend"
   vpc_id                        = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -97,7 +97,7 @@ module "frontend" {
   # checkov:skip=CKV_SECRET_4:Skip secret check as these have to be used within the Github Action
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
-  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.0-ecs"
+  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.1-ecs"
   image_tag                    = var.image_tag
   ecr_repository_uri           = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/consult-frontend"
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -158,7 +158,7 @@ module "worker" {
   # checkov:skip=CKV_SECRET_4:Skip secret check as these have to be used within the Github Action
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
-  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.0-ecs"
+  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.1-ecs"
   image_tag                    = var.image_tag
   ecr_repository_uri           = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/consult-backend"
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -247,22 +247,86 @@ module "sns_topic" {
 
 module "backend-ecs-alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
-  # source                       = "../../i-dot-ai-core-terraform-modules/modules/observability/ecs-alarms"
-  source           = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/ecs-alarms?ref=v1.0.1-ecs-alarms"
-  name             = "${local.name}-backend"
-  ecs_service_name = module.backend.ecs_service_name
-  ecs_cluster_name = data.terraform_remote_state.platform.outputs.ecs_cluster_name
-  sns_topic_arn    = [module.sns_topic.sns_topic_arn]
+  # source         = "../../i-dot-ai-core-terraform-modules/modules/observability/ecs-alarms"
+  source         = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/ecs-alarms?ref=v2.0.0-ecs-alarms"
+  name           = "${local.name}-backend"
+  sns_topic_arns = [module.sns_topic.sns_topic_arn]
+
+  ecs_metadata = {
+    container_insights_enabled = data.terraform_remote_state.platform.outputs.container_insights_enabled
+    cluster_name               = data.terraform_remote_state.platform.outputs.ecs_cluster_name
+    service_name               = module.backend.ecs_service_name
+    is_fargate                 = module.backend.is_fargate
+    task_cpu                   = module.backend.task_cpu
+    task_memory_mib            = module.backend.task_memory_mib
+    ephemeral_storage_gib      = module.backend.ephemeral_storage_gib
+  }
+
+  alarms_config = {
+    ephemeral_storage_high = {
+      threshold = 90
+    }
+  }
 }
 
 module "frontend-ecs-alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
-  # source                       = "../../i-dot-ai-core-terraform-modules/modules/observability/ecs-alarms"
-  source           = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/ecs-alarms?ref=v1.0.1-ecs-alarms"
-  name             = "${local.name}-frontend"
-  ecs_service_name = module.frontend.ecs_service_name
-  ecs_cluster_name = data.terraform_remote_state.platform.outputs.ecs_cluster_name
-  sns_topic_arn    = [module.sns_topic.sns_topic_arn]
+  # source         = "../../i-dot-ai-core-terraform-modules/modules/observability/ecs-alarms"
+  source         = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/ecs-alarms?ref=v2.0.0-ecs-alarms"
+  name           = "${local.name}-frontend"
+  sns_topic_arns = [module.sns_topic.sns_topic_arn]
+
+  ecs_metadata = {
+    container_insights_enabled = data.terraform_remote_state.platform.outputs.container_insights_enabled
+    cluster_name               = data.terraform_remote_state.platform.outputs.ecs_cluster_name
+    service_name               = module.frontend.ecs_service_name
+    is_fargate                 = module.frontend.is_fargate
+    task_cpu                   = module.frontend.task_cpu
+    task_memory_mib            = module.frontend.task_memory_mib
+    ephemeral_storage_gib      = module.frontend.ephemeral_storage_gib
+  }
+
+  alarms_config = {
+    ephemeral_storage_high = {
+      threshold = 90
+    }
+  }
+}
+
+# Worker is an RQ queue processor: bursty CPU by design (long-running jobs
+# can pin a single task's CPU), pinned at 3 tasks with no autoscaling.
+# Overrides raise the CPU alarms to tolerate legitimate job runs while
+# keeping memory, availability, and placement alarms at their defaults.
+module "worker-ecs-alarm" {
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source         = "../../i-dot-ai-core-terraform-modules/modules/observability/ecs-alarms"
+  source         = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/ecs-alarms?ref=v2.0.0-ecs-alarms"
+  name           = "${local.name}-worker"
+  sns_topic_arns = [module.sns_topic.sns_topic_arn]
+
+  ecs_metadata = {
+    container_insights_enabled = data.terraform_remote_state.platform.outputs.container_insights_enabled
+    cluster_name               = data.terraform_remote_state.platform.outputs.ecs_cluster_name
+    service_name               = module.worker.ecs_service_name
+    is_fargate                 = module.worker.is_fargate
+    task_cpu                   = module.worker.task_cpu
+    task_memory_mib            = module.worker.task_memory_mib
+    ephemeral_storage_gib      = module.worker.ephemeral_storage_gib
+  }
+
+  alarms_config = {
+    cpu_high = {
+      threshold = 95
+    }
+
+    task_cpu_high = {
+      threshold = 95
+    }
+
+    ephemeral_storage_high = {
+      threshold = 90
+    }
+  }
 }
 
 module "backend-alb-alarm" {

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,7 +1,6 @@
 module "rds" {
   # source                                = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/rds"
-  # For testing local changes
-  source                                = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/rds?ref=v4.2.0-rds"
+  source                                = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/rds?ref=v4.4.0-rds"
   db_name                               = "consultations" # DO NOT CHANGE THIS!
   kms_secrets_arn                       = data.terraform_remote_state.platform.outputs.kms_key_arn
   name                                  = local.name
@@ -23,4 +22,31 @@ module "rds" {
     module.backend.ecs_sg_id,
     module.worker.ecs_sg_id
   ]
+}
+
+module "rds_alarms" {
+  # source         = "../../i-dot-ai-core-terraform-modules//modules/observability/rds-alarms"
+  source         = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/rds-alarms?ref=v1.0.0-rds-alarms"
+  name           = local.name
+  sns_topic_arns = [module.sns_topic.sns_topic_arn]
+
+  rds_metadata = {
+    engine                 = module.rds.engine
+    is_aurora              = module.rds.is_aurora
+    db_instance_identifier = module.rds.db_instance_identifier
+    db_cluster_identifier  = module.rds.db_cluster_identifier
+    aurora_instance_count  = module.rds.aurora_instance_count
+    storage_type           = module.rds.storage_type
+  }
+
+  alarms_config = {
+    # ~10% of Aurora Serverless v2 min_capacity floor (2 ACU = 4 GiB).
+    freeable_memory_low = {
+      threshold = 429496729
+    }
+    # ~80% of Postgres default max_connections at 4 GiB (~450).
+    database_connections_high = {
+      threshold = 360
+    }
+  }
 }


### PR DESCRIPTION
## Context

To address some observability gaps in alarms configured (or missing) for RDS and ECS.

## Changes proposed in this pull request

- Added configuration to consume new RDS alarm module.
- Updated configuration to consume new version of the ECS alarm module.

## Guidance to review

- Defaults have been configured with Consult in mind as first consumer. Tuning may be required if alarms are too noisy, or if incidents are missed due to alarms lagging.

## Things to check

- Consider reviewing the ECS alarm catalogue to tune alarm configuration specific for this service - https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules/tree/main/modules/observability/ecs-alarms#alarm-catalogue
- Consider reviewing the RDS alarm catalogue to tune alarm configuration specific for this service - https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules/blob/main/modules/observability/rds-alarms/README.md#alarm-catalogue
