### PR TITLE
Monorepo PR 2 - CI: themefinder workflows + workspace-aware backend CI + merged pre-commit

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - "backend/**"
+      - "themefinder/**"
+      - "pyproject.toml"
+      - "uv.lock"
       - "Makefile"
       - ".github/workflows/backend-ci.yml"
   pull_request:
@@ -13,6 +16,9 @@ on:
       - main
     paths:
       - "backend/**"
+      - "themefinder/**"
+      - "pyproject.toml"
+      - "uv.lock"
       - "Makefile"
       - ".github/workflows/backend-ci.yml"
   workflow_dispatch:
@@ -41,11 +47,9 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-        working-directory: ./backend
 
       - name: install dependencies
-        run: uv sync --all-extras
-        working-directory: ./backend
+        run: uv sync --all-packages --all-extras --group dev
 
       - name: Setup app
         env:
@@ -71,8 +75,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: uv sync --all-extras
-        working-directory: ./backend
+        run: uv sync --all-packages --all-extras --group dev
 
       - name: Check code formatting
         run: |

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -1,0 +1,43 @@
+name: pipeline smoke tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pipeline-mapping/**"
+      - "pipeline-sign-off/**"
+      - "themefinder/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/pipeline-smoke.yml"
+  pull_request:
+    paths:
+      - "pipeline-mapping/**"
+      - "pipeline-sign-off/**"
+      - "themefinder/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/pipeline-smoke.yml"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pipeline: [pipeline-mapping, pipeline-sign-off]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build image
+        run: docker build -f ${{ matrix.pipeline }}/Dockerfile -t ${{ matrix.pipeline }}:smoke .
+
+      # --help exits 0 only if all top-level imports + module-level env reads
+      # in the script succeeded. The env values themselves are not used.
+      - name: Run --help
+        run: |
+          docker run --rm \
+            -e LLM_GATEWAY_URL=x \
+            -e LITELLM_CONSULT_OPENAI_API_KEY=x \
+            -e SLACK_WEBHOOK_URL=x \
+            ${{ matrix.pipeline }}:smoke --help

--- a/.github/workflows/themefinder-ci.yml
+++ b/.github/workflows/themefinder-ci.yml
@@ -1,0 +1,44 @@
+name: themefinder CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "themefinder/**"
+      - ".github/workflows/themefinder-ci.yml"
+  pull_request:
+    paths:
+      - "themefinder/**"
+      - ".github/workflows/themefinder-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Install into an isolated venv to bypass the workspace, whose
+      # requires-python is pinned to 3.12 by backend.
+      - name: Install dependencies
+        working-directory: themefinder
+        run: |
+          uv venv --python ${{ matrix.python-version }} .ci-venv
+          uv pip install --python .ci-venv/bin/python -e ".[dev]"
+
+      - name: Run tests with coverage
+        working-directory: themefinder
+        run: .ci-venv/bin/coverage run -m pytest -v -s
+
+      - name: Coverage report
+        working-directory: themefinder
+        run: .ci-venv/bin/coverage report -m --fail-under=95

--- a/.github/workflows/themefinder-ci.yml
+++ b/.github/workflows/themefinder-ci.yml
@@ -12,7 +12,7 @@ on:
       - ".github/workflows/themefinder-ci.yml"
 
 jobs:
-  test:
+  themefinder-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/themefinder-eval.yml
+++ b/.github/workflows/themefinder-eval.yml
@@ -68,8 +68,6 @@ jobs:
         env:
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-          LOCAI_ENDPOINT: ${{ secrets.LOCAI_ENDPOINT }}
-          LOCAI_API_KEY: ${{ secrets.LOCAI_API_KEY }}
           OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
           LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
           CONSULT_EVAL_LITELLM_API_KEY: ${{ secrets.CONSULT_EVAL_LITELLM_API_KEY }}
@@ -120,7 +118,7 @@ jobs:
         if: steps.eval.outputs.eval_success == 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_THEMEFINDER_EVAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -140,7 +138,7 @@ jobs:
         if: failure() || steps.eval.outputs.eval_success == 'false'
         uses: slackapi/slack-github-action@v2.0.0
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_THEMEFINDER_EVAL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/.github/workflows/themefinder-eval.yml
+++ b/.github/workflows/themefinder-eval.yml
@@ -75,7 +75,6 @@ jobs:
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
-          THEMEFINDER_S3_BUCKET_NAME: ${{ secrets.THEMEFINDER_S3_BUCKET_NAME }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           ENVIRONMENT: production
           DATASET: ${{ github.event.inputs.dataset || 'gambling_XS' }}

--- a/.github/workflows/themefinder-eval.yml
+++ b/.github/workflows/themefinder-eval.yml
@@ -40,7 +40,6 @@ jobs:
   eval:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
-    environment: eval
     timeout-minutes: 60
 
     steps:
@@ -71,7 +70,7 @@ jobs:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           LOCAI_ENDPOINT: ${{ secrets.LOCAI_ENDPOINT }}
           LOCAI_API_KEY: ${{ secrets.LOCAI_API_KEY }}
-          OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+          OPENAI_API_VERSION: ${{ secrets.OPENAI_API_VERSION }}
           LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
           CONSULT_EVAL_LITELLM_API_KEY: ${{ secrets.CONSULT_EVAL_LITELLM_API_KEY }}
           AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT: ${{ secrets.AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT }}

--- a/.github/workflows/themefinder-eval.yml
+++ b/.github/workflows/themefinder-eval.yml
@@ -1,0 +1,173 @@
+name: themefinder LLM evaluation
+
+on:
+  pull_request:
+    paths:
+      - 'themefinder/evals/**'
+      - 'themefinder/src/themefinder/**'
+      - '.github/workflows/themefinder-eval.yml'
+  workflow_dispatch:
+    inputs:
+      dataset:
+        description: 'Dataset identifier (e.g., gambling_XS, healthcare_M)'
+        type: string
+        default: 'gambling_XS'
+      eval_type:
+        description: 'Which eval to run'
+        type: choice
+        options:
+          - generation
+          - mapping
+          - condensation
+          - refinement
+          - all
+        default: 'generation'
+
+jobs:
+  start-runner:
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/start-runner.yml@main
+    permissions: write-all
+    with:
+      EC2_INSTANCE_TYPE: t3.medium
+      ENVIRONMENT: prod
+    secrets:
+      AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
+      AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}
+      AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+
+  eval:
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    environment: eval
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: '.python-version'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Install dependencies
+        run: uv sync --package themefinder --extra dev
+
+      - name: Get version info
+        id: version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('themefinder/pyproject.toml', 'rb'))['project']['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Run eval
+        id: eval
+        env:
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          LOCAI_ENDPOINT: ${{ secrets.LOCAI_ENDPOINT }}
+          LOCAI_API_KEY: ${{ secrets.LOCAI_API_KEY }}
+          OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+          LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
+          CONSULT_EVAL_LITELLM_API_KEY: ${{ secrets.CONSULT_EVAL_LITELLM_API_KEY }}
+          AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT: ${{ secrets.AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+          THEMEFINDER_S3_BUCKET_NAME: ${{ secrets.THEMEFINDER_S3_BUCKET_NAME }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          ENVIRONMENT: production
+          DATASET: ${{ github.event.inputs.dataset || 'gambling_XS' }}
+          EVAL_TYPE: ${{ github.event.inputs.eval_type || 'generation' }}
+        run: |
+          set -o pipefail
+          cd themefinder/evals
+
+          if [ "$EVAL_TYPE" = "all" ]; then
+            echo "Running all evals for $DATASET..."
+            uv run python benchmark.py --quick 2>&1 | tee results.txt
+          else
+            echo "Running $EVAL_TYPE eval for $DATASET..."
+            uv run python benchmark.py --quick --evals "$EVAL_TYPE" 2>&1 | tee results.txt
+          fi
+
+          if grep -q "Eval Results\|experiment\|accuracy\|f1" results.txt; then
+            echo "eval_success=true" >> $GITHUB_OUTPUT
+          else
+            echo "eval_success=false" >> $GITHUB_OUTPUT
+          fi
+
+          BENCHMARK_ID=$(grep "BENCHMARK_ID=" results.txt | tail -1 | cut -d= -f2)
+          echo "benchmark_id=$BENCHMARK_ID" >> $GITHUB_OUTPUT
+
+          SCORES=$(grep -E "^\s+(question|f1|accuracy)" results.txt | head -6 | sed 's/^[[:space:]]*//' | tr '\n' ' · ' || echo "")
+          echo "scores=$SCORES" >> $GITHUB_OUTPUT
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: eval-results-${{ github.run_id }}
+          path: |
+            themefinder/evals/benchmark_results/
+            themefinder/evals/results.txt
+          retention-days: 90
+
+      - name: Notify Slack on success
+        if: steps.eval.outputs.eval_success == 'true'
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_THEMEFINDER_EVAL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "✅ ThemeFinder Eval Complete",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "✅ *ThemeFinder Eval*\n`v${{ steps.version.outputs.version }}` · `${{ steps.version.outputs.short_sha }}`\n*Dataset:* ${{ github.event.inputs.dataset || 'gambling_XS' }} · *Benchmark:* `${{ steps.eval.outputs.benchmark_id }}`\n${{ steps.eval.outputs.scores }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run · Download Report>"
+                  }
+                }
+              ]
+            }
+
+      - name: Notify Slack on failure
+        if: failure() || steps.eval.outputs.eval_success == 'false'
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_THEMEFINDER_EVAL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "⚠️ ThemeFinder Eval Failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ *ThemeFinder Eval Failed*\n`v${{ steps.version.outputs.version }}` · `${{ steps.version.outputs.short_sha }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                  }
+                }
+              ]
+            }
+
+  stop-runner:
+    needs: [start-runner, eval]
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
+    if: needs.start-runner.outputs.use-persisted == 0 && always()
+    permissions: write-all
+    with:
+      RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
+      EC2_INSTANCE_ID: ${{ needs.start-runner.outputs.ec2-instance-id }}
+    secrets:
+      AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
+      AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}
+      AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/themefinder-eval.yml
+++ b/.github/workflows/themefinder-eval.yml
@@ -24,7 +24,7 @@ on:
         default: 'generation'
 
 jobs:
-  start-runner:
+  themefinder-eval-start-runner:
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/start-runner.yml@main
     permissions: write-all
     with:
@@ -37,9 +37,9 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
-  eval:
-    needs: start-runner
-    runs-on: ${{ needs.start-runner.outputs.label }}
+  themefinder-eval:
+    needs: themefinder-eval-start-runner
+    runs-on: ${{ needs.themefinder-eval-start-runner.outputs.label }}
     timeout-minutes: 60
 
     steps:
@@ -153,14 +153,14 @@ jobs:
               ]
             }
 
-  stop-runner:
-    needs: [start-runner, eval]
+  themefinder-eval-stop-runner:
+    needs: [themefinder-eval-start-runner, themefinder-eval]
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
-    if: needs.start-runner.outputs.use-persisted == 0 && always()
+    if: needs.themefinder-eval-start-runner.outputs.use-persisted == 0 && always()
     permissions: write-all
     with:
-      RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
-      EC2_INSTANCE_ID: ${{ needs.start-runner.outputs.ec2-instance-id }}
+      RUNNER_LABEL: ${{ needs.themefinder-eval-start-runner.outputs.label }}
+      EC2_INSTANCE_ID: ${{ needs.themefinder-eval-start-runner.outputs.ec2-instance-id }}
     secrets:
       AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
       AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         name: Check for files larger than 5 MB
@@ -17,10 +17,11 @@ repos:
         files: '^backend/.*\.py$'
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
     -   id: detect-secrets
-        exclude: (uv.lock|.env.test|^.github/workflows/|\.cruft\.json)
+        exclude: (uv\.lock|\.env\.example|\.env\.test|^\.github/workflows/|\.cruft\.json)
+
   - repo: local
     hooks:
     -   id: detect-ip
@@ -29,12 +30,14 @@ repos:
         language: pygrep
         exclude: '^static/|\.lock'
         files: .
+
   - repo: local
     hooks:
     -   id: detect-aws-account
         name: Detect AWS account numbers
         language: pygrep
         entry: ':\d{12}:'
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:
@@ -43,7 +46,16 @@ repos:
         additional_dependencies: [ "types-PyYAML" ]
         files: '^backend/.*\.py$'
         exclude: .*migrations
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.11
+    hooks:
+      - id: ruff
+        files: ^themefinder/
+      - id: ruff-format
+        files: ^themefinder/
+
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.7.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout

--- a/themefinder/CONTRIBUTING.md
+++ b/themefinder/CONTRIBUTING.md
@@ -3,3 +3,4 @@
 At present we are not accepting contributions to `themefinder` as it is undergoing rapid development within i.AI. 
 
 If you have a bug report, feature request or feedback, please raise an [issue](https://github.com/i-dot-ai/themefinder/issues) or email us at [packages@cabinetoffice.gov.uk](mailto:packages@cabinetoffice.gov.uk).
+ 


### PR DESCRIPTION
## Summary

PR 2 of the themefinder monorepo migration. Stacked on top of PR #1332 (PR 1).

- Adds `themefinder-ci.yml` — tests + 95% coverage gate, py 3.10/3.11/3.12 matrix via isolated venv (bypasses workspace's 3.12 pin) (PRO-280)
- Adds `themefinder-eval.yml` — LLM evals on self-hosted EC2 runner; reuses existing AWS_GITHUBRUNNER_* and SLACK_WEBHOOK_URL; secrets aligned to consult repo level (PRO-281)
- Updates `backend-ci.yml` — re-runs on themefinder/pyproject/uv.lock changes; switches to workspace-root install (PRO-282)
- Merges pre-commit configs — ruff scoped to themefinder/; bumps pre-commit-hooks/detect-secrets/nbstripout; keeps bandit/mypy backend-only (PRO-283)

Closes PRO-275, PRO-280, PRO-281, PRO-282, PRO-283.

## Test plan

- [x] `themefinder-ci.yml` runs on this PR (paths: themefinder/**) — all 3 python versions pass
- [x] `pre-commit` workflow passes on the merged config
- [x] `backend-ci.yml` runs and passes with workspace-root install
- [x] `themefinder-eval.yml` runnable via workflow_dispatch end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)