### PR TITLE
Fix duplicate key error in demographics display

### DIFF
--- a/frontend/src/components/dashboard/Metrics/Metrics.svelte
+++ b/frontend/src/components/dashboard/Metrics/Metrics.svelte
@@ -211,6 +211,7 @@
                   },
                 )
                 .map((demoOption: DemoOptionsResponseItem) => ({
+                  id: demoOption.id,
                   title: demoOption.value,
                   count: demoOption.count,
                   percentage: getPercentage(demoOption.count, total),

--- a/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.svelte
+++ b/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.svelte
@@ -12,6 +12,7 @@
   import { getConsultationAnalysisUrl } from "../../../global/routes";
 
   interface MetricsDemoItem {
+    id: string;
     title: string;
     count: number;
     percentage: number;
@@ -35,7 +36,7 @@
 </script>
 
 {#snippet cardItem(
-  { title, count, percentage }: MetricsDemoItem,
+  { id, title, count, percentage }: MetricsDemoItem,
   index: number,
 )}
   {#if displayAll || index < hideThreshold}
@@ -69,7 +70,7 @@
   <Panel bg={true} border={true}>
     <Title level={4} text={title} />
 
-    {#each items as item, index (item.title)}
+    {#each items as item, index (item.id)}
       {@render cardItem(item, index)}
     {/each}
 

--- a/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.svelte
+++ b/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.svelte
@@ -36,7 +36,7 @@
 </script>
 
 {#snippet cardItem(
-  { id, title, count, percentage }: MetricsDemoItem,
+  { id: _id, title, count, percentage }: MetricsDemoItem,
   index: number,
 )}
   {#if displayAll || index < hideThreshold}

--- a/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.svelte
+++ b/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.svelte
@@ -36,7 +36,7 @@
 </script>
 
 {#snippet cardItem(
-  { id: _id, title, count, percentage }: MetricsDemoItem,
+  { title, count, percentage }: MetricsDemoItem,
   index: number,
 )}
   {#if displayAll || index < hideThreshold}

--- a/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.test.ts
+++ b/frontend/src/components/dashboard/MetricsDemoCard/MetricsDemoCard.test.ts
@@ -8,11 +8,13 @@ describe("MetricsDemoCard", () => {
     title: "Test Demo Card",
     items: [
       {
+        id: "test-id-1",
         title: "Test Demo Item 1",
         count: 5,
         percentage: 25,
       },
       {
+        id: "test-id-2",
         title: "Test Demo Item 2",
         count: 15,
         percentage: 75,
@@ -20,16 +22,19 @@ describe("MetricsDemoCard", () => {
     ],
     extraItems: [
       {
+        id: "test-id-3",
         title: "Test Demo Item 3",
         count: 5,
         percentage: 25,
       },
       {
+        id: "test-id-4",
         title: "Test Demo Item 4",
         count: 5,
         percentage: 25,
       },
       {
+        id: "test-id-5",
         title: "Test Demo Item 5",
         count: 5,
         percentage: 25,
@@ -96,6 +101,7 @@ describe("MetricsDemoCard", () => {
       title: testData.title,
       items: [
         {
+          id: "test-long-count",
           title: "Test Demo Item 1",
           count: LONG_COUNT,
           percentage: 100,

--- a/frontend/src/components/screens/ConsultationAnalysis/ConsultationAnalysis.svelte
+++ b/frontend/src/components/screens/ConsultationAnalysis/ConsultationAnalysis.svelte
@@ -67,6 +67,7 @@
         return b.count - a.count; // Descending order by count
       })
       .map((demoOption: DemoOptionsResponseItem) => ({
+        id: demoOption.id,
         title: demoOption.value.replaceAll("'", ""),
         count: demoOption.count,
         percentage: getPercentage(demoOption.count, total),
@@ -84,7 +85,7 @@
       },
       {} as Record<
         string,
-        Array<{ title: string; count: number; percentage: number }>
+        Array<{ id: string; title: string; count: number; percentage: number }>
       >,
     ),
   );


### PR DESCRIPTION
Use demographic option ID as Svelte key instead of title to prevent duplicate key errors when values become identical after apostrophe removal.

Issue: Consultation had demographic values like "can't" and "cant" that became duplicates after .replaceAll("'", ""), causing Svelte error: 'each_key_duplicate'

Solution:
- Add 'id' field to MetricsDemoItem interface
- Pass demographic option ID through data transformation
- Use item.id as key instead of item.title in {#each} blocks

Files modified:
- MetricsDemoCard.svelte: Updated interface and key
- ConsultationAnalysis.svelte: Pass id through calculateCategoryItems
- Metrics.svelte: Pass id in demographic mapping

This ensures unique keys even when display values collide after normalization (apostrophe removal, casing differences, etc.)
