### PR TITLE
fix: Record representative responses for level 2 themes

### DIFF
--- a/backend/data_pipeline/sync/candidate_themes.py
+++ b/backend/data_pipeline/sync/candidate_themes.py
@@ -398,8 +398,7 @@ def export_candidate_themes_to_s3(consultation: Consultation) -> int:
     questions = consultation.question_set.filter(has_free_text=True)
 
     for question in questions:
-        # Only export top-level candidate themes (not children)
-        themes = CandidateTheme.objects.filter(question=question, parent__isnull=True)
+        themes = CandidateTheme.objects.filter(question=question)
 
         if not themes.exists():
             logger.warning(
@@ -465,7 +464,7 @@ def _build_candidate_theme_lookup(
     if not batch_themes:
         return {}
 
-    db_themes = CandidateTheme.objects.filter(question=question, parent__isnull=True)
+    db_themes = CandidateTheme.objects.filter(question=question)
     db_themes_by_name = {theme.name: theme for theme in db_themes}
 
     batch_key_to_db_theme = {}


### PR DESCRIPTION
## Context

One of the consultation teams reported that there were no representative responses for level 2 themes. Found this was because we were only including level 1 themes when exporting candidate themes to S3 and when assigning themes to record representative responses.

**Note**: I haven't manually QA'ed this because of the disproportionate effort required to set up the test data to do so. I also think it's a low risk change, especially given it's broken currently so if this fix doesn't work (it should), there's no harm done.