### PR TITLE
Step RDS to latest min version

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -7,7 +7,7 @@ module "rds" {
   public_subnet_ids_list                = data.terraform_remote_state.vpc.outputs.public_subnets
   vpc_id                                = data.terraform_remote_state.vpc.outputs.vpc_id
   engine                                = "aurora-postgresql"
-  engine_version                        = "16.8"
+  engine_version                        = "16.11"
   family                                = null
   engine_mode                           = "provisioned"
   aurora_min_scaling                    = 2


### PR DESCRIPTION
## Context

AWS has upped its min version for aurora psql

## Changes proposed in this pull request

- Change RDS psql version from 16.8 to 16.11
