### PR TITLE
deprecated(semantic search): Deprecating semantic search and remove representative search

### DIFF
--- a/backend/consultations/api/filters.py
+++ b/backend/consultations/api/filters.py
@@ -1,5 +1,4 @@
-from django.contrib.postgres.search import SearchQuery, SearchRank
-from django.db.models import Avg, Count, F, StdDev
+from django.db.models import Count
 from django_filters import UUIDFilter
 from django_filters.rest_framework import BaseInFilter, BooleanFilter, FilterSet
 from pgvector.django import CosineDistance
@@ -99,9 +98,7 @@ class UserFilter(FilterSet):
 
 
 class ResponseSearchSerializer(serializers.Serializer):
-    searchMode = serializers.ChoiceField(
-        choices=["keyword", "semantic", "representative"], required=False
-    )
+    searchMode = serializers.ChoiceField(choices=["keyword", "semantic"], required=False)
     searchValue = serializers.CharField(required=False)
 
 
@@ -123,28 +120,5 @@ class ResponseSearchFilter(SearchFilter):
             # distance: exact match = 0, exact opposite = 2
             distance = CosineDistance("embedding", embedded_query)
             return queryset.annotate(distance=distance).order_by("distance")
-        elif search_mode == "representative":
-            embedded_query = embed_text(search_value)
-            # semantic_score: exact match = 1, exact opposite = -1
-            semantic_score = 1 - CosineDistance("embedding", embedded_query)
-
-            search_query = SearchQuery(search_value)
-            search_rank_score = SearchRank(F("search_vector"), search_query, normalization=32)
-
-            hybrid_score = (0.9 * semantic_score) + (0.1 * search_rank_score)
-            responses = queryset.annotate(
-                hybrid_score=hybrid_score, semantic_score=semantic_score
-            ).filter(semantic_score__gte=0.3)
-
-            mean = responses.aggregate(Avg("hybrid_score"))["hybrid_score__avg"]
-            std = responses.aggregate(StdDev("hybrid_score"))["hybrid_score__stddev"]
-            if std is None or std == 0:
-                return responses.order_by("-hybrid_score")
-
-            return (
-                responses.annotate(z_score=(F("hybrid_score") - mean) / std)
-                .filter(z_score__gte=1)
-                .order_by("-z_score")
-            )
         else:
             return queryset

--- a/backend/consultations/api/filters.py
+++ b/backend/consultations/api/filters.py
@@ -98,7 +98,7 @@ class UserFilter(FilterSet):
 
 
 class ResponseSearchSerializer(serializers.Serializer):
-    searchMode = serializers.ChoiceField(choices=["keyword", "semantic"], required=False)
+    searchMode = serializers.ChoiceField(choices=["keyword"], required=False, default="keyword")
     searchValue = serializers.CharField(required=False)
 
 

--- a/backend/data_pipeline/jobs.py
+++ b/backend/data_pipeline/jobs.py
@@ -31,7 +31,6 @@ def import_consultation(
         consultation_code=consultation_code,
         consultation_title=consultation_name,
         user_id=user_id,
-        enqueue_embeddings=True,
     )
 
 

--- a/backend/data_pipeline/sync/consultation_setup.py
+++ b/backend/data_pipeline/sync/consultation_setup.py
@@ -651,7 +651,7 @@ def import_consultation_from_s3(
     consultation_code: str,
     consultation_title: str,
     user_id: UUID,
-    enqueue_embeddings: bool = True,
+    enqueue_embeddings: bool = False,  # Whether to enqueue embedding jobs after import (default False for consultation setup for now)
     batch_size: int = 512,
 ) -> UUID:
     """

--- a/backend/tests/unit/api/test_filters.py
+++ b/backend/tests/unit/api/test_filters.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 from django.conf import settings
 
@@ -16,35 +14,43 @@ def pad_vector(vector):
 
 
 @pytest.mark.django_db
-@patch("consultations.api.filters.embed_text", return_value=pad_vector([1, 0]))
-def test_semantic_search_filter(mock_embed_text, respondent_1, free_text_question):
-    """Test that ResponseSearchFilter orders responses by semantic distance"""
+def test_keyword_search_filter(respondent_1, free_text_question):
+    """Test that ResponseSearchFilter correctly filters responses using keyword search"""
 
-    # Create responses with different embeddings
-    response_close = Response.objects.create(
+    response_with_match = Response.objects.create(
         respondent=respondent_1,
         question=free_text_question,
-        embedding=pad_vector([0.9, 0.436]),  # Close to [1, 0]
+        free_text="This is about climate policy",
     )
 
-    response_far = Response.objects.create(
+    response_without_match = Response.objects.create(
         respondent=respondent_1,
         question=free_text_question,
-        embedding=pad_vector([0.3, 0.954]),  # Far from [1, 0]
+        free_text="This is about other topics",
     )
 
     response_search_filter = ResponseSearchFilter()
 
     class FakeRequest:
-        def __init__(self):
-            self.query_params = {"searchMode": "semantic", "searchValue": "something"}
+        def __init__(self, search_value):
+            self.query_params = {"searchMode": "keyword", "searchValue": search_value}
 
-    queryset = response_search_filter.filter_queryset(FakeRequest(), Response.objects.all(), None)
+    # Test matching keyword
+    queryset = response_search_filter.filter_queryset(
+        FakeRequest("climate"), Response.objects.all(), None
+    )
+    assert queryset.count() == 1
+    assert response_with_match in queryset
+    assert response_without_match not in queryset
 
-    # Semantic search returns all responses ordered by distance
-    results = list(queryset)
-    assert len(results) == 2
+    # Test case-insensitive matching
+    queryset = response_search_filter.filter_queryset(
+        FakeRequest("CLIMATE"), Response.objects.all(), None
+    )
+    assert queryset.count() == 1
 
-    # The closest response should come first
-    assert results[0] == response_close
-    assert results[1] == response_far
+    # Test non-matching keyword
+    queryset = response_search_filter.filter_queryset(
+        FakeRequest("nonexistent"), Response.objects.all(), None
+    )
+    assert queryset.count() == 0

--- a/backend/tests/unit/api/test_filters.py
+++ b/backend/tests/unit/api/test_filters.py
@@ -1,4 +1,3 @@
-import math
 from unittest.mock import patch
 
 import pytest
@@ -18,30 +17,34 @@ def pad_vector(vector):
 
 @pytest.mark.django_db
 @patch("consultations.api.filters.embed_text", return_value=pad_vector([1, 0]))
-@pytest.mark.parametrize("delta, expected", [(+0.0001, True), (-0.0001, False)])
-def test_semantic_threshold_for_response_search_filter(
-    mock_embed_text, respondent_1, respondent_2, free_text_question, delta, expected
-):
-    """we are checking just above and below the semantic-threshold boundary to see that
-    ResponseSearchFilter is correctly filtering the right responses"""
+def test_semantic_search_filter(mock_embed_text, respondent_1, free_text_question):
+    """Test that ResponseSearchFilter orders responses by semantic distance"""
 
-    angle = 0.3 + delta
-
-    # here we construct the vector need to match the semantic-threshold given
-    # that embed_text is mocked to always return the unit vector
-    embedding = pad_vector([angle, math.sqrt(1 - math.pow(angle, 2))])
-
-    Response.objects.create(
+    # Create responses with different embeddings
+    response_close = Response.objects.create(
         respondent=respondent_1,
         question=free_text_question,
-        embedding=embedding,
+        embedding=pad_vector([0.9, 0.436]),  # Close to [1, 0]
+    )
+
+    response_far = Response.objects.create(
+        respondent=respondent_1,
+        question=free_text_question,
+        embedding=pad_vector([0.3, 0.954]),  # Far from [1, 0]
     )
 
     response_search_filter = ResponseSearchFilter()
 
     class FakeRequest:
         def __init__(self):
-            self.query_params = {"searchMode": "representative", "searchValue": "something"}
+            self.query_params = {"searchMode": "semantic", "searchValue": "something"}
 
     queryset = response_search_filter.filter_queryset(FakeRequest(), Response.objects.all(), None)
-    assert queryset.exists() is expected
+
+    # Semantic search returns all responses ordered by distance
+    results = list(queryset)
+    assert len(results) == 2
+
+    # The closest response should come first
+    assert results[0] == response_close
+    assert results[1] == response_far

--- a/backend/tests/unit/api/views/test_response_views.py
+++ b/backend/tests/unit/api/views/test_response_views.py
@@ -820,58 +820,6 @@ class TestResponseViewSet:
             "The local library needs more funding for children's programs",
         ]
 
-    def test_representative_response_search(
-        self, client, staff_user_token, embedded_responses, django_assert_num_queries
-    ):
-        """Test API endpoint returns representative responses for a theme"""
-        url = reverse(
-            "response-list",
-            kwargs={"consultation_pk": embedded_responses["consultation_id"]},
-        )
-        theme_name = "Public Transport"
-        theme_description = "Local councils should invest in public transport infrastructure"
-
-        with patch(
-            "consultations.api.filters.embed_text",
-            return_value=embedded_responses["search_mode"]["representative"]["embedding"],
-        ):
-            """
-            Test for no N+1 queries. Regardless of the number of responses, we expect:
-            - 1 query to get authentication user for permission checking
-            - 1 query to get authentication user for is_flagged annotation
-            - 1 query to count respondents
-            - 1 query to count filtered responses
-            - 1 query to get responses with related data (includes is_read annotation)
-            - 1 query to calculate average hybrid_score across responses
-            - 1 query to calculate standard deviation of hybrid_score across responses
-            - 1 query to prefetch multiple choice answers
-            - 1 query to prefetch demographic data
-            """
-            with django_assert_num_queries(9):
-                response = client.get(
-                    url,
-                    query_params={
-                        "question_id": embedded_responses["question_id"],
-                        "searchMode": "representative",
-                        "searchValue": f"{theme_name} {theme_description}",
-                    },
-                    headers={"Authorization": f"Bearer {staff_user_token}"},
-                )
-
-        assert response.status_code == 200
-
-        # Parse the response
-        data = orjson.loads(response.content)
-
-        assert len(data["all_respondents"]) == 1
-        assert data["respondents_total"] == 5
-        assert data["filtered_total"] == 1
-
-        # Verify which responses are considered representative
-        response_texts = [r["free_text_answer_text"] for r in data["all_respondents"]]
-        assert response_texts == [
-            "The local council should really be investing in public transport infrastructure to help reduce carbon emissions",
-        ]
 
     def test_get_themes_for_response(self, client, staff_user_token, free_text_question):
         """Test API endpoint returns themes for a specific response"""

--- a/backend/tests/unit/api/views/test_response_views.py
+++ b/backend/tests/unit/api/views/test_response_views.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from unittest.mock import patch
 from uuid import uuid4
 
 import orjson
@@ -774,52 +773,6 @@ class TestResponseViewSet:
         respondent = data["all_respondents"][0]
         assert respondent["identifier"] == str(respondent1.identifier)
         assert respondent["free_text_answer_text"] == response1.free_text
-
-    def test_semantic_search(
-        self,
-        client,
-        staff_user_token,
-        embedded_responses,
-    ):
-        """Test API endpoint returns responses in order of semantic similarity"""
-        url = reverse(
-            "response-list",
-            kwargs={"consultation_pk": embedded_responses["consultation_id"]},
-        )
-
-        with patch(
-            "consultations.api.filters.embed_text",
-            return_value=embedded_responses["search_mode"]["semantic"]["embedding"],
-        ):
-            response = client.get(
-                url,
-                query_params={
-                    "question_id": embedded_responses["question_id"],
-                    "searchMode": "semantic",
-                    "searchValue": "public transport",
-                },
-                headers={"Authorization": f"Bearer {staff_user_token}"},
-            )
-
-        assert response.status_code == 200
-
-        # Parse the response
-        data = orjson.loads(response.content)
-
-        assert len(data["all_respondents"]) == 5
-        assert data["respondents_total"] == 5
-        assert data["filtered_total"] == 5
-
-        # Verify order of responses by semantic similarity to searchValue
-        response_texts = [r["free_text_answer_text"] for r in data["all_respondents"]]
-        assert response_texts == [
-            "We need better buses and trains to connect our neighbourhoods",
-            "The local council should really be investing in public transport infrastructure to help reduce carbon emissions",
-            "I drive to work every day and fuel costs are rising rapidly",
-            "Something must be done about bin collections in my area",
-            "The local library needs more funding for children's programs",
-        ]
-
 
     def test_get_themes_for_response(self, client, staff_user_token, free_text_question):
         """Test API endpoint returns themes for a specific response"""

--- a/frontend/scripts/type-errors.json
+++ b/frontend/scripts/type-errors.json
@@ -1,6 +1,6 @@
 {
   "errorCount": 16,
   "warningCount": 11,
-  "lastUpdated": "2026-04-24",
+  "lastUpdated": "2026-04-30",
   "note": "This file tracks the number of type errors in the codebase. CI will fail if the number of errors increase or decrease without updating this file."
 }

--- a/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
+++ b/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
@@ -8,11 +8,8 @@
   import AnswerCard from "../AnswerCard/AnswerCard.svelte";
   import Finance from "../../svg/material/Finance.svelte";
   import FiltersSidebar from "../FiltersSidebar/FiltersSidebar.svelte";
-  import Select from "../../inputs/Select/Select.svelte";
 
   import {
-    SearchModeLabels,
-    SearchModeValues,
     type DemoData,
     type DemoOption,
     type DemoOptionsResponse,
@@ -50,8 +47,6 @@
 
   export let searchValue: string = "";
   export let setSearchValue = (_value: string) => {};
-  export let searchMode: SearchModeValues = SearchModeValues.KEYWORD;
-  export let setSearchMode = (_searchMode: SearchModeValues) => {};
 
   export let demoOptions: DemoOption = {};
   export let demoData: DemoData = {};
@@ -193,24 +188,6 @@
                   hideLabel={true}
                   value={searchValue}
                   setValue={(value: string) => setSearchValue(value.trim())}
-                />
-              </div>
-
-              <div class="w-full sm:w-auto">
-                <Select
-                  id="search_mode"
-                  label="Search Mode"
-                  hideLabel={true}
-                  value={searchMode}
-                  items={[
-                    {
-                      value: SearchModeValues.KEYWORD,
-                      label: SearchModeLabels.KEYWORD,
-                    },
-                  ]}
-                  onchange={(nextValue: string) => {
-                    setSearchMode(nextValue as SearchModeValues);
-                  }}
                 />
               </div>
             </div>

--- a/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
+++ b/frontend/src/components/dashboard/ResponseAnalysis/ResponseAnalysis.svelte
@@ -207,10 +207,6 @@
                       value: SearchModeValues.KEYWORD,
                       label: SearchModeLabels.KEYWORD,
                     },
-                    {
-                      value: SearchModeValues.SEMANTIC,
-                      label: SearchModeLabels.SEMANTIC,
-                    },
                   ]}
                   onchange={(nextValue: string) => {
                     setSearchMode(nextValue as SearchModeValues);

--- a/frontend/src/components/screens/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail.svelte
@@ -389,9 +389,6 @@
         }}
         {searchValue}
         setSearchValue={(value: string) => (searchValue = value)}
-        {searchMode}
-        setSearchMode={(newSearchMode: SearchModeValues) =>
-          (searchMode = newSearchMode)}
         {demoData}
         demoOptions={formattedDemoOptions || {}}
         demoOptionsData={$demographicsStore.data || undefined}


### PR DESCRIPTION
## Context

We want to deprecate this search mode by removing the search mode toggle (always search by keyword) and no longer trigger the `create_embeddings_for_question` jobs when setting up a consultation. We are still keeping the code and the embedding column of the `consultations_reponse` because it's likely we'll want to bring this feature back in the future.

The reason we are deprecating for now is that:

- The `create_embeddings_for_question`  jobs fails intermittently and we don't have the adequate observability in place to be alerted and debug

- Users are not even aware of the semantic search mode so we don't think it's worth investigating how to fix the jobs when it's easier just to deprecate the semantic search mode for now

We have work planned in the future to revisit semantic search, utilising user research findings to design and implement a more intuitive solution for users.

[Ticket](https://linear.app/iai-consult/issue/CON-240/deprecate-semantic-search-and-remove-representative-search) contains the full context

## Changes proposed in this pull request

This PR deprecate the semantic search on the UI and remove the trigger for embedding job during consultation data set up – This will be revisited in the future thus the codebase are not removed instead entry/trigger is blocked This PR also remove the embedding search(representative) mode filter from the backend as its redundant

### Search filter page
<img width="2107" height="1301" alt="Screenshot 2026-04-29 at 17 00 05" src="https://github.com/user-attachments/assets/13bde303-5361-4e8c-8958-1ade737d4df0" />



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
