### PR TITLE
Helenathompson/pro 379 fix multiple choice options percentages in dashboard

### DIFF
--- a/backend/consultations/api/serializers.py
+++ b/backend/consultations/api/serializers.py
@@ -69,9 +69,13 @@ class QuestionSerializer(serializers.HyperlinkedModelSerializer):
     )
     proportion_of_audited_answers = serializers.SerializerMethodField()
     total_responses = serializers.SerializerMethodField()
+    multi_choice_respondent_count = serializers.SerializerMethodField()
 
     def get_total_responses(self, obj) -> int:
         return obj.prefetched_total_responses
+
+    def get_multi_choice_respondent_count(self, obj) -> int:
+        return obj.prefetched_multi_choice_respondent_count
 
     def get_proportion_of_audited_answers(self, obj) -> float:
         if not obj.has_free_text or not obj.total_responses:
@@ -85,6 +89,7 @@ class QuestionSerializer(serializers.HyperlinkedModelSerializer):
             "id",
             "number",
             "total_responses",
+            "multi_choice_respondent_count",
             "question_text",
             "number",
             "has_free_text",

--- a/backend/consultations/api/views/question.py
+++ b/backend/consultations/api/views/question.py
@@ -45,8 +45,20 @@ class QuestionViewSet(ModelViewSet):
             .annotate(c=Count("*"))
             .values("c")
         )
+        # Count of distinct responses that selected at least one multi-choice option
+        multi_choice_respondent_count = Subquery(
+            models.Response.chosen_options.through.objects.filter(
+                response__question_id=OuterRef("pk")
+            )
+            .order_by()
+            .values("response__question_id")
+            .annotate(c=Count("response_id", distinct=True))
+            .values("c")
+        )
+
         queryset = queryset.annotate(
             prefetched_total_responses=Coalesce(question_response_count, Value(0)),
+            prefetched_multi_choice_respondent_count=Coalesce(multi_choice_respondent_count, Value(0)),
         )
 
         # Response count per multi-choice answer (correlated subquery to avoid full-table JOIN)
@@ -129,6 +141,11 @@ class QuestionViewSet(ModelViewSet):
 
             # Replace the prefetched multichoice answers
             question._prefetched_objects_cache["multichoiceanswer_set"] = list(multichoice_answers)
+
+            # Recalculate multi-choice respondent count with filters
+            question.prefetched_multi_choice_respondent_count = (
+                filtered_responses.filter(chosen_options__isnull=False).distinct().count()
+            )
 
         serializer = self.get_serializer(question)
         return Response(serializer.data)

--- a/frontend/src/components/dashboard/MultiChoice/MultiChoice.svelte
+++ b/frontend/src/components/dashboard/MultiChoice/MultiChoice.svelte
@@ -15,23 +15,25 @@
 
   interface Props {
     data: QuestionMultiAnswer[];
+    totalAnswers: number;
   }
 
-  let { data = [] }: Props = $props();
+  let { data = [], totalAnswers = 0 }: Props = $props();
 </script>
 
 <section class="my-4" transition:fade>
   <Panel border={true}>
-    <TitleRow level={2} title="Multiple Choice Answers">
+    <TitleRow
+      level={2}
+      title="Multiple Choice Answers"
+      subtitle="{totalAnswers} responses"
+    >
       <List slot="icon" />
     </TitleRow>
 
-    {@const total = data
-      .map((item) => item.response_count)
-      .reduce((acc, curr) => acc + curr, 0)}
     <Panel bg={true}>
       {#each data as item, i (i)}
-        {@const percentage = getPercentage(item.response_count, total)}
+        {@const percentage = getPercentage(item.response_count, totalAnswers)}
 
         <div class="mb-1 last:mb-0">
           <Button

--- a/frontend/src/components/dashboard/MultiChoice/MultiChoice.test.ts
+++ b/frontend/src/components/dashboard/MultiChoice/MultiChoice.test.ts
@@ -31,7 +31,10 @@ describe("MultiChoice", () => {
   it("should render data", () => {
     const { container } = render(MultiChoice, {
       data: testData.data,
+      totalAnswers: testData.totalCounts,
     });
+
+    expect(screen.getByText("30 responses")).toBeInTheDocument();
 
     testData.data.forEach((item) => {
       expect(screen.getByText(item.text)).toBeInTheDocument();
@@ -49,7 +52,10 @@ describe("MultiChoice", () => {
   it("should toggle multi answer filters when items clicked", async () => {
     const user = userEvent.setup();
 
-    render(MultiChoice, { data: testData.data });
+    render(MultiChoice, {
+      data: testData.data,
+      totalAnswers: testData.totalCounts,
+    });
 
     // No filters applied yet
     expect(multiAnswerFilters.filters).toStrictEqual([]);

--- a/frontend/src/components/dashboard/MultiChoice/__snapshots__/MultiChoice.test.ts.snap
+++ b/frontend/src/components/dashboard/MultiChoice/__snapshots__/MultiChoice.test.ts.snap
@@ -17,7 +17,7 @@ exports[`MultiChoice > should render data 1`] = `
           class="flex items-center justify-center"
         >
           <div
-            class="bg-pink-50 p-2 rounded-md mt-1.5"
+            class="bg-pink-50 p-2 rounded-md"
           >
             <svg
               class="fill-pink-700"
@@ -56,6 +56,11 @@ exports[`MultiChoice > should render data 1`] = `
           
           <!---->
            
+          <p
+            class="text-neutral-600 text-sm"
+          >
+            30 responses
+          </p>
           <!---->
         </div>
          

--- a/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
+++ b/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.svelte
@@ -35,6 +35,7 @@
     themesLoading?: boolean;
     filtersLoading?: boolean;
     totalAnswers: number;
+    multiChoiceRespondentCount: number;
     demoData: DemoData;
     demoOptions: DemoOption;
     demoOptionsData?: DemoOptionsResponse;
@@ -50,6 +51,7 @@
     themesLoading = true,
     filtersLoading = true,
     totalAnswers = 0,
+    multiChoiceRespondentCount = 0,
     demoData = {},
     demoOptions = {},
     demoOptionsData = [],
@@ -89,7 +91,10 @@
   <div class="col-span-4 md:col-span-3">
     <svelte:boundary>
       {#if multiChoice && multiChoice.length > 0}
-        <MultiChoice data={multiChoice} />
+        <MultiChoice
+          data={multiChoice}
+          totalAnswers={multiChoiceRespondentCount}
+        />
       {/if}
 
       {#snippet failed(error)}

--- a/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.test.ts
+++ b/frontend/src/components/dashboard/QuestionSummary/QuestionSummary.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/svelte";
 
 import QuestionSummary from "./QuestionSummary.svelte";
-import { getPercentage } from "../../../global/utils";
 
 describe("QuestionSummary", () => {
   const testData = {
@@ -36,6 +35,7 @@ describe("QuestionSummary", () => {
     render(QuestionSummary, {
       ...testData,
       multiChoice: multiChoice,
+      multiChoiceRespondentCount: 50,
     });
 
     expect(screen.getByText("Multiple Choice Answers")).toBeInTheDocument();
@@ -43,9 +43,8 @@ describe("QuestionSummary", () => {
     multiChoice.forEach((item) => {
       expect(screen.getByText(item.text)).toBeInTheDocument();
       expect(screen.getAllByText(item.response_count)).toHaveLength(2);
-      expect(
-        screen.getByText(getPercentage(item.response_count, 30) + "%"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("20%")).toBeInTheDocument();
+      expect(screen.getByText("40%")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
@@ -361,6 +361,8 @@
         themesLoading={!dataRequested || $themesStore.isLoading}
         filtersLoading={!dataRequested || $demographicsStore.isLoading}
         totalAnswers={$questionStore.data?.total_responses || 0}
+        multiChoiceRespondentCount={$questionStore.data
+          ?.multi_choice_respondent_count || 0}
         {demoData}
         demoOptions={formattedDemoOptions || {}}
         demoOptionsData={$demographicsStore.data || undefined}

--- a/frontend/src/components/screens/QuestionDetail/__snapshots__/QuestionDetail.test.ts.snap
+++ b/frontend/src/components/screens/QuestionDetail/__snapshots__/QuestionDetail.test.ts.snap
@@ -518,7 +518,7 @@ exports[`QuestionDetail > should match snapshot after loading 1`] = `
                   class="flex items-center justify-center"
                 >
                   <div
-                    class="bg-pink-50 p-2 rounded-md mt-1.5"
+                    class="bg-pink-50 p-2 rounded-md"
                   >
                     <svg
                       class="fill-pink-700"
@@ -557,6 +557,11 @@ exports[`QuestionDetail > should match snapshot after loading 1`] = `
                   
                   <!---->
                    
+                  <p
+                    class="text-neutral-600 text-sm"
+                  >
+                    232 responses
+                  </p>
                   <!---->
                 </div>
                  

--- a/frontend/src/components/screens/QuestionDetail/mocks.ts
+++ b/frontend/src/components/screens/QuestionDetail/mocks.ts
@@ -245,6 +245,7 @@ export const questionMock = {
     id: "5e8176da-fdcd-4f55-ab7b-b2ca8a12a467",
     number: 1,
     total_responses: 100,
+    multi_choice_respondent_count: 232,
     question_text:
       "Do you agree with the proposal to align the flavour categories of chocolate bars as outlined in the draft guidelines of the Chocolate Bar Regulation for the United Kingdom?",
     has_free_text: true,

--- a/frontend/src/global/types.ts
+++ b/frontend/src/global/types.ts
@@ -15,6 +15,7 @@ export interface Question {
   id?: string;
   number?: number;
   total_responses?: number;
+  multi_choice_respondent_count?: number;
   question_text?: string;
   has_free_text?: boolean;
   has_multiple_choice?: boolean;


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

If a question is multi-select, the denominator we should use to calculate the percentage is the number of respondents who answered the question, not the total number of selections.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Before:

<img width="1408" height="460" alt="image" src="https://github.com/user-attachments/assets/131889cb-4cdf-418f-9d73-175474a3dba9" />

After:

<img width="1407" height="466" alt="image" src="https://github.com/user-attachments/assets/f8163580-fce5-4519-91b3-f213d94ac2e5" />

