### PR TITLE
fix: Exclude empty responses when assigning themes

### DIFF
--- a/backend/consultations/api/views/candidate_theme.py
+++ b/backend/consultations/api/views/candidate_theme.py
@@ -98,6 +98,8 @@ class CandidateThemeViewSet(ModelViewSet):
             models.CandidateThemeResponse.objects.filter(
                 candidate_theme=candidate_theme,
             )
+            .filter(response__free_text__isnull=False)
+            .exclude(response__free_text__in=models.EMPTY_FREE_TEXT_VALUES)
             .select_related("response")
             .annotate(
                 sort_key=MD5(

--- a/backend/consultations/api/views/question.py
+++ b/backend/consultations/api/views/question.py
@@ -128,9 +128,7 @@ class QuestionViewSet(ModelViewSet):
             )
 
             # Replace the prefetched multichoice answers
-            question._prefetched_objects_cache["multichoiceanswer_set"] = list(
-                multichoice_answers
-            )
+            question._prefetched_objects_cache["multichoiceanswer_set"] = list(multichoice_answers)
 
         serializer = self.get_serializer(question)
         return Response(serializer.data)
@@ -157,6 +155,10 @@ class QuestionViewSet(ModelViewSet):
         ]
         has_filters = any(request.query_params.get(p) for p in filter_params)
 
+        non_empty_filter = ~Q(
+            responseannotation__response__free_text__in=models.EMPTY_FREE_TEXT_VALUES
+        )
+
         if has_filters:
             filtered_responses = get_filtered_responses(
                 request.query_params, consultation_pk, question_id=pk
@@ -164,12 +166,15 @@ class QuestionViewSet(ModelViewSet):
             themes = themes.annotate(
                 count=Count(
                     "responseannotation",
-                    filter=Q(responseannotation__response__in=filtered_responses),
+                    filter=Q(responseannotation__response__in=filtered_responses)
+                    & non_empty_filter,
                     distinct=True,
                 )
             )
         else:
-            themes = themes.annotate(count=Count("responseannotation", distinct=True))
+            themes = themes.annotate(
+                count=Count("responseannotation", filter=non_empty_filter, distinct=True)
+            )
 
         serializer = QuestionThemeSerializer(themes, many=True)
         return Response({"themes": serializer.data})

--- a/backend/consultations/models.py
+++ b/backend/consultations/models.py
@@ -15,6 +15,8 @@ from simple_history.models import HistoricalRecords
 
 from authentication.models import User
 
+EMPTY_FREE_TEXT_VALUES = ["", "Not Provided", "-"]
+
 
 # TODO: we don't use this anymore, remove it without manage.py makemigrations complaining
 class MultipleChoiceSchemaValidator(BaseValidator):
@@ -173,7 +175,7 @@ class Question(UUIDPrimaryKeyModel, TimeStampedModel):
         Get queryset of non-empty responses for this question.
         """
         return self.response_set.filter(free_text__isnull=False).exclude(
-            free_text__in=["", "Not Provided"]
+            free_text__in=EMPTY_FREE_TEXT_VALUES
         )
 
     def sample_responses(self, keep_count: int) -> SampleResult:

--- a/backend/data_pipeline/sync/candidate_themes.py
+++ b/backend/data_pipeline/sync/candidate_themes.py
@@ -13,7 +13,6 @@ from consultations.models import (
     CandidateThemeResponse,
     Consultation,
     Question,
-    Response,
 )
 from data_pipeline.models import CandidateThemeBatch, ThemeMappingInput, ThemeNodeList
 
@@ -504,8 +503,8 @@ def _import_candidate_theme_responses(
     # Delete existing mappings for this question's candidate themes
     CandidateThemeResponse.objects.filter(candidate_theme__question=question).delete()
 
-    # Build response lookup by themefinder_id
-    responses = Response.objects.filter(question=question).select_related("respondent")
+    # Build response lookup by themefinder_id, excluding empty/placeholder responses
+    responses = question.get_non_empty_responses().select_related("respondent")
     response_lookup = {r.respondent.themefinder_id: r for r in responses}
 
     mapping_lookup = {m.themefinder_id: m.theme_keys for m in mappings}

--- a/backend/data_pipeline/sync/response_annotations.py
+++ b/backend/data_pipeline/sync/response_annotations.py
@@ -7,7 +7,6 @@ import data_pipeline.s3 as s3
 from consultations.models import (
     Consultation,
     Question,
-    Response,
     ResponseAnnotation,
     SelectedTheme,
 )
@@ -460,13 +459,11 @@ def _import_response_annotations(
     detail_lookup = {d.themefinder_id: d.as_bool for d in details}
     mapping_lookup = {m.themefinder_id: m.theme_keys for m in mappings}
 
-    # Get all responses for this question with their respondent themefinder_ids
-    responses = Response.objects.filter(question=question).select_related("respondent")
+    # Get all responses for this question, excluding empty/placeholder responses
+    responses = question.get_non_empty_responses().select_related("respondent")
     # Filter out responses without themefinder_id since we can't match them to batch data
     response_lookup = {
-        r.respondent.themefinder_id: r 
-        for r in responses 
-        if r.respondent.themefinder_id is not None
+        r.respondent.themefinder_id: r for r in responses if r.respondent.themefinder_id is not None
     }
 
     # Create ResponseAnnotation objects
@@ -507,20 +504,20 @@ def _import_response_annotations(
     # Build lookup from created annotations using the response_id to avoid N+1 queries
     # We use response_id because it's available on the annotation object without triggering a query
     annotation_by_response_id = {ann.response_id: ann for ann in created_annotations}  # type: ignore[attr-defined]
-    
+
     # Build reverse lookup from themefinder_id to response_id using our prefetched responses
     response_id_by_tf_id = {
-        r.respondent.themefinder_id: r.id 
-        for r in responses 
+        r.respondent.themefinder_id: r.id
+        for r in responses
         if r.respondent.themefinder_id is not None
     }
 
     # Collect all ResponseAnnotationTheme records to create in bulk
     from consultations.models import ResponseAnnotationTheme
-    
+
     annotation_themes_to_create = []
     themes_linked = 0
-    
+
     for themefinder_id, theme_keys in annotation_theme_data:
         # Get the response_id from our prefetched lookup
         response_id = response_id_by_tf_id.get(themefinder_id)
@@ -530,7 +527,7 @@ def _import_response_annotations(
                 themefinder_id=themefinder_id,
             )
             continue
-            
+
         maybe_annotation = annotation_by_response_id.get(response_id)
         if maybe_annotation is None:
             logger.warning(
@@ -538,7 +535,7 @@ def _import_response_annotations(
                 response_id=response_id,
             )
             continue
-        
+
         # Type narrowing for mypy - at this point we know the annotation is not None
         ann: ResponseAnnotation = maybe_annotation
 


### PR DESCRIPTION
## Context

We sometimes represent empty free text respones as NULL, sometimes as "Not Provided" and sometimes as "-". We should be consistent, in future, in what we choose. But in the meantime, we should exclude these empty responses when assigning themes and retrieving assigned responses. Otherwise, they are sometimes displayed as representative responses and count towards theme frequency in the dashboard, which doesn't make sense at all.