### PR TITLE
fix: Split on first colon to handle issue where there are multiple

### DIFF
--- a/pipeline-sign-off/find_themes_script.py
+++ b/pipeline-sign-off/find_themes_script.py
@@ -271,7 +271,7 @@ async def process_consultation(consultation_dir: str, model_name: str) -> str:
                 refined_themes_df = await generate_themes(question, responses_df, llm)
 
                 def refined_themes_to_theme_node(row: dict):
-                    topic_label, topic_description = row["topic"].split(":")
+                    topic_label, topic_description = row["topic"].split(":", 1)
                     return ThemeNode(
                         topic_id=row["topic_id"],
                         topic_label=topic_label,


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

For multiple consultations, we are seeing an issue where there are no representative responses. After doing some digging[1], I found it was because it's because the find_themes_script is erroring when it encounters multiple colons. This suggests that the LLM is including a colon in either the theme name or the description which is disruptive because we use the colon as a separator to determine which part is the theme name and which is the theme description.

There are a lot of more robust changes we should make off the back of this. But the quick fix for now is to assume that the theme name is everything before the first colon.

[1] https://linear.app/iai-consult/issue/PRO-320/investigate-consultation-issue-mhclg-nppf-representative-responses
