### PR TITLE
PRO-381: Fix finalising selected themes

### DIFF
--- a/frontend/src/components/screens/FinalisingThemesDetail/FinalisingThemesDetail.svelte
+++ b/frontend/src/components/screens/FinalisingThemesDetail/FinalisingThemesDetail.svelte
@@ -20,6 +20,7 @@
     type Question,
     type GeneratedTheme,
     type SelectedTheme,
+    type SelectedThemesResponse,
   } from "../../../global/types";
 
   import Panel from "../../dashboard/Panel/Panel.svelte";
@@ -44,10 +45,10 @@
     type ErrorType,
   } from "../../finalising-themes/ErrorModal/ErrorModal.svelte";
   import {
-    buildSelectedThemeCreateQuery,
-    buildSelectedThemeDeleteQuery,
-    buildSelectedThemesGetQuery,
+    createSelectedTheme,
+    deleteSelectedTheme,
   } from "../../../global/queries/selectedThemes/queries";
+  import type { SelectedThemeMutationError } from "../../../global/queries/selectedThemes/types";
 
   interface Props {
     consultationId: string;
@@ -56,36 +57,7 @@
 
   let { consultationId = "", questionId = "" }: Props = $props();
 
-  let selectedThemes = $derived(
-    buildSelectedThemesGetQuery(consultationId, questionId),
-  );
-  let selectedThemesCreate = $derived(
-    buildSelectedThemeCreateQuery(consultationId, questionId, async () => {
-      refreshThemes();
-    }),
-  );
-  let selectedThemesDelete = $derived(
-    buildSelectedThemeDeleteQuery(
-      consultationId,
-      questionId,
-      async () => refreshThemes(),
-      async (error) => {
-        if (error.status === 404) {
-          // No action or error needed if status 404 (theme already deselected)
-          refreshThemes();
-        } else if (error.status === 412) {
-          errorData = {
-            type: "remove-conflict",
-            lastModifiedBy: error.data?.last_modified_by?.email || "",
-            latestVersion: error.data?.latest_version || "",
-          };
-        } else {
-          errorData = { type: "unexpected" };
-          console.error(error.message);
-        }
-      },
-    ),
-  );
+  const selectedThemesStore = createFetchStore<SelectedThemesResponse>();
   const generatedThemesStore = createFetchStore<GeneratedThemesResponse>();
   const generatedThemesSelectStore = createFetchStore();
   const questionStore = createFetchStore<Question>();
@@ -124,7 +96,7 @@
   let dataRequested: boolean = $state(false);
 
   const errorModalOnClose = () => {
-    selectedThemes.fetch(
+    $selectedThemesStore.fetch(
       getApiGetSelectedThemesUrl(consultationId, questionId),
     );
     $generatedThemesStore.fetch(
@@ -134,6 +106,9 @@
   };
 
   onMount(() => {
+    $selectedThemesStore.fetch(
+      getApiGetSelectedThemesUrl(consultationId, questionId),
+    );
     $generatedThemesStore.fetch(
       getApiGetGeneratedThemesUrl(consultationId, questionId),
     );
@@ -142,17 +117,18 @@
   });
 
   const createTheme = async (title: string, description: string) => {
-    selectedThemesCreate.fetch({
-      body: {
-        name: title,
-        description: description,
-      },
-    });
+    try {
+      await createSelectedTheme(consultationId, questionId, title, description);
+      refreshThemes();
+    } catch (error) {
+      console.error(error);
+      errorData = { type: "unexpected" };
+    }
   };
 
   const removeTheme = async (themeId: string) => {
-    const selectedTheme = selectedThemes.query.data?.results.find(
-      (theme: { id: string }) => theme.id === themeId,
+    const selectedTheme = $selectedThemesStore.data?.results.find(
+      (theme) => theme.id === themeId,
     );
 
     if (!selectedTheme) {
@@ -160,7 +136,29 @@
       return;
     }
 
-    selectedThemesDelete.fetch(themeId, selectedTheme.version);
+    try {
+      await deleteSelectedTheme(
+        consultationId,
+        questionId,
+        themeId,
+        selectedTheme.version,
+      );
+      refreshThemes();
+    } catch (error) {
+      const err = error as SelectedThemeMutationError;
+      if (err.status === 404) {
+        refreshThemes();
+      } else if (err.status === 412) {
+        errorData = {
+          type: "remove-conflict",
+          lastModifiedBy: err.last_modified_by?.email || "",
+          latestVersion: err.latest_version || "",
+        };
+      } else {
+        errorData = { type: "unexpected" };
+        console.error(error);
+      }
+    }
   };
 
   const updateTheme = async (
@@ -168,8 +166,8 @@
     title: string,
     description: string,
   ) => {
-    const selectedTheme = selectedThemes.query.data?.results.find(
-      (theme: { id: string }) => theme.id === themeId,
+    const selectedTheme = $selectedThemesStore.data?.results.find(
+      (theme) => theme.id === themeId,
     );
 
     if (!selectedTheme) {
@@ -184,7 +182,7 @@
           method: "PATCH",
           headers: {
             "Content-Type": "application/json",
-            "If-Match": selectedTheme.version,
+            "If-Match": String(selectedTheme.version),
           },
           body: JSON.stringify({
             name: title,
@@ -194,7 +192,7 @@
       );
 
       if (response.ok) {
-        selectedThemes.fetch(
+        $selectedThemesStore.fetch(
           getApiGetSelectedThemesUrl(consultationId, questionId),
         );
       } else if (response.status === 404) {
@@ -222,7 +220,7 @@
       "POST",
     );
 
-    await selectedThemes.fetch(
+    await $selectedThemesStore.fetch(
       getApiGetSelectedThemesUrl(consultationId, questionId),
     );
     await $generatedThemesStore.fetch(
@@ -247,7 +245,9 @@
   };
 
   const refreshThemes = () => {
-    selectedThemes.fetch();
+    $selectedThemesStore.fetch(
+      getApiGetSelectedThemesUrl(consultationId, questionId),
+    );
     $generatedThemesStore.fetch(
       getApiGetGeneratedThemesUrl(consultationId, questionId),
     );
@@ -303,7 +303,6 @@
 </script>
 
 {#if errorData}
-  <p>TRUE</p>
   <ErrorModal {...errorData} onClose={errorModalOnClose} />
 {/if}
 
@@ -356,7 +355,7 @@
             <h3>Selected Themes</h3>
 
             <Tag variant="primary-light">
-              {selectedThemes.query.data?.results.length} selected
+              {$selectedThemesStore.data?.results?.length ?? 0} selected
             </Tag>
           </div>
 
@@ -380,9 +379,9 @@
         </div>
 
         <p class="text-sm text-neutral-500">
-          {#if (selectedThemes.query.data?.results?.length ?? 0) > 0}
+          {#if ($selectedThemesStore.data?.results?.length ?? 0) > 0}
             Manage your {numSelectedThemesText(
-              selectedThemes.query.data?.results,
+              $selectedThemesStore.data?.results,
             )} for AI to assign responses to. Edit titles or descriptions, or add
             a new theme.
           {:else}
@@ -407,7 +406,7 @@
       </div>
     {/if}
 
-    {#if selectedThemes.query.data?.results.length === 0}
+    {#if $selectedThemesStore.data?.results?.length === 0}
       <div in:fade class="my-8 flex flex-col items-center justify-center gap-2">
         <div class="mb-2">
           <MaterialIcon size="2rem" color="fill-neutral-500">
@@ -422,7 +421,7 @@
       </div>
     {:else}
       <div class="mt-4">
-        {#each selectedThemes.query.data?.results as selectedTheme (selectedTheme.id)}
+        {#each $selectedThemesStore.data?.results ?? [] as selectedTheme (selectedTheme.id)}
           <div transition:slide={{ duration: 150 }} class="mb-4 last:mb-0">
             <SelectedThemeCard
               {consultationId}
@@ -441,8 +440,8 @@
         variant="primary"
         fullWidth={true}
         disabled={!dataRequested ||
-          selectedThemes.query.isPending ||
-          selectedThemes.query.data?.results.length === 0}
+          $selectedThemesStore.isLoading ||
+          ($selectedThemesStore.data?.results?.length ?? 0) === 0}
         handleClick={() =>
           (isConfirmFinalisingThemesModalOpen =
             !isConfirmFinalisingThemesModalOpen)}
@@ -453,11 +452,11 @@
           </MaterialIcon>
 
           <span>
-            {#if !dataRequested || selectedThemes.query.isPending}
+            {#if !dataRequested || $selectedThemesStore.isLoading}
               Loading Selected Themes
             {:else}
-              Sign Off Selected Themes ({selectedThemes.query.data?.results
-                .length})
+              Sign Off Selected Themes ({$selectedThemesStore.data?.results
+                ?.length ?? 0})
             {/if}
           </span>
         </div>
@@ -476,14 +475,14 @@
     >
       <p class="text-sm text-neutral-500">
         Are you sure you want to sign off on these {numSelectedThemesText(
-          selectedThemes.query.data?.results,
+          $selectedThemesStore.data?.results,
         )} for Question {$questionStore.data?.number}?
       </p>
 
       <h4 class="my-4 text-xs font-bold">Selected themes:</h4>
 
       <div class="max-h-64 overflow-y-auto">
-        {#each selectedThemes.query.data?.results as selectedTheme (selectedTheme.id)}
+        {#each $selectedThemesStore.data?.results ?? [] as selectedTheme (selectedTheme.id)}
           <Panel bg={true} border={false}>
             <h5 class="mb-1 text-xs font-bold">{selectedTheme.name}</h5>
             <p class="text-xs text-neutral-500">{selectedTheme.description}</p>

--- a/frontend/src/components/screens/FinalisingThemesDetail/FinalisingThemesDetail.svelte
+++ b/frontend/src/components/screens/FinalisingThemesDetail/FinalisingThemesDetail.svelte
@@ -20,7 +20,6 @@
     type Question,
     type GeneratedTheme,
     type SelectedTheme,
-    type SelectedThemesResponse,
   } from "../../../global/types";
 
   import Panel from "../../dashboard/Panel/Panel.svelte";
@@ -45,10 +44,10 @@
     type ErrorType,
   } from "../../finalising-themes/ErrorModal/ErrorModal.svelte";
   import {
-    createSelectedTheme,
-    deleteSelectedTheme,
+    buildSelectedThemeCreateQuery,
+    buildSelectedThemeDeleteQuery,
+    buildSelectedThemesGetQuery,
   } from "../../../global/queries/selectedThemes/queries";
-  import type { SelectedThemeMutationError } from "../../../global/queries/selectedThemes/types";
 
   interface Props {
     consultationId: string;
@@ -57,7 +56,36 @@
 
   let { consultationId = "", questionId = "" }: Props = $props();
 
-  const selectedThemesStore = createFetchStore<SelectedThemesResponse>();
+  let selectedThemes = $derived(
+    buildSelectedThemesGetQuery(consultationId, questionId),
+  );
+  let selectedThemesCreate = $derived(
+    buildSelectedThemeCreateQuery(consultationId, questionId, async () => {
+      refreshThemes();
+    }),
+  );
+  let selectedThemesDelete = $derived(
+    buildSelectedThemeDeleteQuery(
+      consultationId,
+      questionId,
+      async () => refreshThemes(),
+      async (error) => {
+        if (error.status === 404) {
+          // No action or error needed if status 404 (theme already deselected)
+          refreshThemes();
+        } else if (error.status === 412) {
+          errorData = {
+            type: "remove-conflict",
+            lastModifiedBy: error.data?.last_modified_by?.email || "",
+            latestVersion: error.data?.latest_version || "",
+          };
+        } else {
+          errorData = { type: "unexpected" };
+          console.error(error.message);
+        }
+      },
+    ),
+  );
   const generatedThemesStore = createFetchStore<GeneratedThemesResponse>();
   const generatedThemesSelectStore = createFetchStore();
   const questionStore = createFetchStore<Question>();
@@ -96,7 +124,7 @@
   let dataRequested: boolean = $state(false);
 
   const errorModalOnClose = () => {
-    $selectedThemesStore.fetch(
+    selectedThemes.fetch(
       getApiGetSelectedThemesUrl(consultationId, questionId),
     );
     $generatedThemesStore.fetch(
@@ -106,9 +134,6 @@
   };
 
   onMount(() => {
-    $selectedThemesStore.fetch(
-      getApiGetSelectedThemesUrl(consultationId, questionId),
-    );
     $generatedThemesStore.fetch(
       getApiGetGeneratedThemesUrl(consultationId, questionId),
     );
@@ -117,18 +142,17 @@
   });
 
   const createTheme = async (title: string, description: string) => {
-    try {
-      await createSelectedTheme(consultationId, questionId, title, description);
-      refreshThemes();
-    } catch (error) {
-      console.error(error);
-      errorData = { type: "unexpected" };
-    }
+    selectedThemesCreate.fetch({
+      body: {
+        name: title,
+        description: description,
+      },
+    });
   };
 
   const removeTheme = async (themeId: string) => {
-    const selectedTheme = $selectedThemesStore.data?.results.find(
-      (theme) => theme.id === themeId,
+    const selectedTheme = selectedThemes.query.data?.results.find(
+      (theme: { id: string }) => theme.id === themeId,
     );
 
     if (!selectedTheme) {
@@ -136,29 +160,7 @@
       return;
     }
 
-    try {
-      await deleteSelectedTheme(
-        consultationId,
-        questionId,
-        themeId,
-        selectedTheme.version,
-      );
-      refreshThemes();
-    } catch (error) {
-      const err = error as SelectedThemeMutationError;
-      if (err.status === 404) {
-        refreshThemes();
-      } else if (err.status === 412) {
-        errorData = {
-          type: "remove-conflict",
-          lastModifiedBy: err.last_modified_by?.email || "",
-          latestVersion: err.latest_version || "",
-        };
-      } else {
-        errorData = { type: "unexpected" };
-        console.error(error);
-      }
-    }
+    selectedThemesDelete.fetch(themeId, selectedTheme.version);
   };
 
   const updateTheme = async (
@@ -166,8 +168,8 @@
     title: string,
     description: string,
   ) => {
-    const selectedTheme = $selectedThemesStore.data?.results.find(
-      (theme) => theme.id === themeId,
+    const selectedTheme = selectedThemes.query.data?.results.find(
+      (theme: { id: string }) => theme.id === themeId,
     );
 
     if (!selectedTheme) {
@@ -192,7 +194,7 @@
       );
 
       if (response.ok) {
-        $selectedThemesStore.fetch(
+        selectedThemes.fetch(
           getApiGetSelectedThemesUrl(consultationId, questionId),
         );
       } else if (response.status === 404) {
@@ -220,7 +222,7 @@
       "POST",
     );
 
-    await $selectedThemesStore.fetch(
+    await selectedThemes.fetch(
       getApiGetSelectedThemesUrl(consultationId, questionId),
     );
     await $generatedThemesStore.fetch(
@@ -245,9 +247,7 @@
   };
 
   const refreshThemes = () => {
-    $selectedThemesStore.fetch(
-      getApiGetSelectedThemesUrl(consultationId, questionId),
-    );
+    selectedThemes.fetch();
     $generatedThemesStore.fetch(
       getApiGetGeneratedThemesUrl(consultationId, questionId),
     );
@@ -355,7 +355,7 @@
             <h3>Selected Themes</h3>
 
             <Tag variant="primary-light">
-              {$selectedThemesStore.data?.results?.length ?? 0} selected
+              {selectedThemes.query.data?.results?.length ?? 0} selected
             </Tag>
           </div>
 
@@ -379,9 +379,9 @@
         </div>
 
         <p class="text-sm text-neutral-500">
-          {#if ($selectedThemesStore.data?.results?.length ?? 0) > 0}
+          {#if (selectedThemes.query.data?.results?.length ?? 0) > 0}
             Manage your {numSelectedThemesText(
-              $selectedThemesStore.data?.results,
+              selectedThemes.query.data?.results,
             )} for AI to assign responses to. Edit titles or descriptions, or add
             a new theme.
           {:else}
@@ -406,7 +406,7 @@
       </div>
     {/if}
 
-    {#if $selectedThemesStore.data?.results?.length === 0}
+    {#if selectedThemes.query.data?.results.length === 0}
       <div in:fade class="my-8 flex flex-col items-center justify-center gap-2">
         <div class="mb-2">
           <MaterialIcon size="2rem" color="fill-neutral-500">
@@ -421,7 +421,7 @@
       </div>
     {:else}
       <div class="mt-4">
-        {#each $selectedThemesStore.data?.results ?? [] as selectedTheme (selectedTheme.id)}
+        {#each selectedThemes.query.data?.results ?? [] as selectedTheme (selectedTheme.id)}
           <div transition:slide={{ duration: 150 }} class="mb-4 last:mb-0">
             <SelectedThemeCard
               {consultationId}
@@ -440,8 +440,8 @@
         variant="primary"
         fullWidth={true}
         disabled={!dataRequested ||
-          $selectedThemesStore.isLoading ||
-          ($selectedThemesStore.data?.results?.length ?? 0) === 0}
+          selectedThemes.query.isPending ||
+          (selectedThemes.query.data?.results?.length ?? 0) === 0}
         handleClick={() =>
           (isConfirmFinalisingThemesModalOpen =
             !isConfirmFinalisingThemesModalOpen)}
@@ -452,10 +452,10 @@
           </MaterialIcon>
 
           <span>
-            {#if !dataRequested || $selectedThemesStore.isLoading}
+            {#if !dataRequested || selectedThemes.query.isPending}
               Loading Selected Themes
             {:else}
-              Sign Off Selected Themes ({$selectedThemesStore.data?.results
+              Sign Off Selected Themes ({selectedThemes.query.data?.results
                 ?.length ?? 0})
             {/if}
           </span>
@@ -475,14 +475,14 @@
     >
       <p class="text-sm text-neutral-500">
         Are you sure you want to sign off on these {numSelectedThemesText(
-          $selectedThemesStore.data?.results,
+          selectedThemes.query.data?.results,
         )} for Question {$questionStore.data?.number}?
       </p>
 
       <h4 class="my-4 text-xs font-bold">Selected themes:</h4>
 
       <div class="max-h-64 overflow-y-auto">
-        {#each $selectedThemesStore.data?.results ?? [] as selectedTheme (selectedTheme.id)}
+        {#each selectedThemes.query.data?.results ?? [] as selectedTheme (selectedTheme.id)}
           <Panel bg={true} border={false}>
             <h5 class="mb-1 text-xs font-bold">{selectedTheme.name}</h5>
             <p class="text-xs text-neutral-500">{selectedTheme.description}</p>

--- a/frontend/src/components/screens/FinalisingThemesDetail/__snapshots__/FinalisingThemesDetail.test.ts.snap
+++ b/frontend/src/components/screens/FinalisingThemesDetail/__snapshots__/FinalisingThemesDetail.test.ts.snap
@@ -711,7 +711,7 @@ exports[`EditUser > should match snapshot initially 1`] = `
             <div
               class="flex justify-between items-center gap-2 rounded-md w-max py-0.5 px-2 text-xs bg-pink-100 text-primary border border-pink-300"
             >
-               selected
+              0 selected
               <!---->
             </div>
             <!---->

--- a/frontend/src/global/queries/selectedThemes/queries.ts
+++ b/frontend/src/global/queries/selectedThemes/queries.ts
@@ -1,10 +1,6 @@
-import { buildQuery, type FetchError } from "../../queryClient";
-import type { SelectedTheme, SelectedThemesDeleteResponse } from "../../types";
-import type { SaveThemeError } from "../../../components/finalising-themes/ErrorModal/types";
+import type { SelectedTheme } from "../../types";
 import type {
-  errorData,
   SelectedThemeMutationError,
-  SelectedThemesGetResponse,
   UpdateSelectedThemeBody,
 } from "./types";
 import { selectedThemeQueryParts, selectedThemesQueryParts } from "./parts";
@@ -50,6 +46,26 @@ export const updateSelectedTheme = async (
   return response.json();
 };
 
+export const createSelectedTheme = async (
+  consultationId: string,
+  questionId: string,
+  name: string,
+  description: string,
+): Promise<void> => {
+  const response = await fetch(
+    selectedThemesQueryParts.url(consultationId, questionId),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, description }),
+    },
+  );
+  if (!response.ok) {
+    const errData = await response.json().catch(() => ({}));
+    throw { status: response.status, ...errData } as SelectedThemeMutationError;
+  }
+};
+
 export const deleteSelectedTheme = async (
   consultationId: string,
   questionId: string,
@@ -70,104 +86,4 @@ export const deleteSelectedTheme = async (
     const errData = await response.json().catch(() => ({}));
     throw { status: response.status, ...errData } as SelectedThemeMutationError;
   }
-};
-
-export function buildSelectedThemesGetQuery(
-  consultationId: string,
-  questionId: string,
-) {
-  return buildQuery<SelectedThemesGetResponse>(
-    selectedThemesQueryParts.url(consultationId, questionId),
-    {
-      key: selectedThemesQueryParts.key(consultationId, questionId),
-    },
-  );
-}
-
-export function buildSelectedThemeCreateQuery(
-  consultationId: string,
-  questionId: string,
-  onSuccess: () => Promise<void>,
-) {
-  return buildQuery<SelectedThemesGetResponse>(
-    selectedThemesQueryParts.url(consultationId, questionId),
-    {
-      key: selectedThemesQueryParts.key(consultationId, questionId),
-      method: "POST",
-      onSuccess: onSuccess,
-    },
-  );
-}
-
-export function buildSelectedThemeDeleteQuery(
-  consultationId: string,
-  questionId: string,
-  onSuccess: () => Promise<void>,
-  onError: (error: FetchError<errorData>) => Promise<void>,
-) {
-  return buildQuery<SelectedThemesDeleteResponse>(
-    selectedThemeQueryParts.url(consultationId, questionId, ":themeId"),
-    {
-      key: selectedThemesQueryParts.key(consultationId, questionId),
-      method: "DELETE",
-      onSuccess: onSuccess,
-      onError: onError,
-      getVariables: (themeId, version) => {
-        return {
-          headers: {
-            "Content-Type": "application/json",
-            "If-Match": version,
-          },
-          params: {
-            themeId: themeId,
-          },
-        };
-      },
-    },
-  );
-}
-
-export const getSelectedThemesDeleteQuery = (
-  consultationId: string,
-  questionId: string,
-  resetQueries: () => void,
-  showError: (args: SaveThemeError) => void,
-) => {
-  const query = buildQuery<SelectedThemesDeleteResponse>(
-    selectedThemeQueryParts.url(consultationId, questionId, ":themeId"),
-    {
-      method: "DELETE",
-      onSuccess: async () => {
-        resetQueries();
-      },
-      onError: async (error: FetchError<errorData>) => {
-        if (error.status === 404) {
-          // SelectedTheme has already been deleted, just refetch
-          resetQueries();
-        } else if (error.status === 412) {
-          showError({
-            type: "remove-conflict",
-            lastModifiedBy: error.data?.last_modified_by?.email || "",
-            latestVersion: error.data?.latest_version || "",
-          });
-        } else {
-          showError({ type: "unexpected" });
-          console.error(error);
-        }
-      },
-      getVariables: (themeId, version) => {
-        return {
-          headers: {
-            "Content-Type": "application/json",
-            "If-Match": version,
-          },
-          params: {
-            themeId: themeId,
-          },
-        };
-      },
-    },
-  );
-
-  return query;
 };

--- a/frontend/src/global/queries/selectedThemes/queries.ts
+++ b/frontend/src/global/queries/selectedThemes/queries.ts
@@ -1,6 +1,10 @@
-import type { SelectedTheme } from "../../types";
+import { buildQuery, type FetchError } from "../../queryClient";
+import type { SelectedTheme, SelectedThemesDeleteResponse } from "../../types";
+import type { SaveThemeError } from "../../../components/finalising-themes/ErrorModal/types";
 import type {
+  errorData,
   SelectedThemeMutationError,
+  SelectedThemesGetResponse,
   UpdateSelectedThemeBody,
 } from "./types";
 import { selectedThemeQueryParts, selectedThemesQueryParts } from "./parts";
@@ -46,26 +50,6 @@ export const updateSelectedTheme = async (
   return response.json();
 };
 
-export const createSelectedTheme = async (
-  consultationId: string,
-  questionId: string,
-  name: string,
-  description: string,
-): Promise<void> => {
-  const response = await fetch(
-    selectedThemesQueryParts.url(consultationId, questionId),
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, description }),
-    },
-  );
-  if (!response.ok) {
-    const errData = await response.json().catch(() => ({}));
-    throw { status: response.status, ...errData } as SelectedThemeMutationError;
-  }
-};
-
 export const deleteSelectedTheme = async (
   consultationId: string,
   questionId: string,
@@ -86,4 +70,104 @@ export const deleteSelectedTheme = async (
     const errData = await response.json().catch(() => ({}));
     throw { status: response.status, ...errData } as SelectedThemeMutationError;
   }
+};
+
+export function buildSelectedThemesGetQuery(
+  consultationId: string,
+  questionId: string,
+) {
+  return buildQuery<SelectedThemesGetResponse>(
+    selectedThemesQueryParts.url(consultationId, questionId),
+    {
+      key: selectedThemesQueryParts.key(consultationId, questionId),
+    },
+  );
+}
+
+export function buildSelectedThemeCreateQuery(
+  consultationId: string,
+  questionId: string,
+  onSuccess: () => Promise<void>,
+) {
+  return buildQuery<SelectedThemesGetResponse>(
+    selectedThemesQueryParts.url(consultationId, questionId),
+    {
+      key: selectedThemesQueryParts.key(consultationId, questionId),
+      method: "POST",
+      onSuccess: onSuccess,
+    },
+  );
+}
+
+export function buildSelectedThemeDeleteQuery(
+  consultationId: string,
+  questionId: string,
+  onSuccess: () => Promise<void>,
+  onError: (error: FetchError<errorData>) => Promise<void>,
+) {
+  return buildQuery<SelectedThemesDeleteResponse>(
+    selectedThemeQueryParts.url(consultationId, questionId, ":themeId"),
+    {
+      key: selectedThemesQueryParts.key(consultationId, questionId),
+      method: "DELETE",
+      onSuccess: onSuccess,
+      onError: onError,
+      getVariables: (themeId, version) => {
+        return {
+          headers: {
+            "Content-Type": "application/json",
+            "If-Match": version,
+          },
+          params: {
+            themeId: themeId,
+          },
+        };
+      },
+    },
+  );
+}
+
+export const getSelectedThemesDeleteQuery = (
+  consultationId: string,
+  questionId: string,
+  resetQueries: () => void,
+  showError: (args: SaveThemeError) => void,
+) => {
+  const query = buildQuery<SelectedThemesDeleteResponse>(
+    selectedThemeQueryParts.url(consultationId, questionId, ":themeId"),
+    {
+      method: "DELETE",
+      onSuccess: async () => {
+        resetQueries();
+      },
+      onError: async (error: FetchError<errorData>) => {
+        if (error.status === 404) {
+          // SelectedTheme has already been deleted, just refetch
+          resetQueries();
+        } else if (error.status === 412) {
+          showError({
+            type: "remove-conflict",
+            lastModifiedBy: error.data?.last_modified_by?.email || "",
+            latestVersion: error.data?.latest_version || "",
+          });
+        } else {
+          showError({ type: "unexpected" });
+          console.error(error);
+        }
+      },
+      getVariables: (themeId, version) => {
+        return {
+          headers: {
+            "Content-Type": "application/json",
+            "If-Match": version,
+          },
+          params: {
+            themeId: themeId,
+          },
+        };
+      },
+    },
+  );
+
+  return query;
 };


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Whilst working on #1368 I notice that one of the page is broken when fetching the selected themes in the finalising themes page as a result of `effect_orphan` Svelte error on the page

<img width="1889" height="1035" alt="Screenshot 2026-05-28 at 10 05 43" src="https://github.com/user-attachments/assets/d0d8cdfb-59d1-43b5-85ca-588e239fbbfa" />


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
This PR introduced a fix that handles the error while keeping the tanstack approach considering that we are migrating the codebase to tanstack

<img width="1918" height="1027" alt="Screenshot 2026-05-28 at 10 14 31" src="https://github.com/user-attachments/assets/d10e8500-5bfa-433c-8816-5cdd73b57da9" />

[Ticket](https://linear.app/iai-consult/issue/PRO-381/fix-effect-orphan-svelte-error-on-finalising-themes-page-when-using)
