### PR TITLE
PRO-376: BBC consultation timeout errro fix

### DIFF
--- a/backend/consultations/api/views/response.py
+++ b/backend/consultations/api/views/response.py
@@ -97,12 +97,16 @@ class ResponseViewSet(ModelViewSet):
                 models.Response.objects.filter(read_by=self.request.user, pk=OuterRef("pk"))
             ),
             annotation_is_edited=Exists(
-                models.ResponseAnnotation.history.filter(id=OuterRef("annotation__id")).values(
-                    "id"
-                )[1:]
+                models.ResponseAnnotation.history.filter(
+                    id=OuterRef("annotation__id"),
+                    history_type="~",  # django-simple-history: '+' = created, '~' = updated, '-' = deleted see:https://django-simple-history.readthedocs.io/en/latest/quick_start.html#what-is-django-simple-history-doing-behind-the-scenes
+                )
             ),
+            # Safe to query live table: ResponseSerializer.update() always calls
+            # annotation.save() after any theme change, so annotation_is_edited will be
+            # True even if all human-assigned themes were subsequently removed.
             annotation_has_human_assigned_themes=Exists(
-                models.ResponseAnnotationTheme.history.filter(
+                models.ResponseAnnotationTheme.objects.filter(
                     response_annotation_id=OuterRef("annotation__id"),
                     assigned_by__isnull=False,
                 )


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
This branch fixes a production issues observed on large consultations (6741+ responses) for BBC

API timeout causing "Unexpected token '<'" JSON parse error

The response list endpoint was timing out on large consultations, causing Gunicorn to return an HTML error page instead of JSON. The root cause was two correlated Exists subqueries in `ResponseViewSet.get_queryset` that ran against the `django-simple-history` tables:

- `annotation_is_edited` used an `OFFSET 1` slice on the history table, which PostgreSQL cannot short-circuit because it must scan to find a second matching row for every response in the `queryset.`
- `annotation_has_human_assigned_themes` queried the unbounded history table instead of the live table.

On a consultation with thousands of responses these subqueries ran far too slowly to complete within the worker timeout.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
This PR introduced changes that: 
`response.py`: Replace the OFFSET 1 history slice with a `history_type="~"` filter (semantically equivalent — the first save always produces `+`, every subsequent save produces `~`). Replace the history-table lookup for `annotation_has_human_assigned_themes` with a live-table query on `ResponseAnnotationTheme` (safe because `get_is_edited` in the serializer combines both annotations via OR, so any prior human assignment is covered by `annotation_is_edited`).
`gunicorn_config.py`: Raise the default timeout from 30s to 60s via `GUNICORN_TIMEOUT` env var.

[Ticket](https://linear.app/iai-consult/issue/PRO-376/investigate-issues-reported-by-freya)
