### PR TITLE
PRO-241: Remove theme mapping sign off legacy

### DIFF
--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -282,7 +282,7 @@ class ConsultationViewSet(ModelViewSet):
         Export themes to S3 and submit AWS batch job to assign themes to responses.
 
         Behaviour depends on consultation stage:
-        - FINALISING_THEMES / THEME_SIGN_OFF: exports candidate themes and assigns
+        - FINALISING_THEMES: exports candidate themes and assigns
           them to responses (CandidateThemeResponse), without changing stage.
         - Other stages: exports selected themes and assigns them to responses
           (ResponseAnnotation), advancing stage to ASSIGNING_THEMES.
@@ -292,10 +292,7 @@ class ConsultationViewSet(ModelViewSet):
 
         consultation = self.get_object()
 
-        is_finalising = consultation.stage in (
-            Consultation.Stage.FINALISING_THEMES,
-            Consultation.Stage.THEME_SIGN_OFF,
-        )
+        is_finalising = consultation.stage == Consultation.Stage.FINALISING_THEMES
 
         if is_finalising:
             # During finalising: assign candidate themes to responses

--- a/backend/consultations/migrations/0100_remove_legacy_stage_choices.py
+++ b/backend/consultations/migrations/0100_remove_legacy_stage_choices.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("consultations", "0099_alter_consultation_stage_default"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="consultation",
+            name="stage",
+            field=models.CharField(
+                choices=[
+                    ("setup", "Data Setup"),
+                    ("finding_themes", "Finding Themes"),
+                    ("finalising_themes", "Finalising Themes"),
+                    ("assigning_themes", "Assigning Themes"),
+                    ("analysis", "Analysis"),
+                ],
+                default="finalising_themes",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/backend/consultations/models.py
+++ b/backend/consultations/models.py
@@ -42,18 +42,12 @@ class TimeStampedModel(models.Model):
 
 class Consultation(UUIDPrimaryKeyModel, TimeStampedModel):  # type:ignore
     class Stage(models.TextChoices):
-        # New stages
         SETUP = "setup", "Data Setup"
         FINDING_THEMES = "finding_themes", "Finding Themes"
         FINALISING_THEMES = "finalising_themes", "Finalising Themes"
         ASSIGNING_THEMES = "assigning_themes", "Assigning Themes"
 
-        # Both old and new stages
         ANALYSIS = "analysis", "Analysis"
-
-        # Old stages
-        THEME_SIGN_OFF = "theme_sign_off", "Theme Sign Off"
-        THEME_MAPPING = "theme_mapping", "Theme Mapping"
 
     class ModelName(models.TextChoices):
         GPT_4O = "gpt-4o-sweden"

--- a/e2e_tests/fixtures.ts
+++ b/e2e_tests/fixtures.ts
@@ -1,4 +1,4 @@
-type ConsultationStage = "setup" | "analysis" | "finalising_themes" | "theme_sign_off";
+type ConsultationStage = "setup" | "analysis" | "finalising_themes";
 
 export type Theme = {
   name: string;

--- a/frontend/src/components/finalising-themes/ConsultationStagePanel/ConsultationStagePanel.svelte
+++ b/frontend/src/components/finalising-themes/ConsultationStagePanel/ConsultationStagePanel.svelte
@@ -47,17 +47,7 @@
       step: { order: 2, label: "Finalising Themes", icon: CheckCircle },
       title: "Finalising Themes",
     },
-    // Legacy alias - kept during data migration (Expand phase)
-    theme_sign_off: {
-      step: { order: 2, label: "Finalising Themes", icon: CheckCircle },
-      title: "Finalising Themes",
-    },
     assigning_themes: {
-      step: { order: 3, label: "Assigning Themes (AI)", icon: WandStars },
-      title: "AI Assignment in Progress",
-    },
-    // Legacy alias - kept during data migration (Expand phase)
-    theme_mapping: {
       step: { order: 3, label: "Assigning Themes (AI)", icon: WandStars },
       title: "AI Assignment in Progress",
     },
@@ -79,15 +69,8 @@
     STAGE_CONFIGS[consultation.stage] ?? STAGE_CONFIGS.finalising_themes,
   );
 
-  // Determine which content variant to show - handles both old and new stage values
-  let isFinalisingThemes = $derived(
-    consultation.stage === "finalising_themes" ||
-      consultation.stage === "theme_sign_off",
-  );
-  let isAssigningThemes = $derived(
-    consultation.stage === "assigning_themes" ||
-      consultation.stage === "theme_mapping",
-  );
+  let isFinalisingThemes = $derived(consultation.stage === "finalising_themes");
+  let isAssigningThemes = $derived(consultation.stage === "assigning_themes");
   let isAnalysis = $derived(consultation.stage === "analysis");
 
   // Title adapts to sub-state during finalising

--- a/frontend/src/components/finalising-themes/ConsultationStagePanel/ConsultationStagePanel.test.ts
+++ b/frontend/src/components/finalising-themes/ConsultationStagePanel/ConsultationStagePanel.test.ts
@@ -61,32 +61,6 @@ describe("ConsultationStagePanel", () => {
     ).toBeInTheDocument();
   });
 
-  it("should treat legacy theme_sign_off stage as finalising_themes", () => {
-    render(ConsultationStagePanel, {
-      consultation: { id, stage: "theme_sign_off" },
-      questionsCount: 10,
-      finalisedQuestionCount: 3,
-      allQuestionsFinalised: false,
-      onConfirmClick: onConfirmClickMock,
-    });
-
-    expect(
-      screen.getByText(/3 of 10 questions signed off/i),
-    ).toBeInTheDocument();
-  });
-
-  it("should treat legacy theme_mapping stage as assigning_themes", () => {
-    render(ConsultationStagePanel, {
-      consultation: { id, stage: "theme_mapping" },
-      questionsCount: 10,
-      finalisedQuestionCount: 10,
-      allQuestionsFinalised: true,
-      onConfirmClick: onConfirmClickMock,
-    });
-
-    expect(screen.getByText("AI Assignment in Progress")).toBeInTheDocument();
-  });
-
   it("should render correctly for analysis stage", () => {
     render(ConsultationStagePanel, {
       consultation: { id, stage: "analysis" },

--- a/frontend/src/components/screens/FinalisingThemesArchive/FinalisingThemesArchive.test.ts
+++ b/frontend/src/components/screens/FinalisingThemesArchive/FinalisingThemesArchive.test.ts
@@ -123,26 +123,7 @@ describe("FinalisingThemesArchive", () => {
     });
   });
 
-  it("should render correct panel for Assignment stage (legacy theme_mapping)", async () => {
-    mockRoute({
-      ...consultationMock,
-      body: {
-        ...consultationMock.body,
-        stage: "theme_mapping",
-      },
-    });
-    mockRoute(questionsAllSignedOffMock);
-
-    render(FinalisingThemesArchive, {
-      consultationId: CONSULTATION_ID,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("AI Assignment in Progress")).toBeInTheDocument();
-    });
-  });
-
-  it("should render correct panel for Assignment stage (assigning_themes)", async () => {
+  it("should render correct panel for Assignment stage", async () => {
     mockRoute({
       ...consultationMock,
       body: {

--- a/frontend/src/global/types.ts
+++ b/frontend/src/global/types.ts
@@ -26,10 +26,7 @@ export interface Question {
 export type ConsultationStage =
   | "finalising_themes"
   | "assigning_themes"
-  | "analysis"
-  // Legacy values for now removed stages - to be deleted once backend data is updated
-  | "theme_sign_off"
-  | "theme_mapping";
+  | "analysis";
 export interface NextResponseInfo {
   id: string;
   consultation_id: string;


### PR DESCRIPTION
This is a follow up PR to #1360 that removes the theme sign_off/mapping in the codebase now that they are migrated to finalising themes and assigning themes