### PR TITLE
Monorepo - docs ADR 0007

### DIFF
--- a/docs/architecture/decisions/0007-merge-themefinder-into-consult-as-a-uv-workspace.md
+++ b/docs/architecture/decisions/0007-merge-themefinder-into-consult-as-a-uv-workspace.md
@@ -8,60 +8,43 @@ Proposed
 
 ## Context
 
-ThemeFinder lives in a separate public repository ([i-dot-ai/themefinder](https://github.com/i-dot-ai/themefinder)) and is consumed by consult as a PyPI dependency. In practice, consult is themefinder's only real consumer: the pipeline scripts (`pipeline-sign-off`, `pipeline-mapping`) import its internals directly (`themefinder.llm.OpenAILLM`, `themefinder.models.ThemeNode`, `themefinder.advanced_tasks.theme_clustering_agent.ThemeClusteringAgent`), and the backend depends on it through the same pipelines.
+ThemeFinder lives in a separate public repository ([i-dot-ai/themefinder](https://github.com/i-dot-ai/themefinder)) and is consumed by consult as a PyPI dependency. In practice, consult is themefinder's only real consumer: the backend and both pipeline scripts (`pipeline-sign-off`, `pipeline-mapping`) import its internals directly.
 
-The two-repo split imposes a heavy release ceremony for changes that span both projects. Today, getting a one-line themefinder change into consult requires:
+The two-repo split forces a heavy release dance for any change that spans both projects (edit themefinder → cut a PyPI release → bump pins in consult → rebuild four Docker images), which biases against making themefinder changes in tandem with consult work. It also leaves room for version drift: each Docker image resolves themefinder independently at build time rather than from a shared lock.
 
-1. Edit themefinder, open a PR, get it reviewed and merged
-2. Bump the themefinder version
-3. Cut a PyPI release
-4. Bump the themefinder version pin in consult's `requirements.txt` / `pyproject.toml`
-5. Open a second PR in consult, get it reviewed and merged
-6. Rebuild four Docker images and redeploy
-
-This friction biases against making themefinder changes in tandem with consult work — even when the change is unambiguously needed by consult and has no external consumer who would notice. It also means version drift between the backend and the two pipelines is possible whenever they get rebuilt at different times, since each pulls themefinder transitively rather than from a shared lock.
-
-ThemeFinder is, however, still useful to publish to PyPI for external users (research teams who want to use the library standalone). Any restructuring needs to preserve PyPI publishability and keep public release tags discoverable, even if the canonical development location moves.
-
-A separate planning document captures the full migration mechanics: [`docs/plan-themefinder-monorepo-migration.md`](../../plan-themefinder-monorepo-migration.md).
+ThemeFinder is still useful to publish to PyPI for external users (other government teams, researchers). Any restructuring needs to preserve PyPI publishability and keep release tags discoverable.
 
 ## Decision
 
-We will move themefinder into consult as a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) member, alongside the backend and the two pipelines. Concretely:
+We will move themefinder into consult as a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) member, alongside the backend and the two pipelines.
 
 1. **Single workspace, four packages.** `consult/` becomes a uv workspace whose members are `backend/`, `themefinder/`, `pipeline-sign-off/`, and `pipeline-mapping/`. A single root `pyproject.toml` declares the workspace; a single root `uv.lock` resolves dependencies for all four members together.
-2. **ThemeFinder stays publishable.** Its `pyproject.toml` is preserved unchanged (setuptools build, `[project.optional-dependencies]` extras), so `pip install themefinder` continues to work for external users. Internal consumers (backend, pipelines) reference it through `[tool.uv.sources] themefinder = { workspace = true }`, which uv installs editable.
-3. **Pipelines become workspace members too.** Today both pipelines install with `pip install -r requirements.txt` (a single line: `themefinder>=0.8.2`) and pull their dependency set transitively through themefinder. After migration, each pipeline gets its own `pyproject.toml` enumerating its dependencies explicitly, and its Dockerfile is rewritten as a multi-stage uv build mirroring `backend/Dockerfile`. The pipeline base image bumps from `python:3.11-slim-bullseye` to `python:3.12-slim` to match the workspace Python version.
-4. **Public mirror via subtree sync.** The public `i-dot-ai/themefinder` repo is preserved as a published mirror. A new GitHub Actions workflow in consult runs `git subtree split --prefix=themefinder` and force-pushes to the public repo on every change to `themefinder/**`. The public repo retains its `deploy-pypi.yml` (release-tag triggered) and `deploy-docs.yml`; its `tests.yml`, `eval.yml`, and `pre-commit.yml` are deleted because those checks now run inside consult.
-5. **Migration lands as three PRs.** PR 1 is the atomic core migration (must land in one piece because `build-gh.yml` builds all four Docker images on every push, so a half-migrated state breaks the build). PR 2 ports CI workflows (themefinder tests, evals, merged pre-commit). PR 3 wires up the public-repo sync.
-
-After this lands, the dev loop becomes: edit themefinder → it's immediately available in backend and pipelines → run tests → commit → single PR.
+2. **ThemeFinder stays publishable.** Its `pyproject.toml` is preserved unchanged so `pip install themefinder` continues to work for external users. Internal consumers reference it through `[tool.uv.sources] themefinder = { workspace = true }`, which uv installs editable.
+3. **Pipelines become workspace members.** Today both pipelines pull their dependency set transitively through `themefinder>=0.8.2`. After migration, each pipeline's `pyproject.toml` lists its dependencies explicitly, and its Dockerfile is rewritten as a multi-stage uv build mirroring `backend/Dockerfile`.
+4. **Public mirror via subtree sync.** The public `i-dot-ai/themefinder` repo is preserved as a published mirror. A GitHub Actions workflow in consult runs `git subtree split --prefix=themefinder` and force-pushes to the public repo on every change to `themefinder/**`. The public repo retains `deploy-pypi.yml` and `deploy-docs.yml`; its tests, evals, and pre-commit are deleted because those checks now run inside consult.
 
 ### Alternatives considered
 
-- **Status quo (two repos, PyPI release on every change).** Rejected: the friction is the entire reason for this proposal, and there is no external consumer who benefits from the release cadence currently being a hard gate on internal consult work.
-- **Move themefinder into consult, but keep the pipelines on pip + `requirements.txt`.** This was the original approach (the 2026-04-08 plan). Rejected on the second pass because it leaves two dependency-management tools coexisting in one monorepo, leaves pipeline dependencies unlocked, and means a single themefinder change still requires verifying three different install paths. Going all-in on uv is more work in the migration but eliminates the inconsistency permanently.
-- **Git subtree (instead of a clean copy) when importing themefinder into consult.** Considered for preserving themefinder's commit history inside consult. Rejected because the two histories don't share roots, the import would balloon consult's history, and PyPI release tags can stay attached to the public-repo commits regardless. We use subtree only for the outbound sync.
-- **Archive the public themefinder repo entirely.** Rejected because external users (other government teams, researchers) install from PyPI and may want to read source / file issues against the published version. Keeping a synced mirror is cheap.
+- **Keep the pipelines on `pip install -r requirements.txt`.** Rejected: leaves two dependency-management tools coexisting in one monorepo and pipeline dependencies unlocked.
+- **Git subtree import (preserving themefinder history inside consult).** Rejected: the histories don't share roots, the import would balloon consult's history, and PyPI release tags can stay attached to the public-repo commits regardless. Subtree is used only for the outbound sync.
+- **Archive the public themefinder repo entirely.** Rejected: external users install from PyPI and may want to read source or file issues. Keeping a synced mirror is cheap.
 
 ## Consequences
 
 ### Positive
 
-- **Single-PR cross-cutting changes.** Edits that span themefinder and consult become one review, one merge, one deploy — eliminating the 6-step release dance described in Context.
-- **No more silent version drift.** The four Docker images previously resolved themefinder independently at build time. After migration, a single root `uv.lock` guarantees backend and both pipelines run identical themefinder code.
-- **Faster local dev loop.** uv installs workspace members editable, so a code change in `themefinder/src/` is immediately visible to backend tests and pipeline scripts without any reinstall step.
-- **One CI surface to maintain.** ThemeFinder's tests, evals, and pre-commit checks all move into consult, replacing three separately-evolved workflow sets.
+- **Single-PR cross-cutting changes.** Edits that span themefinder and consult become one review, one merge, one deploy.
+- **No silent version drift.** A single root `uv.lock` guarantees backend and both pipelines run identical themefinder code.
+- **Faster local dev loop.** Workspace members install editable, so a change in `themefinder/src/` is immediately visible to backend tests and pipeline scripts.
+- **One CI surface to maintain.** ThemeFinder's tests, evals, and pre-commit move into consult, replacing three separately-evolved workflow sets.
 
 ### Negative
 
-- **PR 1 is unavoidably large and atomic.** `build-gh.yml` builds four Docker images from repo-root context on every push, so the workspace wiring, all four Dockerfiles, and the Makefile must change in a single PR. Reviewer fatigue is a real risk; we mitigate by splitting CI and sync changes into PRs 2 and 3.
-- **Editable installs require runtime source.** uv's editable install writes a `.pth` file pointing at `themefinder/src/`, so all three Python Docker images must copy `themefinder/src/` and `themefinder/pyproject.toml` into their **runtime** stage, not just the build stage. This is easy to miss and is called out explicitly in the plan.
-- **Public repo history is rewritten on every sync.** `git subtree split` followed by `git push --force` produces a new linear history each time. Existing PyPI release tags remain attached to the commits they were cut from, but new releases land on the rewritten history. Acceptable because the public repo's role shifts from primary development location to published mirror — but this is documented in the public repo README so external contributors know to file PRs against consult.
-- **PyPI release process gets a new step.** Bumping `themefinder/pyproject.toml` no longer suffices on its own — the change has to merge to consult main, wait for the sync workflow, then a release tag is cut on the public repo to fire `deploy-pypi.yml`. The plan documents this; we accept the extra hop because PyPI releases are infrequent compared to internal merges.
-- **Resolution under `exclude-newer = "P14D"` may surface conflicts.** The 14-day index window currently scoped to `backend/pyproject.toml` migrates to the workspace root and now constrains themefinder's pins too. Some themefinder pins (`protobuf==6.33.5`, `cryptography>=46.0.7`) may fall outside the window. If the lock fails, the resolution is a deliberate decision (relax the constraint or upgrade the pin) rather than a silent regression.
-- **Pipeline dependencies must be enumerated explicitly.** Previously transitive through `themefinder>=0.8.2`; now each pipeline's `pyproject.toml` must list `boto3`, `pandas`, `urllib3`, `openai`, `pydantic`, etc. explicitly. A missed import only surfaces at runtime, so the pipeline images need a smoke test before the PR merges.
+- **The migration PR is unavoidably large and atomic.** `build-gh.yml` builds four Docker images from repo-root context on every push, so the workspace wiring, all four Dockerfiles, the Makefile, and the CI workflows must land together.
+- **Editable installs require runtime source.** uv writes a `.pth` file pointing at `themefinder/src/`, so all three Python images must copy `themefinder/src/` and `themefinder/pyproject.toml` into their **runtime** stage, not just the build stage.
+- **Public repo history is rewritten on every sync.** `git subtree split` followed by `git push --force` produces a new linear history each time. Existing PyPI release tags remain attached to their commits, but new releases land on the rewritten history.
+- **PyPI release gains a step.** A version bump must merge to consult main, propagate via the sync workflow, and then a release tag is cut on the public repo to fire `deploy-pypi.yml`.
 
 ### Neutral
 
-- **External users are unaffected.** PyPI installation, README documentation links, and existing release tags continue to work. The only change visible externally is that issues and PRs against the public repo will be redirected to consult.
+- **External users are unaffected.** PyPI installs, README links, and existing release tags continue to work. Issues and PRs against the public repo are redirected to consult.

--- a/docs/architecture/decisions/0007-merge-themefinder-into-consult-as-a-uv-workspace.md
+++ b/docs/architecture/decisions/0007-merge-themefinder-into-consult-as-a-uv-workspace.md
@@ -1,0 +1,67 @@
+# 7. Merge themefinder into consult as a uv workspace
+
+Date: 2026-05-01
+
+## Status
+
+Proposed
+
+## Context
+
+ThemeFinder lives in a separate public repository ([i-dot-ai/themefinder](https://github.com/i-dot-ai/themefinder)) and is consumed by consult as a PyPI dependency. In practice, consult is themefinder's only real consumer: the pipeline scripts (`pipeline-sign-off`, `pipeline-mapping`) import its internals directly (`themefinder.llm.OpenAILLM`, `themefinder.models.ThemeNode`, `themefinder.advanced_tasks.theme_clustering_agent.ThemeClusteringAgent`), and the backend depends on it through the same pipelines.
+
+The two-repo split imposes a heavy release ceremony for changes that span both projects. Today, getting a one-line themefinder change into consult requires:
+
+1. Edit themefinder, open a PR, get it reviewed and merged
+2. Bump the themefinder version
+3. Cut a PyPI release
+4. Bump the themefinder version pin in consult's `requirements.txt` / `pyproject.toml`
+5. Open a second PR in consult, get it reviewed and merged
+6. Rebuild four Docker images and redeploy
+
+This friction biases against making themefinder changes in tandem with consult work — even when the change is unambiguously needed by consult and has no external consumer who would notice. It also means version drift between the backend and the two pipelines is possible whenever they get rebuilt at different times, since each pulls themefinder transitively rather than from a shared lock.
+
+ThemeFinder is, however, still useful to publish to PyPI for external users (research teams who want to use the library standalone). Any restructuring needs to preserve PyPI publishability and keep public release tags discoverable, even if the canonical development location moves.
+
+A separate planning document captures the full migration mechanics: [`docs/plan-themefinder-monorepo-migration.md`](../../plan-themefinder-monorepo-migration.md).
+
+## Decision
+
+We will move themefinder into consult as a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) member, alongside the backend and the two pipelines. Concretely:
+
+1. **Single workspace, four packages.** `consult/` becomes a uv workspace whose members are `backend/`, `themefinder/`, `pipeline-sign-off/`, and `pipeline-mapping/`. A single root `pyproject.toml` declares the workspace; a single root `uv.lock` resolves dependencies for all four members together.
+2. **ThemeFinder stays publishable.** Its `pyproject.toml` is preserved unchanged (setuptools build, `[project.optional-dependencies]` extras), so `pip install themefinder` continues to work for external users. Internal consumers (backend, pipelines) reference it through `[tool.uv.sources] themefinder = { workspace = true }`, which uv installs editable.
+3. **Pipelines become workspace members too.** Today both pipelines install with `pip install -r requirements.txt` (a single line: `themefinder>=0.8.2`) and pull their dependency set transitively through themefinder. After migration, each pipeline gets its own `pyproject.toml` enumerating its dependencies explicitly, and its Dockerfile is rewritten as a multi-stage uv build mirroring `backend/Dockerfile`. The pipeline base image bumps from `python:3.11-slim-bullseye` to `python:3.12-slim` to match the workspace Python version.
+4. **Public mirror via subtree sync.** The public `i-dot-ai/themefinder` repo is preserved as a published mirror. A new GitHub Actions workflow in consult runs `git subtree split --prefix=themefinder` and force-pushes to the public repo on every change to `themefinder/**`. The public repo retains its `deploy-pypi.yml` (release-tag triggered) and `deploy-docs.yml`; its `tests.yml`, `eval.yml`, and `pre-commit.yml` are deleted because those checks now run inside consult.
+5. **Migration lands as three PRs.** PR 1 is the atomic core migration (must land in one piece because `build-gh.yml` builds all four Docker images on every push, so a half-migrated state breaks the build). PR 2 ports CI workflows (themefinder tests, evals, merged pre-commit). PR 3 wires up the public-repo sync.
+
+After this lands, the dev loop becomes: edit themefinder → it's immediately available in backend and pipelines → run tests → commit → single PR.
+
+### Alternatives considered
+
+- **Status quo (two repos, PyPI release on every change).** Rejected: the friction is the entire reason for this proposal, and there is no external consumer who benefits from the release cadence currently being a hard gate on internal consult work.
+- **Move themefinder into consult, but keep the pipelines on pip + `requirements.txt`.** This was the original approach (the 2026-04-08 plan). Rejected on the second pass because it leaves two dependency-management tools coexisting in one monorepo, leaves pipeline dependencies unlocked, and means a single themefinder change still requires verifying three different install paths. Going all-in on uv is more work in the migration but eliminates the inconsistency permanently.
+- **Git subtree (instead of a clean copy) when importing themefinder into consult.** Considered for preserving themefinder's commit history inside consult. Rejected because the two histories don't share roots, the import would balloon consult's history, and PyPI release tags can stay attached to the public-repo commits regardless. We use subtree only for the outbound sync.
+- **Archive the public themefinder repo entirely.** Rejected because external users (other government teams, researchers) install from PyPI and may want to read source / file issues against the published version. Keeping a synced mirror is cheap.
+
+## Consequences
+
+### Positive
+
+- **Single-PR cross-cutting changes.** Edits that span themefinder and consult become one review, one merge, one deploy — eliminating the 6-step release dance described in Context.
+- **No more silent version drift.** The four Docker images previously resolved themefinder independently at build time. After migration, a single root `uv.lock` guarantees backend and both pipelines run identical themefinder code.
+- **Faster local dev loop.** uv installs workspace members editable, so a code change in `themefinder/src/` is immediately visible to backend tests and pipeline scripts without any reinstall step.
+- **One CI surface to maintain.** ThemeFinder's tests, evals, and pre-commit checks all move into consult, replacing three separately-evolved workflow sets.
+
+### Negative
+
+- **PR 1 is unavoidably large and atomic.** `build-gh.yml` builds four Docker images from repo-root context on every push, so the workspace wiring, all four Dockerfiles, and the Makefile must change in a single PR. Reviewer fatigue is a real risk; we mitigate by splitting CI and sync changes into PRs 2 and 3.
+- **Editable installs require runtime source.** uv's editable install writes a `.pth` file pointing at `themefinder/src/`, so all three Python Docker images must copy `themefinder/src/` and `themefinder/pyproject.toml` into their **runtime** stage, not just the build stage. This is easy to miss and is called out explicitly in the plan.
+- **Public repo history is rewritten on every sync.** `git subtree split` followed by `git push --force` produces a new linear history each time. Existing PyPI release tags remain attached to the commits they were cut from, but new releases land on the rewritten history. Acceptable because the public repo's role shifts from primary development location to published mirror — but this is documented in the public repo README so external contributors know to file PRs against consult.
+- **PyPI release process gets a new step.** Bumping `themefinder/pyproject.toml` no longer suffices on its own — the change has to merge to consult main, wait for the sync workflow, then a release tag is cut on the public repo to fire `deploy-pypi.yml`. The plan documents this; we accept the extra hop because PyPI releases are infrequent compared to internal merges.
+- **Resolution under `exclude-newer = "P14D"` may surface conflicts.** The 14-day index window currently scoped to `backend/pyproject.toml` migrates to the workspace root and now constrains themefinder's pins too. Some themefinder pins (`protobuf==6.33.5`, `cryptography>=46.0.7`) may fall outside the window. If the lock fails, the resolution is a deliberate decision (relax the constraint or upgrade the pin) rather than a silent regression.
+- **Pipeline dependencies must be enumerated explicitly.** Previously transitive through `themefinder>=0.8.2`; now each pipeline's `pyproject.toml` must list `boto3`, `pandas`, `urllib3`, `openai`, `pydantic`, etc. explicitly. A missed import only surfaces at runtime, so the pipeline images need a smoke test before the PR merges.
+
+### Neutral
+
+- **External users are unaffected.** PyPI installation, README documentation links, and existing release tags continue to work. The only change visible externally is that issues and PRs against the public repo will be redirected to consult.

--- a/docs/architecture/decisions/0007-merge-themefinder-into-consult-as-a-uv-workspace.md
+++ b/docs/architecture/decisions/0007-merge-themefinder-into-consult-as-a-uv-workspace.md
@@ -12,22 +12,22 @@ ThemeFinder lives in a separate public repository ([i-dot-ai/themefinder](https:
 
 The two-repo split forces a heavy release dance for any change that spans both projects (edit themefinder → cut a PyPI release → bump pins in consult → rebuild four Docker images), which biases against making themefinder changes in tandem with consult work. It also leaves room for version drift: each Docker image resolves themefinder independently at build time rather than from a shared lock.
 
-ThemeFinder is still useful to publish to PyPI for external users (other government teams, researchers). Any restructuring needs to preserve PyPI publishability and keep release tags discoverable.
+ThemeFinder is still useful to publish to PyPI for external users (other government teams, researchers). Any restructuring needs to preserve PyPI publishability and keep historic release tags discoverable.
 
 ## Decision
 
-We will move themefinder into consult as a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) member, alongside the backend and the two pipelines.
+We will move themefinder into consult as a [uv workspace](https://docs.astral.sh/uv/concepts/projects/workspaces/) member, alongside the backend and the two pipelines. The public `i-dot-ai/themefinder` repo will be archived with a redirect notice; PyPI releases will be cut from consult going forward.
 
 1. **Single workspace, four packages.** `consult/` becomes a uv workspace whose members are `backend/`, `themefinder/`, `pipeline-sign-off/`, and `pipeline-mapping/`. A single root `pyproject.toml` declares the workspace; a single root `uv.lock` resolves dependencies for all four members together.
-2. **ThemeFinder stays publishable.** Its `pyproject.toml` is preserved unchanged so `pip install themefinder` continues to work for external users. Internal consumers reference it through `[tool.uv.sources] themefinder = { workspace = true }`, which uv installs editable.
+2. **ThemeFinder stays publishable from consult.** Its `pyproject.toml` is preserved unchanged so `pip install themefinder` continues to work for external users. Internal consumers reference it through `[tool.uv.sources] themefinder = { workspace = true }`, which uv installs editable. A `deploy-pypi.yml` workflow in consult publishes new releases on tag push.
 3. **Pipelines become workspace members.** Today both pipelines pull their dependency set transitively through `themefinder>=0.8.2`. After migration, each pipeline's `pyproject.toml` lists its dependencies explicitly, and its Dockerfile is rewritten as a multi-stage uv build mirroring `backend/Dockerfile`.
-4. **Public mirror via subtree sync.** The public `i-dot-ai/themefinder` repo is preserved as a published mirror. A GitHub Actions workflow in consult runs `git subtree split --prefix=themefinder` and force-pushes to the public repo on every change to `themefinder/**`. The public repo retains `deploy-pypi.yml` and `deploy-docs.yml`; its tests, evals, and pre-commit are deleted because those checks now run inside consult.
+4. **Archive the public repo with a redirect notice.** The public `i-dot-ai/themefinder` repo is archived (read-only). Its README is updated to point to `i-dot-ai/consult` for development, issues, and new releases. Historic source code and PyPI release tags remain browseable on the archive; external users continue to install from PyPI unchanged.
 
 ### Alternatives considered
 
 - **Keep the pipelines on `pip install -r requirements.txt`.** Rejected: leaves two dependency-management tools coexisting in one monorepo and pipeline dependencies unlocked.
-- **Git subtree import (preserving themefinder history inside consult).** Rejected: the histories don't share roots, the import would balloon consult's history, and PyPI release tags can stay attached to the public-repo commits regardless. Subtree is used only for the outbound sync.
-- **Archive the public themefinder repo entirely.** Rejected: external users install from PyPI and may want to read source or file issues. Keeping a synced mirror is cheap.
+- **Git subtree import (preserving themefinder history inside consult).** Rejected: the histories don't share roots, the import would balloon consult's history, and PyPI release tags can stay attached to the public-repo commits regardless.
+- **Public mirror via subtree sync.** Rejected: adds a force-pushing sync workflow and a PAT secret for no practical gain. External users can still read source on the archived repo, file issues against consult, and install from PyPI. Archiving with a redirect notice is the standard pattern for this kind of consolidation (e.g. `googleapis/python-bigquery` → `googleapis/google-cloud-python`).
 
 ## Consequences
 
@@ -42,9 +42,9 @@ We will move themefinder into consult as a [uv workspace](https://docs.astral.sh
 
 - **The migration PR is unavoidably large and atomic.** `build-gh.yml` builds four Docker images from repo-root context on every push, so the workspace wiring, all four Dockerfiles, the Makefile, and the CI workflows must land together.
 - **Editable installs require runtime source.** uv writes a `.pth` file pointing at `themefinder/src/`, so all three Python images must copy `themefinder/src/` and `themefinder/pyproject.toml` into their **runtime** stage, not just the build stage.
-- **Public repo history is rewritten on every sync.** `git subtree split` followed by `git push --force` produces a new linear history each time. Existing PyPI release tags remain attached to their commits, but new releases land on the rewritten history.
-- **PyPI release gains a step.** A version bump must merge to consult main, propagate via the sync workflow, and then a release tag is cut on the public repo to fire `deploy-pypi.yml`.
+- **Future themefinder source history lives only in consult.** Once the public repo is archived, new commits to `themefinder/` are only visible inside consult. Pre-archive history and release tags remain readable on the archived repo.
 
 ### Neutral
 
-- **External users are unaffected.** PyPI installs, README links, and existing release tags continue to work. Issues and PRs against the public repo are redirected to consult.
+- **External users are unaffected at install time.** `pip install themefinder` continues to work; the package is published from consult to the same PyPI project. Issues and PRs are redirected to consult via the archived repo's README.
+- **PyPI release process moves to consult.** Bump `themefinder/pyproject.toml`, merge, tag the release in consult; `deploy-pypi.yml` publishes. One repo, one release flow.

--- a/docs/plan-themefinder-monorepo-migration.md
+++ b/docs/plan-themefinder-monorepo-migration.md
@@ -1,0 +1,383 @@
+# Plan: Move ThemeFinder into Consult as a Monorepo
+
+> **Updated 2026-04-30.** This supersedes the original 2026-04-08 plan. The shape of the migration (uv workspace, 3 PRs, subtree sync to public repo) is unchanged. The deltas are in the **Changes since original plan** section at the bottom — read those first if you've seen the prior version.
+
+## Context
+
+Today, getting a themefinder change into consult requires: edit themefinder → bump version → merge → PyPI release → update version pins in consult → rebuild Docker images → deploy. Two repos, two PRs, a PyPI release, and four Docker builds for what might be a one-line prompt change.
+
+The two projects are tightly coupled — consult's pipeline scripts import themefinder internals (`themefinder.llm.OpenAILLM`, `themefinder.models.ThemeNode`, `themefinder.advanced_tasks.theme_clustering_agent`), and themefinder is effectively a private library with one real consumer. Moving themefinder into consult as a uv workspace member eliminates the release ceremony while keeping it publishable to PyPI for external users.
+
+**After this migration, the dev loop becomes:** edit themefinder → it's immediately available in backend and pipelines → run tests → commit → single PR.
+
+## Snapshot of current state (2026-04-30)
+
+- **consult** main: `0c4e78f86`. No root `pyproject.toml` / `uv.lock`. Backend uses `[dependency-groups]` (PEP 735) for dev deps. `requires-python = ">=3.12,<3.13"`. `[tool.uv] exclude-newer = "P14D"`. Dockerfiles for `backend`, `pipeline-sign-off`, `pipeline-mapping` all build from repo-root context. `build-gh.yml` builds all 4 services (`pipeline-mapping,pipeline-sign-off,backend,frontend`) on every push.
+- **themefinder** main: `312510d`. `requires-python = ">=3.10,<3.13"`. Uses `[project.optional-dependencies] dev = [...]` and `docs = [...]` (PEP 621 extras), not `[dependency-groups]`. Has its own `uv.lock` and `.python-version` (3.12). New top-level file `setup_consultation.py` (a CLI tool, in coverage omit). Pre-commit includes ruff + ruff-format (newer than consult's pre-commit config).
+- Both pipeline scripts still import themefinder internals (`themefinder.llm.OpenAILLM`, `themefinder.models.ThemeNode`, `themefinder.advanced_tasks.theme_clustering_agent.ThemeClusteringAgent`, plus the `rule_*_slack` functions and the `theme_*` async functions).
+- Pipeline `requirements.txt` files contain a single line: `themefinder>=0.8.2`; pipelines currently install with `pip install -r requirements.txt` and use `python:3.11-slim-bullseye`. After migration, the pipelines become **uv workspace members** alongside `backend` and `themefinder`, with their own `pyproject.toml`. The `requirements.txt` files are deleted.
+
+## Target Directory Structure
+
+```
+consult/
+├── pyproject.toml              ← NEW: root workspace config (uv workspace only, not a package)
+├── uv.lock                     ← NEW: single lockfile for the whole workspace
+├── .python-version             ← NEW: 3.12 (matches both backend and themefinder constraints)
+├── Makefile
+├── docker-compose.yml
+├── Procfile.dev
+├── backend/
+│   ├── pyproject.toml          ← MODIFIED: themefinder as workspace dependency
+│   ├── Dockerfile              ← MODIFIED: copy workspace + themefinder into build AND runtime stages
+│   └── ...
+├── frontend/
+├── themefinder/                ← NEW: copied (not subtree) from public repo
+│   ├── pyproject.toml          ← KEPT: unchanged (still publishable to PyPI; setuptools build, [project.optional-dependencies])
+│   ├── src/themefinder/
+│   ├── tests/
+│   ├── evals/
+│   ├── docs/
+│   ├── examples/
+│   ├── setup_consultation.py   ← KEPT: themefinder CLI tool
+│   ├── Makefile                ← KEPT (renamed targets handled in PR1: see Phase 3)
+│   └── ...
+├── pipeline-sign-off/
+│   ├── pyproject.toml          ← NEW: workspace member; deps + themefinder = workspace
+│   ├── Dockerfile              ← REWRITTEN: uv-based, multi-stage, mirrors backend
+│   ├── find_themes_script.py
+│   └── requirements.txt        ← DELETED
+├── pipeline-mapping/
+│   ├── pyproject.toml          ← NEW: workspace member; deps + themefinder = workspace
+│   ├── Dockerfile              ← REWRITTEN: uv-based, multi-stage, mirrors backend
+│   ├── assign_themes_script.py
+│   └── requirements.txt        ← DELETED
+└── .github/workflows/
+    ├── themefinder-ci.yml      ← NEW: tests + 95% coverage
+    ├── themefinder-eval.yml    ← NEW: LLM evals (moved from public repo)
+    ├── sync-themefinder.yml    ← NEW: auto-push subtree to public repo
+    ├── backend-ci.yml          ← MODIFIED: also trigger on themefinder/** changes; sync from root
+    └── ... (existing workflows unchanged)
+```
+
+## PR Structure
+
+The migration is split into 3 PRs. Phases 1–3 must land together because `build-gh.yml` builds all 4 images on every push — a half-migrated state breaks builds.
+
+| PR | Phases | What | Can merge independently? |
+|---|---|---|---|
+| **PR 1** | 1 + 2 + 3 | Core migration: copy themefinder, workspace config, Dockerfiles, Makefile | Atomic: must land as one |
+| **PR 2** | 4 | CI: themefinder-ci.yml, themefinder-eval.yml, backend-ci.yml triggers, merged pre-commit | After PR 1 |
+| **PR 3** | 5 | Public repo sync: sync workflow + token + README updates | After PR 1 |
+
+## Implementation Checklist
+
+### PR 1: Core Migration
+
+#### Phase 1: Copy and wire up the workspace
+
+- [ ] Copy themefinder repo contents into `consult/themefinder/` (exclude `.git/`, `.github/`). Keep themefinder's `pyproject.toml`, `Makefile`, `mkdocs.yml`, `setup_consultation.py`, `.python-version`, `.adr-dir`, README/LICENCE.
+- [ ] Delete themefinder's `uv.lock` from the copied subdir (workspace uses one root lockfile).
+- [ ] Create root `consult/pyproject.toml` as workspace-only (no `[project]`, just workspace config):
+  ```toml
+  [tool.uv.workspace]
+  members = ["backend", "themefinder", "pipeline-sign-off", "pipeline-mapping"]
+
+  [tool.uv]
+  exclude-newer = "P14D"
+  ```
+- [ ] Create root `consult/.python-version` containing `3.12`.
+- [ ] Update `backend/pyproject.toml` — declare workspace source for themefinder:
+  ```toml
+  [tool.uv.sources]
+  themefinder = { workspace = true }
+  ```
+  Remove `[tool.uv] exclude-newer = "P14D"` from `backend/pyproject.toml` (now lives at root).
+- [ ] Delete `backend/uv.lock`.
+- [ ] **Create `pipeline-sign-off/pyproject.toml`** as a workspace member. Deps inferred from `find_themes_script.py` imports (`themefinder`, `boto3`, `pandas`, `urllib3`, `openai`, `pydantic`):
+  ```toml
+  [project]
+  name = "pipeline-sign-off"
+  version = "0.1.0"
+  requires-python = ">=3.12,<3.13"
+  dependencies = [
+    "themefinder",
+    "boto3>=1.42.17",
+    "pandas>=2.2.2",
+    "urllib3>=2.0.0",
+    "openai>=2.14.0",
+    "pydantic>=2.12.5",
+  ]
+
+  [tool.uv.sources]
+  themefinder = { workspace = true }
+
+  [build-system]
+  requires = ["hatchling"]
+  build-backend = "hatchling.build"
+
+  [tool.hatch.build.targets.wheel]
+  only-include = ["find_themes_script.py"]
+  ```
+  *Note: pin versions to whatever resolves cleanly under root `exclude-newer = "P14D"`. The build-system entry exists so uv can install the package editable; `only-include` keeps the wheel minimal.*
+- [ ] **Create `pipeline-mapping/pyproject.toml`** with the same shape but `name = "pipeline-mapping"` and deps inferred from `assign_themes_script.py` imports (subset: themefinder, boto3, pandas, urllib3 — verify before pinning).
+- [ ] Delete `pipeline-sign-off/requirements.txt` and `pipeline-mapping/requirements.txt`.
+- [ ] Run `uv lock` from repo root to generate `consult/uv.lock`. Then `uv sync --all-packages --all-extras --group dev` to install everything (all 4 workspace members + themefinder's `dev`/`docs` extras + backend's `dev` group).
+- [ ] Verify resolution didn't break under `exclude-newer = "P14D"`. If themefinder needs an older pin not within the 14-day window, raise to root (decision required: relax constraint or upgrade pin).
+- [ ] Verify: `uv run python -c "from themefinder.models import ThemeNode; print('ok')"`.
+- [ ] Verify: `make test-backend` passes from repo root.
+
+#### Phase 2: Update Dockerfiles
+
+The build context for all 4 images is the repo root (set in `build-gh.yml` via `i-dot-ai-core-github-actions/build-docker.yml`). Workspace members install editable, so **themefinder source must be present in the runtime image too** — not just at build time — because the venv contains a `.pth` file pointing at `/src/themefinder/src`.
+
+**`backend/Dockerfile`** — both stages need workspace + themefinder source:
+- [ ] `uv-packages` stage (currently `WORKDIR /src/backend; COPY ./backend/pyproject.toml ./backend/uv.lock ./`): replace with workspace-aware copy:
+  ```dockerfile
+  WORKDIR /src
+  COPY pyproject.toml uv.lock .python-version ./
+  COPY themefinder/pyproject.toml ./themefinder/
+  COPY themefinder/src/ ./themefinder/src/
+  COPY backend/pyproject.toml ./backend/
+  WORKDIR /src/backend
+  ENV UV_PROJECT_ENVIRONMENT=venv
+  RUN uv sync --frozen --no-install-project
+  ```
+- [ ] Runtime stage (currently `COPY ./backend ./backend` and `COPY --from=uv-packages /src/backend/venv ./backend/venv`): also copy themefinder pyproject + src so editable install resolves at runtime:
+  ```dockerfile
+  WORKDIR /src
+  COPY ./backend ./backend
+  COPY ./themefinder/pyproject.toml ./themefinder/
+  COPY ./themefinder/src ./themefinder/src
+  COPY --from=uv-packages /src/backend/venv ./backend/venv
+  ```
+
+**`pipeline-sign-off/Dockerfile`** and **`pipeline-mapping/Dockerfile`** — rewrite as multi-stage uv-based builds, mirroring `backend/Dockerfile`. Bumps base image from `python:3.11-slim-bullseye` to `python:3.12-slim` (workspace lock targets 3.12). Editable install applies here too — runtime stage must include workspace root + themefinder source + the pipeline's own pyproject:
+  ```dockerfile
+  # uv-packages stage: build the venv
+  FROM public.ecr.aws/docker/library/python:3.12-slim AS uv-packages
+
+  COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+  WORKDIR /src
+  COPY pyproject.toml uv.lock .python-version ./
+  COPY themefinder/pyproject.toml ./themefinder/
+  COPY themefinder/src/ ./themefinder/src/
+  COPY pipeline-sign-off/pyproject.toml ./pipeline-sign-off/
+  COPY pipeline-sign-off/find_themes_script.py ./pipeline-sign-off/
+
+  WORKDIR /src/pipeline-sign-off
+  ENV UV_PROJECT_ENVIRONMENT=venv
+  RUN uv sync --frozen --package pipeline-sign-off
+
+  # runtime stage
+  FROM public.ecr.aws/docker/library/python:3.12-slim
+
+  RUN groupadd --system nonroot && useradd --system --gid nonroot nonroot
+
+  WORKDIR /src
+  COPY ./pipeline-sign-off ./pipeline-sign-off
+  COPY ./themefinder/pyproject.toml ./themefinder/
+  COPY ./themefinder/src ./themefinder/src
+  COPY --from=uv-packages /src/pipeline-sign-off/venv ./pipeline-sign-off/venv
+
+  RUN chown -R nonroot:nonroot /src
+
+  WORKDIR /src/pipeline-sign-off
+  USER nonroot
+  ENV PATH="/src/pipeline-sign-off/venv/bin:$PATH"
+  ENTRYPOINT ["python", "find_themes_script.py"]
+  ```
+- [ ] `pipeline-mapping/Dockerfile` follows the same pattern with `pipeline-mapping` and `assign_themes_script.py` substituted throughout.
+- [ ] Delete `pipeline-sign-off/requirements.txt` and `pipeline-mapping/requirements.txt`.
+
+**`.dockerignore`** — exclude themefinder paths not needed at runtime:
+- [ ] Add lines: `themefinder/evals/`, `themefinder/docs/`, `themefinder/tests/`, `themefinder/examples/`, `themefinder/setup_consultation.py`.
+
+**Verification:**
+- [ ] `make docker_build_local service=backend` succeeds.
+- [ ] `make docker_build_local service=pipeline-sign-off` succeeds.
+- [ ] `make docker_build_local service=pipeline-mapping` succeeds.
+- [ ] Run a built backend image and verify Django boots.
+- [ ] Run pipeline images with `--help` flag (or equivalent dry-run) to confirm imports resolve.
+
+#### Phase 3: Update Makefile and local dev
+
+- [ ] Change `make install` from `cd backend && uv sync` to `uv sync --all-packages --all-extras --group dev` (run from repo root). One command now installs backend, themefinder, and both pipelines.
+- [ ] Update `make test-backend`: drop `cd backend && PYTHONPATH=..` if root-level `uv run` works (the workspace lets `uv run pytest --rootdir=backend backend/tests/` resolve from root). If tests rely on `PYTHONPATH=..`, leave the cd in place and use `cd backend && uv run pytest tests/ --random-order`.
+- [ ] Add `make test-themefinder` target: `uv run --package themefinder pytest themefinder/tests/ -v`.
+- [ ] Add `make test-all` target combining backend, frontend, and themefinder.
+- [ ] Add `make run-evals` target: `cd themefinder/evals && uv run python benchmark.py --quick`.
+- [ ] Optional: add `make run-pipeline-sign-off` / `make run-pipeline-mapping` targets that exercise each script via `uv run --package pipeline-sign-off python find_themes_script.py --help` (sanity check that workspace wiring works locally).
+- [ ] Update `check-python-code` / `format-python-code` if you want them to also lint themefinder + pipelines (decision required — see Risks).
+- [ ] Verify: `make serve` boots cleanly with workspace install.
+- [ ] Verify: `make test-themefinder` passes.
+
+### PR 2: CI Migration
+
+#### `themefinder-ci.yml` (new)
+
+Mirrors the current `themefinder/.github/workflows/tests.yml` but path-scoped:
+- [ ] Triggers: `pull_request` and `push: branches: [main]` with `paths: ['themefinder/**', '.github/workflows/themefinder-ci.yml']`.
+- [ ] Matrix: `python-version: ['3.10', '3.11', '3.12']` — themefinder still publishes to PyPI for those versions, so we keep matrix coverage.
+- [ ] `astral-sh/setup-uv` pinned to the same SHA themefinder uses (`08807647e7069bb48b6ef5acd8ec9567f424441b`).
+- [ ] `uv sync --package themefinder --extra dev --extra docs` (or `--all-extras --package themefinder`).
+- [ ] `uv run --package themefinder coverage run -m pytest -v -s` (cwd = `themefinder/`).
+- [ ] `uv run --package themefinder coverage report -m --fail-under=95`.
+
+#### `themefinder-eval.yml` (new)
+
+Port of the public repo's `eval.yml`. Self-hosted EC2 runner via `i-dot-ai/i-dot-ai-core-github-actions` — these secrets already exist in the consult repo (used by `build-gh.yml`):
+- [ ] Trigger paths: `themefinder/evals/**`, `themefinder/src/themefinder/**`, `.github/workflows/themefinder-eval.yml`.
+- [ ] `workflow_dispatch` inputs: `dataset` (string, default `gambling_XS`) and `eval_type` (choice: generation/mapping/condensation/refinement/all, default `generation`).
+- [ ] Update working dir to `themefinder/evals` instead of `evals`.
+- [ ] Update install step to `uv sync --package themefinder --extra dev` (or whatever ends up needed).
+
+**Secrets needed in consult (only add if not already present):**
+
+| Secret | Already in consult? | Notes |
+|---|---|---|
+| `AWS_GITHUBRUNNER_USER_ACCESS_KEY` | ✅ | Used by `build-gh.yml` |
+| `AWS_GITHUBRUNNER_USER_SECRET_ID` | ✅ | Used by `build-gh.yml` |
+| `AWS_GITHUBRUNNER_PAT` | ✅ | Used by `build-gh.yml` |
+| `AWS_REGION` | ✅ | Used by `build-gh.yml` |
+| `AWS_ACCOUNT_ID` | ✅ | Used by `build-gh.yml` |
+| `AZURE_OPENAI_ENDPOINT` | ❌ copy from themefinder | |
+| `AZURE_OPENAI_API_KEY` | ❌ | |
+| `AZURE_OPENAI_API_VERSION` | ❌ | |
+| `LLM_GATEWAY_URL` | ❌ | |
+| `CONSULT_EVAL_LITELLM_API_KEY` | ❌ | |
+| `LOCAI_ENDPOINT` | ❌ | |
+| `LOCAI_API_KEY` | ❌ | |
+| `AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT` | ❌ | |
+| `LANGFUSE_SECRET_KEY` | ❌ | |
+| `LANGFUSE_PUBLIC_KEY` | ❌ | |
+| `LANGFUSE_BASE_URL` | ❌ | |
+| `THEMEFINDER_S3_BUCKET_NAME` | ❌ | |
+| `HF_TOKEN` | ❌ | **New** since original plan — used by sentence-transformers |
+| `SLACK_WEBHOOK_URL` | Check (consult may already have one) | If consult already has a different webhook, keep two distinct secret names |
+
+- [ ] Create a GitHub `eval` environment in the consult repo to scope these secrets, mirroring themefinder's setup.
+
+#### `backend-ci.yml` (modified)
+
+- [ ] Add `themefinder/**` and `pyproject.toml` and `uv.lock` to trigger paths (so backend CI re-runs when shared deps change).
+- [ ] Change `uv sync --all-extras` (cwd backend) → `uv sync --all-packages --all-extras --group dev` from root, or `uv sync --package consult --all-extras --group dev` from root.
+- [ ] Verify backend CI step `uv run python manage.py migrate` still works with workspace venv path.
+
+#### Pre-commit merge
+
+Consult's `.pre-commit-config.yaml` and themefinder's differ in versions, hook set, and exclude patterns. Merged config:
+
+- [ ] Bump `pre-commit-hooks` to `v6.0.0` (themefinder's version; superset).
+- [ ] Bump `detect-secrets` to `v1.5.0`. Combine excludes: `(uv.lock|.env.example|.env.test|^.github/workflows/|\.cruft\.json)` (themefinder used `poetry.lock`; replace with `uv.lock` since the monorepo uses uv).
+- [ ] Keep `bandit` (consult-only, scoped `^backend/.*\.py$`).
+- [ ] Keep `mypy` (consult-only — themefinder doesn't use it).
+- [ ] Add `ruff` + `ruff-format` from themefinder, **scoped to `^themefinder/`** so we don't surprise the consult team by enforcing ruff format on backend code (consult currently runs ruff via the Makefile, not pre-commit). Decision required: do we want ruff at root scope eventually? Captured as a follow-up.
+- [ ] Bump `nbstripout` to `0.9.1`.
+- [ ] Keep the local `detect-ip` and `detect-aws-account` hooks.
+- [ ] `run_precommit.yml` already uses `python-version-file: 'backend/pyproject.toml'`. That's fine, no change needed.
+
+### PR 3: Public Repo Sync
+
+- [ ] Create `.github/workflows/sync-themefinder.yml`:
+  ```yaml
+  name: Sync themefinder to public repo
+  on:
+    push:
+      branches: [main]
+      paths: ['themefinder/**']
+  jobs:
+    sync:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v6
+          with:
+            fetch-depth: 0
+        - name: Push themefinder subtree to public repo
+          run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git remote add themefinder https://x-access-token:${{ secrets.THEMEFINDER_PUSH_TOKEN }}@github.com/i-dot-ai/themefinder.git
+            git subtree split --prefix=themefinder -b themefinder-sync
+            git push themefinder themefinder-sync:main --force
+  ```
+- [ ] Create `THEMEFINDER_PUSH_TOKEN` secret in consult repo (GitHub PAT with push access to `i-dot-ai/themefinder`).
+- [ ] In the public `i-dot-ai/themefinder` repo: keep `deploy-pypi.yml` (release-tag triggered) and `deploy-docs.yml` (push-to-main triggered, fires automatically after each sync). **Delete `tests.yml`, `eval.yml`, `pre-commit.yml` from the public repo** to avoid duplicate work — those run in consult now.
+- [ ] Update public repo README: development happens in `i-dot-ai/consult`; this repo is a published mirror. Issues + PyPI releases still happen here.
+- [ ] Verify: merge a no-op `themefinder/` change to consult main; confirm it appears in public repo and `deploy-docs.yml` succeeds.
+- [ ] Document the PyPI release process in consult `docs/`: bump version in `consult/themefinder/pyproject.toml` → merge to main → wait for sync → create release on public repo with tag matching version → `deploy-pypi.yml` fires.
+
+## Workflow Locations After Migration
+
+| Workflow | Location | Trigger |
+|---|---|---|
+| ThemeFinder tests + coverage | consult repo | PR/push touching `themefinder/**` |
+| ThemeFinder evals | consult repo | PR touching `themefinder/{evals,src}/**`, manual dispatch |
+| Backend tests | consult repo (existing) | PR/push touching `backend/**`, `themefinder/**`, `pyproject.toml`, `uv.lock` |
+| Pre-commit | consult repo (existing, with merged config) | PR/push to main |
+| Docker builds (4 images) | consult repo (existing) | Every push |
+| Auto-sync to public repo | consult repo | Push to main touching `themefinder/**` |
+| Docs deploy | public themefinder repo (kept) | Push to main (fires after auto-sync) |
+| PyPI publish | public themefinder repo (kept) | Release tag (manual) |
+
+## Risks and Mitigations
+
+1. **PEP 621 extras vs PEP 735 groups inconsistency.** Themefinder uses `[project.optional-dependencies]` (so `dev`/`docs` are part of the published wheel's metadata — this is a feature, since PyPI users can `pip install themefinder[dev]`). Consult uses `[dependency-groups]` (PEP 735, not published). Workspace install needs both: `uv sync --all-packages --all-extras --group dev`. Verified that `uv` resolves this correctly. *Don't* convert themefinder to dependency-groups — it would break PyPI users.
+
+2. **Editable install at runtime in Docker.** uv installs workspace members editable; the venv has a `.pth` file pointing at `/src/themefinder/src`. **All three Python images** (`backend`, `pipeline-sign-off`, `pipeline-mapping`) must therefore copy `themefinder/src/` and `themefinder/pyproject.toml` into the runtime stage, not just the venv. The original plan only updated the `uv-packages` stage — easy to miss. Phase 2 above calls this out for each Dockerfile.
+
+3. **`exclude-newer = "P14D"` may break themefinder resolution.** Some themefinder pins (e.g. `protobuf==6.33.5`, `cryptography>=46.0.7`) might fall outside a 14-day window if the workspace lock is regenerated against fresh indexes. Mitigation: when Phase 1 lock fails, raise `exclude-newer` or pin the affected dep. Decision should be deliberate (the constraint exists for supply-chain reasons).
+
+4. **Pre-commit version conflicts.** Themefinder uses newer hook revs (pre-commit-hooks v6.0.0, detect-secrets v1.5.0, nbstripout 0.9.1) than consult (v4.4.0, v1.4.0, 0.7.1). Bumping to themefinder's revs is the path of least resistance but could surface new lint errors in consult code — run pre-commit on the merged config locally before opening PR 2.
+
+5. **Ruff scoping.** Themefinder's pre-commit runs ruff project-wide; consult deliberately runs ruff only via the Makefile. PR 2 scopes the ruff hooks to `^themefinder/` to avoid changing consult's lint policy in a CI PR. A follow-up decision: do we want ruff at root scope?
+
+6. **Subtree force-push rewrites public repo history.** Each sync is `git subtree split` then `git push --force`. PyPI release tags stay attached to the commits they were cut from, but new releases land on a new history. Acceptable because development now happens in consult; document this in the public repo README.
+
+7. **Eval workflow secret duplication.** Many secrets need copying from themefinder repo to consult. Use a GitHub `eval` environment in consult to scope them (matching themefinder's setup). Some AWS_* secrets already exist in consult — reuse, don't duplicate.
+
+8. **Build context size.** Adding `themefinder/` to the Docker build context inflates context size for backend + 2 pipeline images. `.dockerignore` excludes evals/docs/tests/examples/setup_consultation.py from production builds.
+
+9. **`setup_consultation.py` retention.** This file lives at themefinder repo root and is referenced by themefinder's Makefile target and coverage omit. After move, it sits at `themefinder/setup_consultation.py` — both relative paths still work because they're resolved from `themefinder/` cwd. No code change needed; just don't drop the file during the copy.
+
+10. **Backend tests' `PYTHONPATH=..` dependency.** Consult's `Makefile` runs backend pytest as `cd backend && PYTHONPATH=.. uv run pytest tests/`. The `PYTHONPATH=..` exists for a reason (likely to expose top-level packages like `lambda/` or imports across the repo). Don't drop this without checking — verify in Phase 3.
+
+11. **Pipelines becoming workspace members is a structural change.** Pipelines previously had no `pyproject.toml` and pulled their dep set transitively through `themefinder>=0.8.2`. After migration each pipeline declares its own deps explicitly, locked under the root `uv.lock`. Implications: (a) version drift between backend and pipelines can no longer happen silently — a single resolution must satisfy all four packages, which is the point but may surface conflicts on Phase 1 lock; (b) the inferred dep list (`boto3`, `pandas`, `urllib3`, `openai`, `pydantic`) must be verified against `find_themes_script.py` and `assign_themes_script.py` imports — a missed import will only surface at runtime. (c) Bumps base image from `python:3.11-slim-bullseye` to `python:3.12-slim` to match the workspace lock; smoke-test the built images against AWS Lambda / ECR target environment before merging.
+
+## Changes since the original plan (2026-04-08 → 2026-04-30)
+
+The 3-PR shape and the workspace approach are unchanged. Concrete deltas:
+
+**Themefinder has moved on:**
+- Added explicit deps: `tenacity>=8.0.0`, `tiktoken>=0.5.0`. Pinned `protobuf==6.33.5`. Bumped `cryptography>=46.0.7` (security).
+- New top-level file `setup_consultation.py` (a CLI tool used by themefinder consumers; in coverage omit). Plan now calls out preserving this in the copy step.
+- Themefinder pre-commit gained `ruff` + `ruff-format` and bumped hook revs. Original plan said "merge detect-secrets and nbstripout"; the actual merge is larger and ruff scoping is a new decision point.
+- Removed `requirements*.txt` files from themefinder; uses `uv` exclusively. (Doesn't change the migration but means there's no "unify requirements" step.)
+- Removed `langchain` from evals (uses OpenAI SDK directly). Smaller eval dep tree, but no plan-level change.
+- `eval.yml` workflow added a new `HF_TOKEN` secret (sentence-transformers download). Added to the secret-copy list above.
+- `setup-uv` now pinned to a specific SHA (`08807647...`). PR 2 should match.
+- `.python-version` is `3.12`; matches what we'll set at consult root.
+- Coverage gate on themefinder is `--fail-under=95` (already in original plan, confirmed unchanged).
+
+**Consult-side state to be aware of:**
+- Backend CI uses `uv sync --all-extras` from `./backend`. Plan now specifies the workspace-aware replacement.
+- `[tool.uv] exclude-newer = "P14D"` exists at backend pyproject and needs to migrate to root pyproject. Documented as risk #3.
+- `build-gh.yml` builds 4 services from repo-root context — confirms PR 1 must be atomic. Unchanged from original plan.
+- `run_precommit.yml` reads python version from `backend/pyproject.toml`; that file remains so no change needed.
+
+**Departure from the original plan: pipelines now use uv too.**
+- Original plan kept the pipelines on `pip install -r requirements.txt` and added a single `pip install ./themefinder` line. That left two dependency-management tools (pip + uv) in the same monorepo and meant pipeline deps were unlocked.
+- New approach (this revision): both pipelines become **uv workspace members** with their own `pyproject.toml`. `requirements.txt` files are **deleted entirely**. Dockerfiles are rewritten as multi-stage uv builds mirroring `backend/Dockerfile`. One `uv.lock` covers all four images. Bumps pipeline base image from `python:3.11-slim-bullseye` to `python:3.12-slim` to match the workspace's resolved Python.
+- New risk surfaced by this change: pipeline imports must be enumerated explicitly in each pipeline's `pyproject.toml` (see risk #11). Previously they were inherited transitively through themefinder.
+
+**New risks documented:**
+- Editable install runtime requirement (risk #2).
+- `exclude-newer` may force pin renegotiation (risk #3).
+- Ruff scoping decision (risk #5).
+- PEP 621 vs PEP 735 install-flag specifics (risk #1).
+- Pipelines as workspace members + base image bump (risk #11).
+
+**Trimmed from original plan:**
+- "Remove themefinder>=0.8.2 from requirements.txt" — superseded; `requirements.txt` files are deleted outright.
+- Original plan listed pre-commit merge as a one-liner; now expanded with concrete version + scope decisions.

--- a/docs/plan-themefinder-monorepo-migration.md
+++ b/docs/plan-themefinder-monorepo-migration.md
@@ -1,6 +1,6 @@
 # Plan: Move ThemeFinder into Consult as a Monorepo
 
-> **Updated 2026-04-30.** This supersedes the original 2026-04-08 plan. The shape of the migration (uv workspace, 3 PRs, subtree sync to public repo) is unchanged. The deltas are in the **Changes since original plan** section at the bottom — read those first if you've seen the prior version.
+> **Updated 2026-05-18.** Supersedes the 2026-04-30 revision. The shape (uv workspace, 3 PRs) is unchanged, but PR 3 is now "publish PyPI from consult + archive the public repo with a redirect notice" rather than an outbound subtree sync. Rationale: reviewer feedback on PR #1321 — archiving with a redirect is the standard consolidation pattern (e.g. `googleapis/python-bigquery` → `google-cloud-python`) and avoids a force-pushing sync workflow for no practical gain. The deltas are in the **Changes since previous revision** section at the bottom.
 
 ## Context
 
@@ -55,7 +55,7 @@ consult/
 └── .github/workflows/
     ├── themefinder-ci.yml      ← NEW: tests + 95% coverage
     ├── themefinder-eval.yml    ← NEW: LLM evals (moved from public repo)
-    ├── sync-themefinder.yml    ← NEW: auto-push subtree to public repo
+    ├── deploy-themefinder-pypi.yml ← NEW: publishes themefinder to PyPI on release tag
     ├── backend-ci.yml          ← MODIFIED: also trigger on themefinder/** changes; sync from root
     └── ... (existing workflows unchanged)
 ```
@@ -68,7 +68,7 @@ The migration is split into 3 PRs. Phases 1–3 must land together because `buil
 |---|---|---|---|
 | **PR 1** | 1 + 2 + 3 | Core migration: copy themefinder, workspace config, Dockerfiles, Makefile | Atomic: must land as one |
 | **PR 2** | 4 | CI: themefinder-ci.yml, themefinder-eval.yml, backend-ci.yml triggers, merged pre-commit | After PR 1 |
-| **PR 3** | 5 | Public repo sync: sync workflow + token + README updates | After PR 1 |
+| **PR 3** | 5 | Publish from consult + archive public repo with redirect notice | After PR 1 |
 
 ## Implementation Checklist
 
@@ -278,35 +278,28 @@ Consult's `.pre-commit-config.yaml` and themefinder's differ in versions, hook s
 - [ ] Keep the local `detect-ip` and `detect-aws-account` hooks.
 - [ ] `run_precommit.yml` already uses `python-version-file: 'backend/pyproject.toml'`. That's fine, no change needed.
 
-### PR 3: Public Repo Sync
+### PR 3: Publish from consult, archive public repo
 
-- [ ] Create `.github/workflows/sync-themefinder.yml`:
-  ```yaml
-  name: Sync themefinder to public repo
-  on:
-    push:
-      branches: [main]
-      paths: ['themefinder/**']
-  jobs:
-    sync:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v6
-          with:
-            fetch-depth: 0
-        - name: Push themefinder subtree to public repo
-          run: |
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git remote add themefinder https://x-access-token:${{ secrets.THEMEFINDER_PUSH_TOKEN }}@github.com/i-dot-ai/themefinder.git
-            git subtree split --prefix=themefinder -b themefinder-sync
-            git push themefinder themefinder-sync:main --force
-  ```
-- [ ] Create `THEMEFINDER_PUSH_TOKEN` secret in consult repo (GitHub PAT with push access to `i-dot-ai/themefinder`).
-- [ ] In the public `i-dot-ai/themefinder` repo: keep `deploy-pypi.yml` (release-tag triggered) and `deploy-docs.yml` (push-to-main triggered, fires automatically after each sync). **Delete `tests.yml`, `eval.yml`, `pre-commit.yml` from the public repo** to avoid duplicate work — those run in consult now.
-- [ ] Update public repo README: development happens in `i-dot-ai/consult`; this repo is a published mirror. Issues + PyPI releases still happen here.
-- [ ] Verify: merge a no-op `themefinder/` change to consult main; confirm it appears in public repo and `deploy-docs.yml` succeeds.
-- [ ] Document the PyPI release process in consult `docs/`: bump version in `consult/themefinder/pyproject.toml` → merge to main → wait for sync → create release on public repo with tag matching version → `deploy-pypi.yml` fires.
+The public `i-dot-ai/themefinder` repo is archived (read-only) with a redirect notice. PyPI releases are cut from consult going forward. Historic source and release tags remain browseable on the archive.
+
+**In consult:**
+
+- [ ] Port `deploy-pypi.yml` from the public themefinder repo to `consult/.github/workflows/deploy-themefinder-pypi.yml`. Trigger: `release` event with a tag prefix like `themefinder-v*` (namespaced so it can't collide with future consult releases). Working dir: `themefinder/`. Build with `uv build --package themefinder` from repo root; publish via the existing trusted-publisher setup on PyPI (or `PYPI_API_TOKEN` secret — copy from themefinder repo if not already set).
+- [ ] Port docs deploy: `themefinder/mkdocs.yml` and `docs/` come over with the copy in PR 1. Add `.github/workflows/deploy-themefinder-docs.yml` (or fold into an existing docs workflow) triggered on push to `main` with `paths: ['themefinder/docs/**', 'themefinder/src/**']`.
+- [ ] Copy secrets required by `deploy-pypi.yml` / `deploy-docs.yml` from themefinder repo into consult (PyPI token if not using trusted publishing; docs deploy creds).
+- [ ] Document the PyPI release process in `consult/docs/`: bump version in `themefinder/pyproject.toml` → merge to consult main → cut a GitHub release in consult with tag `themefinder-vX.Y.Z` → `deploy-themefinder-pypi.yml` fires.
+
+**In the public `i-dot-ai/themefinder` repo:**
+
+- [ ] Update README to a short redirect notice at the top: "ThemeFinder development has moved to [i-dot-ai/consult](https://github.com/i-dot-ai/consult/tree/main/themefinder). File issues and PRs there. This repo is preserved read-only for historic source and PyPI release tags. `pip install themefinder` continues to work unchanged."
+- [ ] Disable issues and PRs (Settings → Features) so traffic is funnelled to consult.
+- [ ] Archive the repo (Settings → Archive this repository). All workflows (`tests.yml`, `eval.yml`, `pre-commit.yml`, `deploy-pypi.yml`, `deploy-docs.yml`) stop running on the archive — no need to delete them.
+
+**Verification:**
+
+- [ ] After archive, confirm the redirect notice is the first thing visible on the repo landing page.
+- [ ] In consult: cut a no-op `themefinder-vX.Y.Z+test` patch release; confirm `deploy-themefinder-pypi.yml` publishes to PyPI TestPyPI (or a pre-release version on PyPI) and `pip install themefinder==X.Y.Z+test` resolves.
+- [ ] Confirm `pip install themefinder` (latest release) still works after the next real release is cut from consult.
 
 ## Workflow Locations After Migration
 
@@ -317,9 +310,9 @@ Consult's `.pre-commit-config.yaml` and themefinder's differ in versions, hook s
 | Backend tests | consult repo (existing) | PR/push touching `backend/**`, `themefinder/**`, `pyproject.toml`, `uv.lock` |
 | Pre-commit | consult repo (existing, with merged config) | PR/push to main |
 | Docker builds (4 images) | consult repo (existing) | Every push |
-| Auto-sync to public repo | consult repo | Push to main touching `themefinder/**` |
-| Docs deploy | public themefinder repo (kept) | Push to main (fires after auto-sync) |
-| PyPI publish | public themefinder repo (kept) | Release tag (manual) |
+| Docs deploy | consult repo | Push to main touching `themefinder/docs/**` or `themefinder/src/**` |
+| PyPI publish | consult repo | Release with tag `themefinder-v*` |
+| Public `i-dot-ai/themefinder` | archived, read-only | n/a — historic source + release tags only |
 
 ## Risks and Mitigations
 
@@ -333,7 +326,7 @@ Consult's `.pre-commit-config.yaml` and themefinder's differ in versions, hook s
 
 5. **Ruff scoping.** Themefinder's pre-commit runs ruff project-wide; consult deliberately runs ruff only via the Makefile. PR 2 scopes the ruff hooks to `^themefinder/` to avoid changing consult's lint policy in a CI PR. A follow-up decision: do we want ruff at root scope?
 
-6. **Subtree force-push rewrites public repo history.** Each sync is `git subtree split` then `git push --force`. PyPI release tags stay attached to the commits they were cut from, but new releases land on a new history. Acceptable because development now happens in consult; document this in the public repo README.
+6. **PyPI publishing moves to consult — must not break installs.** The PyPI project remains `themefinder` and external `pip install themefinder` continues to resolve unchanged; only the upload origin changes. Risks: (a) trusted-publisher configuration on PyPI is tied to the public repo — either reconfigure trusted publishing for `i-dot-ai/consult` or fall back to a `PYPI_API_TOKEN` secret; (b) tag namespace collides if both repos remain active — archiving the public repo (Phase 5) prevents accidental double-publish.
 
 7. **Eval workflow secret duplication.** Many secrets need copying from themefinder repo to consult. Use a GitHub `eval` environment in consult to scope them (matching themefinder's setup). Some AWS_* secrets already exist in consult — reuse, don't duplicate.
 
@@ -345,7 +338,17 @@ Consult's `.pre-commit-config.yaml` and themefinder's differ in versions, hook s
 
 11. **Pipelines becoming workspace members is a structural change.** Pipelines previously had no `pyproject.toml` and pulled their dep set transitively through `themefinder>=0.8.2`. After migration each pipeline declares its own deps explicitly, locked under the root `uv.lock`. Implications: (a) version drift between backend and pipelines can no longer happen silently — a single resolution must satisfy all four packages, which is the point but may surface conflicts on Phase 1 lock; (b) the inferred dep list (`boto3`, `pandas`, `urllib3`, `openai`, `pydantic`) must be verified against `find_themes_script.py` and `assign_themes_script.py` imports — a missed import will only surface at runtime. (c) Bumps base image from `python:3.11-slim-bullseye` to `python:3.12-slim` to match the workspace lock; smoke-test the built images against AWS Lambda / ECR target environment before merging.
 
-## Changes since the original plan (2026-04-08 → 2026-04-30)
+## Changes since previous revision (2026-04-30 → 2026-05-18)
+
+Driven by review feedback on PR #1321: drop the subtree mirror, archive the public repo with a redirect, publish PyPI from consult.
+
+- **PR 3 reshaped.** Was: outbound `git subtree split` + `git push --force` to the public repo on every `themefinder/**` change, with `deploy-pypi.yml` / `deploy-docs.yml` still firing on the public repo. Now: port `deploy-pypi.yml` (and docs deploy) into consult and archive the public repo read-only with a redirect notice.
+- **No `THEMEFINDER_PUSH_TOKEN` secret needed.** Sync workflow removed; no cross-repo write credentials required.
+- **Release tag scheme.** Releases in consult use a `themefinder-v*` tag prefix to avoid colliding with any future consult-level release tags. Documented in the new release-process note in `consult/docs/`.
+- **Trusted-publisher reconfiguration on PyPI.** New risk #6 — PyPI's trusted-publisher binding (if used) is tied to the public repo and must be moved to `i-dot-ai/consult`, or replaced with a token-based publish. To check before merging PR 3.
+- **External-user surface unchanged.** `pip install themefinder` still resolves; historic releases remain attached to their commits on the (now archived) public repo. Issues redirect to consult via the archived repo's README.
+
+## Changes from original plan (2026-04-08 → 2026-04-30)
 
 The 3-PR shape and the workspace approach are unchanged. Concrete deltas:
 


### PR DESCRIPTION
## Summary

- Adds [ADR 0007](docs/architecture/decisions/0007-merge-themefinder-into-consult-as-a-uv-workspace.md) proposing the themefinder → consult monorepo migration as a uv workspace, with pipelines as workspace members.
- Includes the supporting [plan document](docs/plan-themefinder-monorepo-migration.md) so the approach is reviewable in one place before the implementation PRs land.
- Status on the ADR is **Proposed** — this PR is the chance to push back on the shape (workspace vs alternatives, atomic PR 1, public-repo subtree sync, pipelines becoming uv workspace members) before the migration starts.

## Context for reviewers

The plan was previously revised (2026-04-08 → 2026-04-30) to make the pipelines full uv workspace members rather than keeping them on `pip install -r requirements.txt`. That's the most recent change in approach; the **Changes since the original plan** section at the bottom of the plan summarises the deltas.

Implementation will land in three follow-up PRs (atomic PR 1 covering workspace + Dockerfiles + Makefile; PR 2 for CI; PR 3 for public-repo sync) tracked under [Linear project: Migrate themefinder into Consult](https://linear.app/iai-consult/project/migrate-themefinder-into-consult-4b859be2cfbf/overview).

## Test plan

- [ ] Reviewers read the ADR and the plan, push back on the chosen approach or the alternatives considered
- [ ] Confirm Status: Proposed → Accepted before merging (once review is done)
- [ ] No code changes; CI should be a docs-only no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)