### PR TITLE
E2E tests: Add three user tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Installation instructions assume using a Mac with Homebrew.
 - pre-commit (`brew install pre-commit`)
 - Postegres(optional) (`brew install postgresql`) if you are getting `psycopg2` error during `make setup`
 
+### Prerequisites for running end-to-end tests
+
+Make sure that you have `coreutils` installed:
+`brew install coreutils`
+
+Also note that you will need to add a personal access token on github with `read:packages` access and then use this to log in on the command line before running the end-to-end tests:
+```
+echo $PASSWORD | docker login ghcr.io -u <username> --password-stdin
+```
+
 ### Clone and install
 
 ```
@@ -78,13 +88,8 @@ make test-frontend
 Run end-to-end tests:
 
 ```
+docker compose up -d postgres # postgres must be running already
 make test-end-to-end
-```
-
- If you are getting error while running e2e that the frontend is failing to start during the docker spin up its likely because of the timeout module that is missing and you will need to run
-
-```shell
-brew install coreutils
 ```
 
 ### VSCode setup (recommended)

--- a/backend/consultations/api/filters.py
+++ b/backend/consultations/api/filters.py
@@ -1,5 +1,5 @@
 from django.db.models import Count
-from django_filters import UUIDFilter
+from django_filters import CharFilter, UUIDFilter
 from django_filters.rest_framework import BaseInFilter, BooleanFilter, FilterSet
 from pgvector.django import CosineDistance
 from rest_framework import serializers
@@ -75,6 +75,7 @@ def get_filtered_responses(query_params, consultation_id, question_id=None):
 
 
 class UserFilter(FilterSet):
+    email = CharFilter(field_name="email", lookup_expr="exact")
     is_in = BooleanFilter(method="filter_by_consultation")
     consultation_id = UUIDFilter(method="filter_by_consultation")
 

--- a/e2e_tests/tests/helpers.ts
+++ b/e2e_tests/tests/helpers.ts
@@ -72,6 +72,44 @@ export async function deleteFixtureData(fixtureData: Fixture) {
 }
 
 /**
+ * Tears down user by email
+ */
+export async function deleteUser(email: string) {
+  const context = await apirequest.newContext();
+  const authData = await getToken(context);
+
+  // Retrieve user ID by email
+  const response = await context.fetch(`/api/users/?email=${email}`, {
+    method: "GET",
+    headers: {
+      Cookie: `sessionId=${authData.sessionId}; accessToken=${authData.accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok())
+    throw new Error(`Failed to retrieve user ID: ${response.status}`)
+
+  const data = await response.json();
+  if (!data?.results?.length || !data.results[0].id)
+    throw new Error(`No user found with email: ${email}`);
+
+  const id = data.results[0].id;
+
+  const fixture_response = await context.fetch(`/api/users/${id}/`, {
+    method: "DELETE",
+    headers: {
+      Cookie: `sessionId=${authData.sessionId}; accessToken=${authData.accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!fixture_response.ok())
+    throw new Error(`User deletion failed: ${fixture_response.status}
+    ${await fixture_response.text()}`);
+}
+
+/**
  * Finds the first consultation link that points to an actual consultation detail page
  * (not the consultations list page itself)
  */

--- a/e2e_tests/tests/users.e2e.ts
+++ b/e2e_tests/tests/users.e2e.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+
+import {
+  createFixtureData,
+  deleteFixtureData,
+  deleteUser,
+  getFirstConsultationLink
+} from './helpers';
+import { defaultUser, setupConsultation } from '../fixtures';
+import type { FixtureReference } from "../fixtures";
+
+
+test.describe('Users Page', () => {
+  let uniqueEmail: string;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/support/users');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('adding a user that already exists shows an error message', async ({ page }) => {
+    // Click the "Add User" button to open the form
+    await page.locator('a[href="/support/users/new"]').click();
+    // Check if form is open
+    await expect(page).toHaveURL(/\/support\/users\/new/);
+    await page.waitForLoadState('networkidle');
+    // Fill in the form with an existing user's email
+    await page.getByRole('textbox', { name: /email/i }).fill(defaultUser.email);
+    // Submit the form
+    await page.getByRole('button', { name: 'Add user' }).click();
+    // Check for the error message indicating the user already exists
+    await expect(page.getByText('Error: user with this email address already exists.')).toBeVisible();
+  });
+
+  test('adding a user with valid details succeeds', async ({ page }) => {
+    // Click the "Add User" button to open the form
+    await page.locator('a[href="/support/users/new"]').click();
+    // Check if form is open
+    await expect(page).toHaveURL(/\/support\/users\/new/);
+    await page.waitForLoadState('networkidle');
+    // Fill in the form with valid details
+    uniqueEmail = `testuser${Date.now()}@example.com`;
+    await page.getByRole('textbox', { name: /email/i }).fill(uniqueEmail);
+    // Submit the form
+    await page.getByRole('button', { name: 'Add user' }).click();
+    // Check that it goes back to users list page
+    await expect(page).toHaveURL(/\/support\/users/);
+    await page.waitForLoadState('networkidle');
+    // Check new user appears in the list
+    await expect(page.getByText(uniqueEmail)).toBeVisible()
+  });
+
+  test.afterEach(async () => {
+    if (uniqueEmail) {
+      await deleteUser(uniqueEmail);
+    }
+  });
+
+});
+
+test.describe('Consultation Details - Adding Users', () => {
+
+  let testData: FixtureReference = {};
+
+  test.beforeAll(async ({ request }) => {
+    testData = await createFixtureData(request, {
+      consultations: [setupConsultation],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/support/consultations');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('Ensure that adding a user to a consultation persists and shows up in the consultation details', async ({ page }) => {
+    // Navigate to the consultation details page
+    const result = await getFirstConsultationLink(page);
+    expect(result).toBeTruthy();
+    const consultationId = result!.href.match(/\/consultations\/([^/]+)/)?.[1];
+    await page.goto(`/support/consultations/${consultationId}/users/new`);
+    await page.waitForLoadState('networkidle');
+    // Fill in the form with valid details
+    await page.getByRole('textbox', { name: /email/i }).fill(defaultUser.email);
+    // Submit the form
+    await page.getByRole('button', { name: /Add users/i }).click();
+    await expect(page.getByText("Successfully added 1 users to consultation.")).toBeVisible();
+    // Go back to consultation details page
+    await page.goto(`/support/consultations/${consultationId}`);
+    await page.waitForLoadState('networkidle');
+    // Check that the user appears in the consultation details page
+    await expect(page.getByText(defaultUser.email)).toBeVisible();
+  });
+
+  test.afterAll(async () => {
+    await deleteFixtureData(testData);
+  });
+
+});

--- a/frontend/astro.config.ts
+++ b/frontend/astro.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
       // svelte/elements is a types-only export, exclude from dependency scanning
       exclude: ["svelte/elements"],
     },
+    server: {
+      hmr: {
+        host: "0.0.0.0",
+        clientPort: 3000,
+      },
+    },
   },
 
   image: {


### PR DESCRIPTION
# Context
  
  Adds e2e tests covering the user management support console pages. Includes a fix to the Vite dev
  server HMR configuration so tests run reliably when the frontend is running inside Docker (via make 
  test-end-to-end).
  
 # Changes proposed in this pull request

  - e2e_tests/tests/users.e2e.ts — three new Playwright tests:
    - Adding a user that already exists shows a validation error
    - Adding a new user succeeds and the user appears in the list
    - Adding a user to a consultation persists and shows in the consultation details
  - README.md — documents coreutils and GHCR login as prerequisites for running e2e tests locally

Probably temporary change to be removed (but included for discussion):
 - frontend/astro.config.ts — explicit HMR host/port config so Vite's WebSocket connects correctly
  when running in Docker, preventing the error overlay from blocking test interactions

#  Guidance to review

 Run the e2e tests locally:
- with `make test-end-to-end` 
- or (for more reliable testing) run `make serve in one terminal and then `cd e2e_tests && playwright test users.e2e.ts` in another

Verify all three new tests pass across browsers.

# Note

I noted some issues while trying to run the tests and have documented some of these in https://incubatorforartificialintelligence.atlassian.net/wiki/spaces/Consult/pages/25559057/Tech+Debt#Development-vs-Testing-vs-Deployment and https://incubatorforartificialintelligence.atlassian.net/wiki/spaces/Consult/pages/25559057/Tech+Debt#Write-Playwright-End-to-End-Tests.

I also made the astro config change to help with testing locally via make - we need to think about how to make this process more robust.