### PR TITLE
Bugfix: pro-377 - apply infra changes unconditionally and import existing SSM params 

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -134,6 +134,7 @@ jobs:
     outputs:
       services_matrix: ${{ steps.filter.outputs.services_matrix }}
       targets_matrix: ${{ steps.filter.outputs.targets_matrix }}
+      all_parameters_exist: ${{ steps.filter.outputs.all_parameters_exist }}
     permissions:
       id-token: write
     steps:
@@ -154,6 +155,7 @@ jobs:
           config=$(cat .github/service-config.json)
           services_entries='[]'
           targets_entries='[]'
+          all_parameters_exist=true
 
           # Process substitution avoids a pipe subshell so entries
           # accumulate correctly across iterations
@@ -161,13 +163,12 @@ jobs:
             service=$(echo $row | jq -r '.service')
             new_tag=$(echo $row | jq -r '.tag')
 
-            # Falls back to empty string if the parameter doesn't exist yet (first deploy)
             ssm_name="/i-dot-ai-${{ needs.set-vars.outputs.environment }}-${{ needs.set-vars.outputs.app-name }}/env_secrets/${service}/IMAGE_TAG"
             echo "querying SSM: ${ssm_name}"
             current_tag=$(aws ssm get-parameter \
               --name "${ssm_name}" \
               --query "Parameter.Value" \
-              --output text 2>&1) && echo "SSM result: ${current_tag}" || { echo "SSM error: ${current_tag}"; current_tag=""; }
+              --output text 2>&1) && echo "SSM result: ${current_tag}" || { echo "SSM error: ${current_tag}"; current_tag=""; all_parameters_exist=false; }
 
             echo "service=${service} new_tag=${new_tag} current_tag=${current_tag} match=$([[ "$new_tag" == "$current_tag" ]] && echo yes || echo no)"
             if [[ "$new_tag" != "$current_tag" ]]; then
@@ -179,11 +180,16 @@ jobs:
             fi
           done < <(echo '${{ needs.set-vars.outputs.service_matrix }}' | jq -c '.[]')
 
+          if [[ "${all_parameters_exist}" == "false" ]]; then
+            echo "One or more SSM parameters do not exist yet — infrastructure has not been deployed. Skipping app release."
+          fi
+
+          echo "all_parameters_exist=${all_parameters_exist}" >> $GITHUB_OUTPUT
           echo "services_matrix=$services_entries" >> $GITHUB_OUTPUT
           echo "targets_matrix=$targets_entries" >> $GITHUB_OUTPUT
 
   build-images:
-    if: ${{ needs.filter-services.outputs.services_matrix != '[]' }}
+    if: ${{ needs.filter-services.outputs.services_matrix != '[]' && needs.filter-services.outputs.all_parameters_exist == 'true' }}
     strategy:
       matrix:
         object: ${{ fromJson(needs.filter-services.outputs.services_matrix) }}
@@ -210,7 +216,7 @@ jobs:
   # Updates SSM with the new image tag for each changed service, once per service,
   # before Terraform reads it during deploy-containers.
   update-ssm-image-tags:
-    if: ${{ needs.filter-services.outputs.services_matrix != '[]' }}
+    if: ${{ needs.filter-services.outputs.services_matrix != '[]' && needs.filter-services.outputs.all_parameters_exist == 'true' }}
     runs-on: ${{ needs.start-runner.outputs.label }}
     strategy:
       matrix:
@@ -237,7 +243,7 @@ jobs:
   # Terraform reads the updated image tags from SSM (written by update-ssm-image-tags)
   # so only task definitions whose tag has changed will be updated in ECS.
   deploy-containers:
-    if: ${{ needs.filter-services.outputs.targets_matrix != '[]' }}
+    if: ${{ needs.filter-services.outputs.targets_matrix != '[]' && needs.filter-services.outputs.all_parameters_exist == 'true' }}
     strategy:
       matrix:
         object: ${{ fromJson(needs.filter-services.outputs.targets_matrix) }}

--- a/.github/workflows/release-infra.yml
+++ b/.github/workflows/release-infra.yml
@@ -35,11 +35,8 @@ jobs:
       repo: ${{ steps.export.outputs.repo }}
       infra-config-repo: ${{ steps.export.outputs.infra-config-repo }}
       environment: ${{ steps.env-var.outputs.environment }}
-      terraform-changed: ${{ steps.check-terraform.outputs.terraform-changed }}
-      lambda-changed: ${{ steps.check-terraform.outputs.lambda-changed }}
       commit-hash: ${{ steps.export.outputs.commit-hash }}
       sha-short: ${{ steps.export.outputs.sha-short }}
-      should-deploy: ${{ steps.should-deploy.outputs.should-deploy }}
 
     steps:
       - name: Validate prod deployment uses a release tag
@@ -94,29 +91,7 @@ jobs:
           echo "environment=${ENVIRONMENT}"
           echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
 
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
-        id: check-terraform
-        with:
-          filters: |
-            terraform-changed:
-              - 'terraform/**'
-            lambda-changed:
-              - 'lambda/**'
-
-      - id: should-deploy
-        run: |
-          if [[ "${{ github.event_name }}" == "release" || \
-                "${{ github.event_name }}" == "workflow_dispatch" || \
-                "${{ github.event_name }}" == "push" || \
-                "${{ steps.check-terraform.outputs.terraform-changed }}" == "true" || \
-                "${{ steps.check-terraform.outputs.lambda-changed }}" == "true" ]]; then
-            echo "should-deploy=true" >> $GITHUB_OUTPUT
-          else
-            echo "should-deploy=false" >> $GITHUB_OUTPUT
-          fi
-
   start-runner:
-    if: needs.set-vars.outputs.should-deploy == 'true'
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/start-runner.yml@main
     needs: set-vars
     permissions: write-all
@@ -134,7 +109,7 @@ jobs:
   build-lambdas:
     needs:
       - set-vars
-    if: needs.set-vars.outputs.lambda-changed == 'true' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: always()
     uses: ./.github/workflows/build-lambda-artifacts.yml
     with:
       upload_directory: ./lambda/build
@@ -164,7 +139,7 @@ jobs:
   determine-success:
     needs: [set-vars, start-runner, build-infra]
     runs-on: ${{ needs.start-runner.outputs.label }}
-    if: always() && needs.set-vars.outputs.should-deploy == 'true' && needs.set-vars.outputs.environment == 'prod'
+    if: always() && needs.set-vars.outputs.environment == 'prod'
     outputs:
       success: ${{ steps.success.outputs.success }}
     steps:
@@ -179,7 +154,7 @@ jobs:
   notify-slack:
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/slack-notify.yml@main
     needs: [set-vars, start-runner, build-infra, determine-success]
-    if: always() && needs.set-vars.outputs.should-deploy == 'true' && needs.set-vars.outputs.environment == 'prod'
+    if: always() && needs.set-vars.outputs.environment == 'prod'
     with:
       WORKFLOW_PASSED: ${{ needs.determine-success.outputs.success == 'true' }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
@@ -201,7 +176,7 @@ jobs:
       - notify-slack
     uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/stop-runner.yml@main
     permissions: write-all
-    if: always() && needs.set-vars.outputs.should-deploy == 'true' && needs.start-runner.outputs.use-persisted == 0
+    if: always() && needs.start-runner.outputs.use-persisted == 0
     with:
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
       EC2_INSTANCE_ID: ${{ needs.start-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
# Context

 The release-infra workflow (after change by #1333) was silently skipping deployments on merges to main, and terraform could easily get into a confused state if the SSM parameters were written by release-app. Fixes for both of these issues.
  
#  Changes proposed in this pull request

  release-infra.yml: Remove the paths-filter-based should-deploy gate entirely. release-infra now always runs when triggered, regardless of which files changed. The filtering was only relevant for workflow_run triggers (tag pushes, releases, and manual dispatches already bypassed it). It doesn't ever make sense to do this filtering in practice as there is no way to know what was previously deployed, even when merging main, as a different branch may have been released on dev or preprod.

  terraform/secrets.tf: Add an import block for the image_tag_placeholders SSM parameters. These parameters already exist in AWS but are not in Terraform state, so without this Terraform would attempt to create them and fail with ParameterAlreadyExists. The import
  block adopts the existing parameters into state on the next apply. The existing ignore_changes = [value] lifecycle rule ensures the real image tag values are not overwritten.

#  Guidance to review

  The key question is whether always running release-infra on every merge to main is acceptable. Previously it only ran when terraform/** or lambda/** changed — now it runs unconditionally. Terraform apply is idempotent so there's no correctness risk, just a small increase in CI time per merge.

  The import block is probably a good permanent thing to leave in place, even though it will be skipped after the first run.

