### PR TITLE
chore(themes level): Update theme level  tag display to render only when there are themes levels

### DIFF
--- a/frontend/src/components/screens/ThemeSignOffDetail/ThemeSignOffDetail.svelte
+++ b/frontend/src/components/screens/ThemeSignOffDetail/ThemeSignOffDetail.svelte
@@ -587,8 +587,8 @@
           </div>
 
           <p class="text-sm text-neutral-500">
-            Browse AI-generated themes organised by topic hierarchy. Click
-            "Select Theme" to add themes to your selected list for analysis.
+            Browse themes found by the AI and click "Select" to add a theme to
+            your list of selected themes for analysis.
           </p>
         </Panel>
       </div>
@@ -597,6 +597,7 @@
         <GeneratedThemeCard
           {consultationId}
           {questionId}
+          {hasNestedThemes}
           {theme}
           {expandedThemes}
           setExpandedThemes={(id) => {

--- a/frontend/src/components/screens/ThemeSignOffDetail/__snapshots__/ThemeSignOffDetail.test.ts.snap
+++ b/frontend/src/components/screens/ThemeSignOffDetail/__snapshots__/ThemeSignOffDetail.test.ts.snap
@@ -488,8 +488,8 @@ exports[`EditUser > should match snapshot after loading 1`] = `
           <p
             class="text-sm text-neutral-500"
           >
-            Browse AI-generated themes organised by topic hierarchy. Click
-            "Select Theme" to add themes to your selected list for analysis.
+            Browse themes found by the AI and click "Select" to add a theme to
+            your list of selected themes for analysis.
           </p>
           <!---->
         </div>
@@ -886,8 +886,8 @@ exports[`EditUser > should match snapshot initially 1`] = `
           <p
             class="text-sm text-neutral-500"
           >
-            Browse AI-generated themes organised by topic hierarchy. Click
-            "Select Theme" to add themes to your selected list for analysis.
+            Browse themes found by the AI and click "Select" to add a theme to
+            your list of selected themes for analysis.
           </p>
           <!---->
         </div>

--- a/frontend/src/components/theme-sign-off/GeneratedThemeCard/GeneratedThemeCard.svelte
+++ b/frontend/src/components/theme-sign-off/GeneratedThemeCard/GeneratedThemeCard.svelte
@@ -31,6 +31,7 @@
     handleSelect: (theme: GeneratedTheme) => void;
     themesBeingSelected: string[];
     maxAnswers?: number;
+    hasNestedThemes?: boolean;
   }
   let {
     consultationId,
@@ -42,6 +43,7 @@
     setExpandedThemes = () => {},
     handleSelect = () => {},
     themesBeingSelected = [],
+    hasNestedThemes = false,
   }: Props = $props();
 
   const answersStore = createFetchStore<CandidateThemeResponsesResponse>();
@@ -90,12 +92,13 @@
 
             <div class="flex flex-wrap items-center gap-2">
               <h3>{theme.name}</h3>
-
-              <div class={clsx([disabled && "grayscale"])}>
-                <Tag variant="success">
-                  Level {level + 1}
-                </Tag>
-              </div>
+              {#if hasNestedThemes}
+                <div class={clsx([disabled && "grayscale"])}>
+                  <Tag variant="success">
+                    Level {level + 1}
+                  </Tag>
+                </div>
+              {/if}
             </div>
           </div>
         </div>
@@ -169,7 +172,6 @@
       {/if}
     </article>
   </Panel>
-
   {#if expanded}
     <div transition:slide class="pt-4">
       {#each theme.children as childTheme (childTheme.id)}
@@ -177,6 +179,7 @@
           {consultationId}
           {questionId}
           theme={childTheme}
+          {hasNestedThemes}
           level={level + 1}
           {handleSelect}
           {themesBeingSelected}

--- a/frontend/src/components/theme-sign-off/GeneratedThemeCard/GeneratedThemeCard.test.ts
+++ b/frontend/src/components/theme-sign-off/GeneratedThemeCard/GeneratedThemeCard.test.ts
@@ -17,6 +17,7 @@ describe("GeneratedThemeCard", () => {
     setExpandedThemes: () => {},
     handleSelect: () => {},
     themesBeingSelected: [],
+    hasNestedThemes: false,
   };
   const answers = ["Answer 1", "Answer 2"];
 
@@ -91,5 +92,37 @@ describe("GeneratedThemeCard", () => {
       "handleSelect",
       "answersMock",
     ]);
+  });
+
+  it("should render level tag only if theme has children", async () => {
+    const CHILD_THEME = {
+      id: "child-theme",
+      name: "Child Theme",
+      description: "This is a child theme",
+    };
+    render(GeneratedThemeCard, {
+      ...testData,
+      hasNestedThemes: true,
+      theme: {
+        ...testData.theme,
+        children: [CHILD_THEME],
+      },
+      expandedThemes: [testData.theme.id],
+    });
+
+    expect(screen.getByText("Level 1")).toBeInTheDocument();
+  });
+
+  it("should not render level tag if theme has no children", async () => {
+    render(GeneratedThemeCard, {
+      ...testData,
+      theme: {
+        ...testData.theme,
+        children: [],
+      },
+      expandedThemes: [testData.theme.id],
+    });
+
+    expect(screen.queryByText("Level 1")).toBeNull();
   });
 });

--- a/frontend/src/components/theme-sign-off/GeneratedThemeCard/__snapshots__/GeneratedThemeCard.test.ts.snap
+++ b/frontend/src/components/theme-sign-off/GeneratedThemeCard/__snapshots__/GeneratedThemeCard.test.ts.snap
@@ -31,17 +31,7 @@ exports[`GeneratedThemeCard > should render 1`] = `
                   Test Theme
                 </h3>
                  
-                <div
-                  class="svelte-2iwj05"
-                >
-                  <div
-                    class="flex justify-between items-center gap-2 rounded-md w-max py-0.5 px-2 text-xs text-secondary bg-teal-50 border border-teal-400"
-                  >
-                    Level 1
-                    <!---->
-                  </div>
-                  <!---->
-                </div>
+                <!---->
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Context

Sometimes the LLM identifies parent and child themes where a level 1 theme is an umbrella theme (e.g., fruits) and level 2 themes are sub-themes (e.g., apples, bananas, pears).

We don't want to display the 'Level 1' tag if there are only level 1 themes because it can be confusing to users what the tag represents.

[Ticket](https://linear.app/iai-consult/issue/CON-239/dont-display-level-1-tag-when-there-are-only-level-1-themes) for more context

## Changes proposed in this pull request

This PR updates the rendering logic to only show the theme level e.g fruits when there are children themes(sub-themes) e.g Mango, Bananas.

This PR also updates the text `"Browse AI-generated themes organised by topic hierarchy. Click "Select Theme" to add themes to your selected list for analysis."`
To 
`"Browse themes found by the AI and click "Select" to add a theme to your list of selected themes for analysis."` to improve clarity in the theme sign off component

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
