### PR TITLE
Fix search input

### DIFF
--- a/frontend/src/global/stores.ts
+++ b/frontend/src/global/stores.ts
@@ -80,6 +80,7 @@ export const createFetchStore = <T>({
   });
 
   let prevPromise: Promise<void> | null = null;
+  let prevUrl: string;
   let resolvePrev: (() => void) | null = null;
   let debouncedFetch: ReturnType<typeof debounce> | null = null;
 
@@ -93,7 +94,7 @@ export const createFetchStore = <T>({
     // even though it awaits debounce timeout
     store.update((store) => ({ ...store, isLoading: true, error: "" }));
 
-    if (!debouncedFetch) {
+    if (!debouncedFetch || (prevUrl && prevUrl !== url)) {
       debouncedFetch = debounce(async () => {
         try {
           if (mockFetch) {
@@ -150,6 +151,8 @@ export const createFetchStore = <T>({
 
       debouncedFetch!();
     });
+
+    prevUrl = url;
 
     return prevPromise;
   };


### PR DESCRIPTION
## Context
The search input on the dashboard was only capturing the input value as it was at the start of typing, missing the remaining characters entered until the typing finishes.

## Changes proposed in this pull request
This PR adds a comparison for the entire URL of a fetch so that when the query params change, it invalidates the existing fetch.

## Guidance to review
Confirm search input is sending the correct search value in the url as a fetch request. Regression testing for the rest of the app.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
