### PR TITLE
Interactive Story Mocks

### DIFF
--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -20,6 +20,7 @@
   import stories from "./stories.ts";
   import { mockRoute, toTitleCase } from "../../global/utils.ts";
   import { queryClient } from "../../global/queryClient.ts";
+  import Textarea from "../inputs/Textarea/Textarea.svelte";
 
   const getSelectedUrlParam = () => {
     return Object.fromEntries(new URLSearchParams(window.location.search))
@@ -169,97 +170,144 @@
           {:else}
             <StoryComponent {...componentProps as object} />
 
-            {#each currStory.props as prop (prop.name)}
-              {@const inputId = `input-${prop.name.toLowerCase().replaceAll(" ", "-")}`}
+            <hr class="my-4" />
 
-              <div class="mt-4 pl-4">
-                {#if ["number", "text", "bool", "select", "json", "html", "func"].includes(prop.type)}
-                  <div class="mb-1">
-                    <Title level={4} text={prop.name} />
-                  </div>
-                {/if}
+            <div class="mt-4 pl-4">
+              <h3 class="text-neutral-500">Props</h3>
 
-                {#if prop.type === "number"}
-                  <input
-                    id={inputId}
-                    class="rounded-lg border border-neutral-300 p-2"
-                    type="number"
-                    value={(prop.value as string).toString()}
-                    oninput={(e) => {
-                      prop.value = parseInt(
-                        (e?.target as unknown as { value: string })?.value,
-                      );
-                    }}
-                  />
-                {:else if prop.type === "text"}
-                  <TextInput
-                    id={inputId}
-                    label={prop.name}
-                    hideLabel={true}
-                    value={prop.value! as string}
-                    setValue={(newVal) => (prop.value = newVal)}
-                  />
-                {:else if prop.type === "bool"}
-                  <Switch
-                    id={inputId}
-                    label={prop.name}
-                    hideLabel={true}
-                    value={prop.value as boolean}
-                    handleChange={(newVal) => (prop.value = newVal)}
-                  />
-                {:else if prop.type === "select"}
-                  <Select
-                    id={inputId}
-                    label={prop.name}
-                    hideLabel={true}
-                    value={prop.label}
-                    items={prop.options! as { value: string; label: string }[]}
-                    onchange={(nextVal) => {
-                      if (!nextVal) {
-                        return;
-                      }
-                      prop.value = prop.options?.find(
-                        (opt: { label: string }) => {
-                          return opt.label === nextVal;
-                        },
-                      )?.value;
-                    }}
-                  />
-                {:else if prop.type === "json"}
-                  <CodeMirror
-                    value={JSON.stringify(prop.value)}
-                    lang={json()}
-                    onchange={(newVal) => {
-                      prop.value = JSON.parse(newVal);
-                    }}
-                  />
-                {:else if prop.type === "html"}
-                  <CodeMirror
-                    value={prop.rawHtml}
-                    lang={json()}
-                    onchange={(newVal) => {
-                      // return if not valid html
-                      const doc = document.createElement("div");
-                      doc.innerHTML = newVal;
-                      if (!newVal || doc.innerHTML !== newVal) {
-                        return;
-                      }
+              {#each currStory.props as prop (prop.name)}
+                {@const inputId = `input-${prop.name.toLowerCase().replaceAll(" ", "-")}`}
 
-                      prop.value = createRawSnippet(() => ({
-                        render: () => newVal,
-                      }));
-                      prop.rawHtml = newVal;
-                    }}
-                  />
-                {:else if prop.type === "func"}
-                  <Tag>
-                    <span class="italic">
-                      Function: {prop.schema || "No schema provided"}
-                    </span>
-                  </Tag>
-                {/if}
-              </div>
-            {/each}
+                  {#if ["number", "text", "bool", "select", "json", "html", "func"].includes(prop.type)}
+                    <div class="mb-1">
+                      <Title level={4} text={prop.name} />
+                    </div>
+                  {/if}
+
+                  {#if prop.type === "number"}
+                    <input
+                      id={inputId}
+                      class="rounded-lg border border-neutral-300 p-2"
+                      type="number"
+                      value={(prop.value as string).toString()}
+                      oninput={(e) => {
+                        prop.value = parseInt(
+                          (e?.target as unknown as { value: string })?.value,
+                        );
+                      }}
+                    />
+                  {:else if prop.type === "text"}
+                    <TextInput
+                      id={inputId}
+                      label={prop.name}
+                      hideLabel={true}
+                      value={prop.value! as string}
+                      setValue={(newVal) => (prop.value = newVal)}
+                    />
+                  {:else if prop.type === "bool"}
+                    <Switch
+                      id={inputId}
+                      label={prop.name}
+                      hideLabel={true}
+                      value={prop.value as boolean}
+                      handleChange={(newVal) => (prop.value = newVal)}
+                    />
+                  {:else if prop.type === "select"}
+                    <Select
+                      id={inputId}
+                      label={prop.name}
+                      hideLabel={true}
+                      value={prop.label}
+                      items={prop.options! as { value: string; label: string }[]}
+                      onchange={(nextVal) => {
+                        if (!nextVal) {
+                          return;
+                        }
+                        prop.value = prop.options?.find(
+                          (opt: { label: string }) => {
+                            return opt.label === nextVal;
+                          },
+                        )?.value;
+                      }}
+                    />
+                  {:else if prop.type === "json"}
+                    <CodeMirror
+                      value={JSON.stringify(prop.value)}
+                      lang={json()}
+                      onchange={(newVal) => {
+                        prop.value = JSON.parse(newVal);
+                      }}
+                    />
+                  {:else if prop.type === "html"}
+                    <CodeMirror
+                      value={prop.rawHtml}
+                      lang={json()}
+                      onchange={(newVal) => {
+                        // return if not valid html
+                        const doc = document.createElement("div");
+                        doc.innerHTML = newVal;
+                        if (!newVal || doc.innerHTML !== newVal) {
+                          return;
+                        }
+
+                        prop.value = createRawSnippet(() => ({
+                          render: () => newVal,
+                        }));
+                        prop.rawHtml = newVal;
+                      }}
+                    />
+                  {:else if prop.type === "func"}
+                    <Tag>
+                      <span class="italic">
+                        Function: {prop.schema || "No schema provided"}
+                      </span>
+                    </Tag>
+                  {/if}
+              {/each}
+
+              {#if currStory.mocks}
+                <hr class="my-4" />
+
+                <h3 class="text-neutral-500">Mocks</h3>
+
+                {#each currStory.mocks as currMock}
+                  <h4 class="text-neutral-700 text-sm">{currMock.name || "Unnamed Mock"}</h4>
+
+                  {#key currMock}
+                    <div class="mocks pl-4">
+                      <Select
+                        id={(currMock.name || "mock") + "-status"}
+                        label={"Status:"}
+                        hideLabel={false}
+                        value={(currMock.status || 200).toString()}
+                        items={[
+                          {value:"200", label: "Success"},
+                          {value:"400", label: "Bad Request"},
+                          {value:"500", label: "Server Error"},
+                        ]}
+                        onchange={(nextVal) => {
+                          if (!nextVal) {
+                            return;
+                          }
+                          currMock.status = parseInt(nextVal);
+                        }}
+                      />
+
+                      <hr class="mt-4 mb-2" />
+
+                      <Textarea
+                        id={(currMock.name || "mock") + "-body"}
+                        label="Body"
+                        value={JSON.stringify(currMock.body || "")}
+                        setValue={(newValue) => {
+                          currMock.body = JSON.parse(newValue);
+                        }}
+                      />
+                    </div>
+                  {/key}
+                {/each}
+              {/if}
+            </div>
           {/if}
         </div>
       {:else}
@@ -274,5 +322,8 @@
 <style>
   :global(div[data-testid="panel-component"]) {
     overflow-y: auto;
+  }
+  :global(.mocks label) {
+    font-size: 0.9rem;
   }
 </style>

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -274,7 +274,7 @@
                   <h4 class="text-neutral-700 text-sm">{currMock.name || "Unnamed Mock"}</h4>
 
                   {#key currMock}
-                    <div class="mocks pl-4">
+                    <div class="mocks pl-4 mb-4">
                       <Select
                         id={(currMock.name || "mock") + "-status"}
                         label={"Status:"}

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -178,91 +178,91 @@
               {#each currStory.props as prop (prop.name)}
                 {@const inputId = `input-${prop.name.toLowerCase().replaceAll(" ", "-")}`}
 
-                  {#if ["number", "text", "bool", "select", "json", "html", "func"].includes(prop.type)}
-                    <div class="mb-1">
-                      <Title level={4} text={prop.name} />
-                    </div>
-                  {/if}
+                {#if ["number", "text", "bool", "select", "json", "html", "func"].includes(prop.type)}
+                  <div class="mb-1">
+                    <Title level={4} text={prop.name} />
+                  </div>
+                {/if}
 
-                  {#if prop.type === "number"}
-                    <input
-                      id={inputId}
-                      class="rounded-lg border border-neutral-300 p-2"
-                      type="number"
-                      value={(prop.value as string).toString()}
-                      oninput={(e) => {
-                        prop.value = parseInt(
-                          (e?.target as unknown as { value: string })?.value,
-                        );
-                      }}
-                    />
-                  {:else if prop.type === "text"}
-                    <TextInput
-                      id={inputId}
-                      label={prop.name}
-                      hideLabel={true}
-                      value={prop.value! as string}
-                      setValue={(newVal) => (prop.value = newVal)}
-                    />
-                  {:else if prop.type === "bool"}
-                    <Switch
-                      id={inputId}
-                      label={prop.name}
-                      hideLabel={true}
-                      value={prop.value as boolean}
-                      handleChange={(newVal) => (prop.value = newVal)}
-                    />
-                  {:else if prop.type === "select"}
-                    <Select
-                      id={inputId}
-                      label={prop.name}
-                      hideLabel={true}
-                      value={prop.label}
-                      items={prop.options! as { value: string; label: string }[]}
-                      onchange={(nextVal) => {
-                        if (!nextVal) {
-                          return;
-                        }
-                        prop.value = prop.options?.find(
-                          (opt: { label: string }) => {
-                            return opt.label === nextVal;
-                          },
-                        )?.value;
-                      }}
-                    />
-                  {:else if prop.type === "json"}
-                    <CodeMirror
-                      value={JSON.stringify(prop.value)}
-                      lang={json()}
-                      onchange={(newVal) => {
-                        prop.value = JSON.parse(newVal);
-                      }}
-                    />
-                  {:else if prop.type === "html"}
-                    <CodeMirror
-                      value={prop.rawHtml}
-                      lang={json()}
-                      onchange={(newVal) => {
-                        // return if not valid html
-                        const doc = document.createElement("div");
-                        doc.innerHTML = newVal;
-                        if (!newVal || doc.innerHTML !== newVal) {
-                          return;
-                        }
+                {#if prop.type === "number"}
+                  <input
+                    id={inputId}
+                    class="rounded-lg border border-neutral-300 p-2"
+                    type="number"
+                    value={(prop.value as string).toString()}
+                    oninput={(e) => {
+                      prop.value = parseInt(
+                        (e?.target as unknown as { value: string })?.value,
+                      );
+                    }}
+                  />
+                {:else if prop.type === "text"}
+                  <TextInput
+                    id={inputId}
+                    label={prop.name}
+                    hideLabel={true}
+                    value={prop.value! as string}
+                    setValue={(newVal) => (prop.value = newVal)}
+                  />
+                {:else if prop.type === "bool"}
+                  <Switch
+                    id={inputId}
+                    label={prop.name}
+                    hideLabel={true}
+                    value={prop.value as boolean}
+                    handleChange={(newVal) => (prop.value = newVal)}
+                  />
+                {:else if prop.type === "select"}
+                  <Select
+                    id={inputId}
+                    label={prop.name}
+                    hideLabel={true}
+                    value={prop.label}
+                    items={prop.options! as { value: string; label: string }[]}
+                    onchange={(nextVal) => {
+                      if (!nextVal) {
+                        return;
+                      }
+                      prop.value = prop.options?.find(
+                        (opt: { label: string }) => {
+                          return opt.label === nextVal;
+                        },
+                      )?.value;
+                    }}
+                  />
+                {:else if prop.type === "json"}
+                  <CodeMirror
+                    value={JSON.stringify(prop.value)}
+                    lang={json()}
+                    onchange={(newVal) => {
+                      prop.value = JSON.parse(newVal);
+                    }}
+                  />
+                {:else if prop.type === "html"}
+                  <CodeMirror
+                    value={prop.rawHtml}
+                    lang={json()}
+                    onchange={(newVal) => {
+                      // return if not valid html
+                      const doc = document.createElement("div");
+                      doc.innerHTML = newVal;
+                      if (!newVal || doc.innerHTML !== newVal) {
+                        return;
+                      }
 
-                        prop.value = createRawSnippet(() => ({
-                          render: () => newVal,
-                        }));
-                        prop.rawHtml = newVal;
-                      }}
-                    />
-                  {:else if prop.type === "func"}
-                    <Tag>
-                      <span class="italic">
-                        Function: {prop.schema || "No schema provided"}
-                      </span>
-                    </Tag>
-                  {/if}
+                      prop.value = createRawSnippet(() => ({
+                        render: () => newVal,
+                      }));
+                      prop.rawHtml = newVal;
+                    }}
+                  />
+                {:else if prop.type === "func"}
+                  <Tag>
+                    <span class="italic">
+                      Function: {prop.schema || "No schema provided"}
+                    </span>
+                  </Tag>
+                {/if}
               {/each}
 
               {#if currStory.mocks}
@@ -270,20 +270,22 @@
 
                 <h3 class="text-neutral-500">Mocks</h3>
 
-                {#each currStory.mocks as currMock}
-                  <h4 class="text-neutral-700 text-sm">{currMock.name || "Unnamed Mock"}</h4>
+                {#each currStory.mocks as currMock, i (i)}
+                  <h4 class="text-sm text-neutral-700">
+                    {currMock.name || "Unnamed Mock"}
+                  </h4>
 
                   {#key currMock}
-                    <div class="mocks pl-4 mb-4">
+                    <div class="mocks mb-4 pl-4">
                       <Select
                         id={(currMock.name || "mock") + "-status"}
-                        label={"Status:"}
+                        label="Status:"
                         hideLabel={false}
                         value={(currMock.status || 200).toString()}
                         items={[
-                          {value:"200", label: "Success"},
-                          {value:"400", label: "Bad Request"},
-                          {value:"500", label: "Server Error"},
+                          { value: "200", label: "Success" },
+                          { value: "400", label: "Bad Request" },
+                          { value: "500", label: "Server Error" },
                         ]}
                         onchange={(nextVal) => {
                           if (!nextVal) {
@@ -293,7 +295,7 @@
                         }}
                       />
 
-                      <hr class="mt-4 mb-2" />
+                      <hr class="mb-2 mt-4" />
 
                       <Textarea
                         id={(currMock.name || "mock") + "-body"}

--- a/frontend/src/components/Stories/StoriesDisplay.svelte
+++ b/frontend/src/components/Stories/StoriesDisplay.svelte
@@ -302,7 +302,11 @@
                         label="Body"
                         value={JSON.stringify(currMock.body || "")}
                         setValue={(newValue) => {
-                          currMock.body = JSON.parse(newValue);
+                          try {
+                            currMock.body = JSON.parse(newValue);
+                          } catch {
+                            // JSON not valid, do nothing
+                          }
                         }}
                       />
                     </div>

--- a/frontend/src/components/screens/AssignThemesForm/mocks.ts
+++ b/frontend/src/components/screens/AssignThemesForm/mocks.ts
@@ -5,4 +5,5 @@ export const CONSULTATION_ID = "folder1";
 export const assignMock = {
   url: getApiAssignThemesUrl(CONSULTATION_ID),
   method: "POST",
+  name: "assignMock"
 };

--- a/frontend/src/components/screens/AssignThemesForm/mocks.ts
+++ b/frontend/src/components/screens/AssignThemesForm/mocks.ts
@@ -5,5 +5,5 @@ export const CONSULTATION_ID = "folder1";
 export const assignMock = {
   url: getApiAssignThemesUrl(CONSULTATION_ID),
   method: "POST",
-  name: "assignMock"
+  name: "assignMock",
 };

--- a/frontend/src/global/types.ts
+++ b/frontend/src/global/types.ts
@@ -314,5 +314,6 @@ export interface Mock {
   status?: number;
   method?: string;
   throws?: Error;
+  name?: string;
   callback?: (args: RequestInit | { url: string; params: unknown }) => void;
 }


### PR DESCRIPTION
## Context
Some stories have mocks applied but they are fixed with no way to adjust them through the UI without making code changes.

## Changes proposed in this pull request

This PR adds extra functionality to the StoriesDisplay component that allows the user to change the status and body of mocks applied to the current story while on the "interactive" tab.

## Guidance to review
Test the new functionality on /stories route.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
