### PR TITLE
Helenathompson/pro 380 create script command to import selected themes from another

### DIFF
--- a/backend/consultations/api/serializers.py
+++ b/backend/consultations/api/serializers.py
@@ -352,5 +352,9 @@ class ConsultationExportSerializer(serializers.Serializer):
     question_ids = serializers.ListSerializer(child=serializers.CharField())
 
 
+class ImportFinalisedThemesSerializer(serializers.Serializer):
+    source_consultation_id = serializers.UUIDField()
+
+
 class TokenSerializer(serializers.Serializer):
     internal_access_token = serializers.CharField()

--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -1,7 +1,9 @@
+from collections import Counter
 from typing import Any
 
 import sentry_sdk
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Count, Exists, OuterRef, Subquery, Value
 from django.db.models.functions import Coalesce
 from django.http import Http404
@@ -23,10 +25,12 @@ from consultations.api.serializers import (
     ConsultationSerializer,
     ConsultationSetupSerializer,
     DemographicOptionSerializer,
+    ImportFinalisedThemesSerializer,
 )
 from consultations.models import (
     Consultation,
     DemographicOption,
+    Question,
     SelectedTheme,
 )
 from consultations.models import (
@@ -582,6 +586,205 @@ class ConsultationViewSet(ModelViewSet):
         return Response(
             {"error": "No fixture data provided"},
             status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="import-finalised-themes",
+        permission_classes=[IsAuthenticated, IsAdminUser],
+    )
+    def import_finalised_themes(self, request, pk=None) -> Response:
+        """
+        Import finalised themes from a source consultation into this (target) consultation.
+
+        Matches questions by text between source and target. Preserves the
+        original user attribution and timestamps.
+
+        URL: POST /api/consultations/{target_consultation_id}/import-finalised-themes/
+        Body: { "source_consultation_id": "<uuid>" }
+        Query: ?dry_run=true to preview without making changes
+        """
+
+        input_serializer = ImportFinalisedThemesSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+
+        target = self.get_object()
+        dry_run = request.query_params.get("dry_run", "").lower() == "true"
+        source_consultation_id = input_serializer.validated_data["source_consultation_id"]
+
+        try:
+            source = Consultation.objects.get(id=source_consultation_id)
+        except Consultation.DoesNotExist:
+            return Response(
+                {"error": f"Source consultation '{source_consultation_id}' not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if source.id == target.id:
+            return Response(
+                {"error": "Source and target consultation cannot be the same"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        finalised_stages = {Consultation.Stage.ASSIGNING_THEMES, Consultation.Stage.ANALYSIS}
+        if source.stage not in finalised_stages:
+            return Response(
+                {"error": "Source consultation must have finalised themes"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if target.stage in finalised_stages:
+            return Response(
+                {"error": "Target consultation has already finalised themes"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        source_questions = source.question_set.filter(has_free_text=True)
+        target_questions = target.question_set.filter(has_free_text=True)
+
+        # Detect duplicate question texts within each consultation
+        source_text_counts = Counter(q.text for q in source_questions)
+        target_text_counts = Counter(q.text for q in target_questions)
+        duplicate_source_texts = {t for t, c in source_text_counts.items() if c > 1}
+        duplicate_target_texts = {t for t, c in target_text_counts.items() if c > 1}
+
+        source_by_text = {q.text: q for q in source_questions}
+        target_by_text = {q.text: q for q in target_questions}
+
+        source_themes_by_question: dict = {}
+        for theme in SelectedTheme.objects.filter(question__in=source_questions).select_related(
+            "last_modified_by"
+        ):
+            source_themes_by_question.setdefault(theme.question_id, []).append(theme)
+
+        target_questions_with_themes = set(
+            SelectedTheme.objects.filter(question__in=target_questions)
+            .values_list("question_id", flat=True)
+            .distinct()
+        )
+
+        questions = []
+
+        for target_q in target_questions.order_by("number"):
+            question_info = {
+                "question_number": target_q.number,
+                "question_text": target_q.text,
+            }
+
+            if target_q.text in duplicate_target_texts:
+                question_info["status"] = "duplicate_in_target"
+                questions.append(question_info)
+                continue
+
+            if target_q.text in duplicate_source_texts:
+                question_info["status"] = "duplicate_in_source"
+                questions.append(question_info)
+                continue
+
+            if target_q.text not in source_by_text:
+                question_info["status"] = "no_match_in_source"
+                questions.append(question_info)
+                continue
+
+            if target_q.id in target_questions_with_themes:
+                question_info["status"] = "has_existing_themes"
+                questions.append(question_info)
+                continue
+
+            source_q = source_by_text[target_q.text]
+            themes = source_themes_by_question.get(source_q.id, [])
+
+            if not themes:
+                question_info["status"] = "no_themes_in_source"
+                questions.append(question_info)
+                continue
+
+            question_info["status"] = "will_import"
+            question_info["source_themes"] = [t.name for t in themes]
+            questions.append(question_info)
+
+        unmatched_source = sorted(set(source_by_text.keys()) - {q.text for q in target_questions})
+        warnings = {"unmatched_source_questions": unmatched_source}
+
+        if dry_run:
+            return Response(
+                {
+                    "dry_run": True,
+                    "source_consultation": {"id": str(source.id), "title": source.title},
+                    "target_consultation": {"id": str(target.id), "title": target.title},
+                    "questions": questions,
+                    "warnings": warnings,
+                }
+            )
+
+        # Execute the import
+        imported_themes = 0
+        with transaction.atomic():
+            for q_info in questions:
+                if q_info["status"] != "will_import":
+                    continue
+
+                target_q = target_by_text[q_info["question_text"]]
+                source_q = source_by_text[q_info["question_text"]]
+                themes = source_themes_by_question.get(source_q.id, [])
+
+                for theme in themes:
+                    new_theme = SelectedTheme.objects.create(
+                        question=target_q,
+                        name=theme.name,
+                        description=theme.description,
+                        key=theme.key,
+                        last_modified_by=theme.last_modified_by,
+                    )
+                    # Preserve original timestamps from the source to maintain audit trail.
+                    # QuerySet.update() is required because auto_now/auto_now_add bypass save().
+                    SelectedTheme.objects.filter(pk=new_theme.pk).update(
+                        created_at=theme.created_at,
+                        modified_at=theme.modified_at,
+                    )
+                    imported_themes += 1
+
+                target_q.theme_status = Question.ThemeStatus.CONFIRMED
+                target_q.save(update_fields=["theme_status"])
+
+            # Advance stage to FINALISING_THEMES if currently earlier in the pipeline
+            earlier_stages = {Consultation.Stage.SETUP, Consultation.Stage.FINDING_THEMES}
+            if target.stage in earlier_stages:
+                target.stage = Consultation.Stage.FINALISING_THEMES
+                target.save(update_fields=["stage"])
+
+        # Export to S3
+        try:
+            export_selected_themes_to_s3(target)
+        except Exception as e:
+            logger.error("S3 export failed after theme import: {error}", error=str(e))
+            return Response(
+                {
+                    "error": f"Themes were saved to the database ({imported_themes} imported) but S3 export failed: {e}",
+                    "total_themes_imported": imported_themes,
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        logger.info(
+            "Imported {count} selected themes from '{source}' to '{target}' by user {user}",
+            count=imported_themes,
+            source=source.title,
+            target=target.title,
+            user=request.user.email,
+        )
+
+        return Response(
+            {
+                "dry_run": False,
+                "source_consultation": {"id": str(source.id), "title": source.title},
+                "target_consultation": {"id": str(target.id), "title": target.title},
+                "total_themes_imported": imported_themes,
+                "questions": questions,
+                "warnings": warnings,
+                "performed_by": request.user.email,
+            }
         )
 
     @action(

--- a/backend/consultations/models.py
+++ b/backend/consultations/models.py
@@ -46,7 +46,6 @@ class Consultation(UUIDPrimaryKeyModel, TimeStampedModel):  # type:ignore
         FINDING_THEMES = "finding_themes", "Finding Themes"
         FINALISING_THEMES = "finalising_themes", "Finalising Themes"
         ASSIGNING_THEMES = "assigning_themes", "Assigning Themes"
-
         ANALYSIS = "analysis", "Analysis"
 
     class ModelName(models.TextChoices):

--- a/backend/tests/unit/api/views/test_consultation_views.py
+++ b/backend/tests/unit/api/views/test_consultation_views.py
@@ -18,6 +18,7 @@ from factories import (
     QuestionFactory,
     RespondentFactory,
     ResponseFactory,
+    SelectedThemeFactory,
     UserFactory,
 )
 
@@ -915,3 +916,272 @@ class TestAssignThemesEndpoint:
             )
 
             assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestImportFinalisedThemesEndpoint:
+    def test_dry_run_returns_preview(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.FINALISING_THEMES)
+        question_text = "Do you agree with the proposal?"
+        source_q = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text=question_text
+        )
+        QuestionFactory(consultation=target, has_free_text=True, number=1, text=question_text)
+        SelectedThemeFactory(question=source_q, name="Theme A", description="Desc A")
+        SelectedThemeFactory(question=source_q, name="Theme B", description="Desc B")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+        response = client.post(
+            url + "?dry_run=true",
+            {"source_consultation_id": str(source.id)},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dry_run"] is True
+        assert data["questions"][0]["status"] == "will_import"
+        assert data["questions"][0]["source_themes"] == ["Theme A", "Theme B"]
+        assert SelectedTheme.objects.filter(question__consultation=target).count() == 0
+
+    def test_import_creates_themes_and_updates_question_status(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.FINALISING_THEMES)
+        question_text = "Do you agree with the proposal?"
+        source_q = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text=question_text
+        )
+        target_q = QuestionFactory(
+            consultation=target, has_free_text=True, number=1, text=question_text
+        )
+        SelectedThemeFactory(question=source_q, name="Theme A", description="Desc A")
+        SelectedThemeFactory(question=source_q, name="Theme B", description="Desc B")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+
+        with patch("consultations.api.views.consultation.export_selected_themes_to_s3"):
+            response = client.post(
+                url,
+                {"source_consultation_id": str(source.id)},
+                content_type="application/json",
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["dry_run"] is False
+        assert data["total_themes_imported"] == 2
+        assert SelectedTheme.objects.filter(question__consultation=target).count() == 2
+        target_q.refresh_from_db()
+        assert target_q.theme_status == Question.ThemeStatus.CONFIRMED
+
+    def test_import_advances_stage_to_finalising_themes(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.SETUP)
+        question_text = "Do you agree with the proposal?"
+        source_q = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text=question_text
+        )
+        QuestionFactory(consultation=target, has_free_text=True, number=1, text=question_text)
+        SelectedThemeFactory(question=source_q, name="Theme A", description="Desc A")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+
+        with patch("consultations.api.views.consultation.export_selected_themes_to_s3"):
+            response = client.post(
+                url,
+                {"source_consultation_id": str(source.id)},
+                content_type="application/json",
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+        assert response.status_code == 200
+        target.refresh_from_db()
+        assert target.stage == Consultation.Stage.FINALISING_THEMES
+
+    def test_skips_questions_with_existing_themes(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.FINALISING_THEMES)
+        question_text = "Do you agree with the proposal?"
+        source_q = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text=question_text
+        )
+        target_q = QuestionFactory(
+            consultation=target, has_free_text=True, number=1, text=question_text
+        )
+        SelectedThemeFactory(question=source_q, name="Theme A", description="Desc A")
+        SelectedThemeFactory(question=target_q, name="Existing", description="Already here")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+
+        with patch("consultations.api.views.consultation.export_selected_themes_to_s3"):
+            response = client.post(
+                url,
+                {"source_consultation_id": str(source.id)},
+                content_type="application/json",
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["questions"][0]["status"] == "has_existing_themes"
+        assert SelectedTheme.objects.filter(question=target_q).count() == 1
+        assert SelectedTheme.objects.get(question=target_q).name == "Existing"
+        assert "source_themes" not in data["questions"][0]
+
+    def test_duplicate_target_questions_skipped(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.FINALISING_THEMES)
+        question_text = "Do you agree?"
+        source_q = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text=question_text
+        )
+        QuestionFactory(consultation=target, has_free_text=True, number=1, text=question_text)
+        QuestionFactory(consultation=target, has_free_text=True, number=2, text=question_text)
+        SelectedThemeFactory(question=source_q, name="Theme A", description="Desc A")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+
+        with patch("consultations.api.views.consultation.export_selected_themes_to_s3"):
+            response = client.post(
+                url,
+                {"source_consultation_id": str(source.id)},
+                content_type="application/json",
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert all(q["status"] == "duplicate_in_target" for q in data["questions"])
+        assert SelectedTheme.objects.filter(question__consultation=target).count() == 0
+
+    def test_duplicate_source_questions_skipped(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.FINALISING_THEMES)
+        question_text = "Do you agree?"
+        source_q1 = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text=question_text
+        )
+        QuestionFactory(consultation=source, has_free_text=True, number=2, text=question_text)
+        QuestionFactory(consultation=target, has_free_text=True, number=1, text=question_text)
+        SelectedThemeFactory(question=source_q1, name="Theme A", description="Desc A")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+
+        with patch("consultations.api.views.consultation.export_selected_themes_to_s3"):
+            response = client.post(
+                url,
+                {"source_consultation_id": str(source.id)},
+                content_type="application/json",
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["questions"][0]["status"] == "duplicate_in_source"
+        assert SelectedTheme.objects.filter(question__consultation=target).count() == 0
+
+    def test_no_match_in_source(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.FINALISING_THEMES)
+        source_q = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text="Source question"
+        )
+        QuestionFactory(consultation=target, has_free_text=True, number=1, text="Target question")
+        SelectedThemeFactory(question=source_q, name="Theme A", description="Desc A")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+
+        with patch("consultations.api.views.consultation.export_selected_themes_to_s3"):
+            response = client.post(
+                url,
+                {"source_consultation_id": str(source.id)},
+                content_type="application/json",
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["questions"][0]["status"] == "no_match_in_source"
+        assert SelectedTheme.objects.filter(question__consultation=target).count() == 0
+
+    def test_unmatched_source_questions_in_warnings(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.FINALISING_THEMES)
+        shared_text = "Shared question"
+        source_only_text = "Only in source"
+        source_q = QuestionFactory(
+            consultation=source, has_free_text=True, number=1, text=shared_text
+        )
+        QuestionFactory(consultation=source, has_free_text=True, number=2, text=source_only_text)
+        QuestionFactory(consultation=target, has_free_text=True, number=1, text=shared_text)
+        SelectedThemeFactory(question=source_q, name="Theme A", description="Desc A")
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+        response = client.post(
+            url + "?dry_run=true",
+            {"source_consultation_id": str(source.id)},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert source_only_text in data["warnings"]["unmatched_source_questions"]
+
+    def test_rejects_same_consultation(self, client, staff_user_token):
+        consultation = ConsultationFactory(title="Same", stage=Consultation.Stage.ANALYSIS)
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": consultation.id})
+
+        response = client.post(
+            url,
+            {"source_consultation_id": str(consultation.id)},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert response.status_code == 400
+
+    def test_rejects_source_has_not_finalised_themes(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.FINALISING_THEMES)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.SETUP)
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+        response = client.post(
+            url,
+            {"source_consultation_id": str(source.id)},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Source consultation must have finalised themes"
+
+    def test_rejects_target_has_already_finalised_themes(self, client, staff_user_token):
+        source = ConsultationFactory(title="Source", stage=Consultation.Stage.ANALYSIS)
+        target = ConsultationFactory(title="Target", stage=Consultation.Stage.ASSIGNING_THEMES)
+
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+        response = client.post(
+            url,
+            {"source_consultation_id": str(source.id)},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Target consultation has already finalised themes"
+
+    def test_requires_admin(self, client):
+        target = ConsultationFactory(title="Target")
+        url = reverse("consultations-import-finalised-themes", kwargs={"pk": target.id})
+
+        response = client.post(
+            url,
+            {"source_consultation_id": str(uuid4())},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 401

--- a/frontend/src/components/screens/ImportThemesForm.svelte
+++ b/frontend/src/components/screens/ImportThemesForm.svelte
@@ -1,0 +1,314 @@
+<script lang="ts">
+  import clsx from "clsx";
+  import { slide } from "svelte/transition";
+
+  import { getApiImportFinalisedThemesUrl } from "../../global/routes";
+  import Button from "../inputs/Button/Button.svelte";
+  import Text from "../Text/Text.svelte";
+
+  interface QuestionPreview {
+    question_number: number;
+    question_text: string;
+    status: string;
+    source_themes?: string[];
+  }
+
+  interface ImportPreviewResponse {
+    dry_run: boolean;
+    source_consultation: { id: string; title: string };
+    target_consultation: { id: string; title: string };
+    total_themes_imported?: number;
+    questions: QuestionPreview[];
+    warnings: {
+      unmatched_source_questions: string[];
+    };
+    performed_by?: string;
+  }
+
+  export let targetConsultationId: string;
+  export let targetConsultationTitle: string;
+
+  let sourceConsultationId = "";
+  let loading = false;
+  let errors: Record<string, string> = {};
+  let preview: ImportPreviewResponse | null = null;
+  let result: ImportPreviewResponse | null = null;
+
+  const statusLabels: Record<string, string> = {
+    will_import: "Will import",
+    duplicate_in_target: "Warning — Multiple matching questions",
+    duplicate_in_source: "Warning — Duplicate question",
+    no_match_in_source: "Warning — No matching question",
+    no_themes_in_source: "Warning — Matching question has no themes",
+    has_existing_themes: "Warning — Selected themes already exist",
+  };
+
+  const parseResponse = async (response: Response) => {
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      return await response.json();
+    }
+    return null;
+  };
+
+  const handlePreview = async () => {
+    errors = {};
+    preview = null;
+    result = null;
+    loading = true;
+
+    try {
+      const response = await fetch(
+        getApiImportFinalisedThemesUrl(targetConsultationId) + "?dry_run=true",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            source_consultation_id: sourceConsultationId,
+          }),
+        },
+      );
+
+      const data = await parseResponse(response);
+
+      if (!response.ok) {
+        errors["general"] =
+          data?.error || `Error ${response.status}: ${response.statusText}`;
+        return;
+      }
+
+      preview = data;
+    } catch (err: unknown) {
+      errors["general"] =
+        err instanceof Error ? err.message : "An unknown error occurred";
+    } finally {
+      loading = false;
+    }
+  };
+
+  const handleConfirm = async () => {
+    errors = {};
+    loading = true;
+
+    try {
+      const response = await fetch(
+        getApiImportFinalisedThemesUrl(targetConsultationId),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            source_consultation_id: sourceConsultationId,
+          }),
+        },
+      );
+
+      const data = await parseResponse(response);
+
+      if (!response.ok) {
+        errors["general"] =
+          data?.error || `Error ${response.status}: ${response.statusText}`;
+        return;
+      }
+
+      result = data;
+      preview = null;
+    } catch (err: unknown) {
+      errors["general"] =
+        err instanceof Error ? err.message : "An unknown error occurred";
+    } finally {
+      loading = false;
+    }
+  };
+
+  $: themesToImport = preview
+    ? preview.questions.filter((q) => q.status === "will_import")
+    : [];
+</script>
+
+<form
+  class={clsx(["flex", "flex-col", "gap-4"])}
+  on:submit|preventDefault={handlePreview}
+>
+  <Text>
+    Import finalised themes into <strong>{targetConsultationTitle}</strong> from
+    another consultation.
+  </Text>
+
+  <label class="flex flex-col gap-1">
+    <span class="text-sm font-medium">Source consultation ID</span>
+    <input
+      type="text"
+      bind:value={sourceConsultationId}
+      placeholder="e.g. 4d1414d5-9300-447b-b788-50d0bef7e807"
+      class="rounded border border-gray-300 px-3 py-2 text-sm"
+      required
+    />
+  </label>
+
+  {#if "general" in errors}
+    <small class="text-sm text-red-500" transition:slide={{ duration: 300 }}>
+      {errors.general}
+    </small>
+  {/if}
+
+  {#if !preview && !result}
+    <Button
+      type="submit"
+      variant="primary"
+      disabled={loading || !sourceConsultationId}
+    >
+      {loading ? "Loading..." : "Preview import"}
+    </Button>
+  {/if}
+</form>
+
+{#if preview}
+  <div class="mt-6 flex flex-col gap-4">
+    <Text>
+      Importing from <strong>{preview.source_consultation.title}</strong>
+    </Text>
+
+    {#if themesToImport.length > 0}
+      <div class="rounded border border-green-200 bg-green-50 p-3">
+        <p class="text-sm font-medium text-green-800">
+          {themesToImport.reduce(
+            (sum, q) => sum + (q.source_themes?.length || 0),
+            0,
+          )} finalised theme(s) will be imported across {themesToImport.length} question(s).
+        </p>
+      </div>
+    {:else}
+      <div class="rounded border border-amber-200 bg-amber-50 p-3">
+        <p class="text-sm font-medium text-amber-800">
+          No finalised themes will be imported.
+        </p>
+      </div>
+    {/if}
+
+    <div class="overflow-x-auto">
+      <table class="w-full text-left text-sm">
+        <thead class="font-bold">
+          <tr>
+            <th class="py-2 pr-2">Q#</th>
+            <th class="py-2 pr-2">Question</th>
+            <th class="py-2 pr-2">Status</th>
+            <th class="py-2 pr-2">Themes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each preview.questions as question (question.question_number)}
+            <tr class="border-t hover:bg-gray-50">
+              <td class="py-2 pr-2">{question.question_number}</td>
+              <td class="max-w-xs break-words py-2 pr-2"
+                >{question.question_text}</td
+              >
+              <td class="py-2 pr-2">
+                <span
+                  class={clsx([
+                    "rounded px-2 py-0.5 text-xs",
+                    question.status === "will_import" &&
+                      "bg-green-100 text-green-800",
+                    question.status !== "will_import" &&
+                      "bg-red-100 text-red-800",
+                  ])}
+                >
+                  {statusLabels[question.status] || question.status}
+                </span>
+              </td>
+              <td class="py-2 pr-2">
+                {#if question.source_themes}
+                  <ul class="m-0 list-none p-0">
+                    {#each question.source_themes as theme, i (i)}
+                      <li>{theme}</li>
+                    {/each}
+                  </ul>
+                {:else}
+                  —
+                {/if}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+
+    {#if preview.warnings.unmatched_source_questions.length > 0}
+      <div class="rounded border border-amber-200 bg-amber-50 p-3">
+        <p class="text-sm font-medium text-amber-800">
+          {preview.warnings.unmatched_source_questions.length} source question(s)
+          have no match in target:
+        </p>
+        <ul class="mt-1 list-inside list-disc text-sm text-amber-700">
+          {#each preview.warnings.unmatched_source_questions as q, i (i)}
+            <li>{q}</li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+
+    {#if themesToImport.length > 0}
+      <div class="flex gap-2">
+        <Button
+          variant="primary"
+          handleClick={handleConfirm}
+          disabled={loading}
+        >
+          {loading ? "Importing..." : "Confirm import"}
+        </Button>
+        <Button variant="default" handleClick={() => (preview = null)}>
+          Cancel
+        </Button>
+      </div>
+    {:else}
+      <Button variant="default" handleClick={() => (preview = null)}>
+        Back
+      </Button>
+    {/if}
+  </div>
+{/if}
+
+{#if result}
+  <div class="mt-6 flex flex-col gap-4">
+    <div class="rounded border border-green-200 bg-green-50 p-3">
+      <p class="text-sm font-medium text-green-800">
+        Successfully imported {result.total_themes_imported} finalised theme(s) from
+        <strong>{result.source_consultation.title}</strong>.
+      </p>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table class="w-full text-left text-sm">
+        <thead class="font-bold">
+          <tr>
+            <th class="py-2 pr-2">Q#</th>
+            <th class="py-2 pr-2">Question</th>
+            <th class="py-2 pr-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each result.questions as question (question.question_number)}
+            <tr class="border-t hover:bg-gray-50">
+              <td class="py-2 pr-2">{question.question_number}</td>
+              <td class="max-w-xs break-words py-2 pr-2"
+                >{question.question_text}</td
+              >
+              <td class="py-2 pr-2">
+                <span
+                  class={clsx([
+                    "rounded px-2 py-0.5 text-xs",
+                    question.status === "will_import" &&
+                      "bg-green-100 text-green-800",
+                    question.status !== "will_import" &&
+                      "bg-red-100 text-red-800",
+                  ])}
+                >
+                  {statusLabels[question.status] || question.status}
+                </span>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  </div>
+{/if}

--- a/frontend/src/global/routes.ts
+++ b/frontend/src/global/routes.ts
@@ -60,6 +60,19 @@ export const getConsultationAnalysisUrl = (consultationId: string) => {
 export const getSupportConsultationDeleteUrl = (consultationId: string) => {
   return urlJoin(Routes.SupportConsultations, consultationId, Suffixes.Delete);
 };
+export const getSupportConsultationImportThemesUrl = (
+  consultationId: string,
+) => {
+  return urlJoin(Routes.SupportConsultations, consultationId, "import-themes");
+};
+export const getApiImportFinalisedThemesUrl = (consultationId: string) => {
+  return urlJoin(
+    Routes.ApiConsultations,
+    consultationId,
+    "import-finalised-themes",
+    "/",
+  );
+};
 export const getFinaliseThemesUrl = (consultationId: string) => {
   return urlJoin(Routes.Consultations, consultationId, Suffixes.FinaliseThemes);
 };

--- a/frontend/src/pages/support/consultations/[consultationId]/import-themes.astro
+++ b/frontend/src/pages/support/consultations/[consultationId]/import-themes.astro
@@ -1,0 +1,37 @@
+---
+import { fetchBackendApi } from "../../../../global/api";
+import type {
+  AstroGlobalRuntime,
+  ConsultationResponse,
+} from "../../../../global/types";
+
+import Layout from "../../../../layouts/Layout.astro";
+import Section from "../../../../components/Section/Section.svelte";
+import Title from "../../../../components/Title.svelte";
+import ImportThemesForm from "../../../../components/screens/ImportThemesForm.svelte";
+import { getApiConsultationUrl, Routes } from "../../../../global/routes";
+
+const { consultationId } = (Astro as unknown as AstroGlobalRuntime).params;
+
+if (!consultationId) {
+  return (Astro as unknown as AstroGlobalRuntime).redirect(
+    Routes.SupportConsultations,
+  );
+}
+
+let consultation = await fetchBackendApi<ConsultationResponse>(
+  Astro,
+  getApiConsultationUrl(consultationId),
+);
+---
+
+<Layout>
+  <Section>
+    <Title level={1} text="Import finalised themes" />
+    <ImportThemesForm
+      targetConsultationId={consultationId}
+      targetConsultationTitle={consultation.title}
+      client:load
+    />
+  </Section>
+</Layout>

--- a/frontend/src/pages/support/consultations/[consultationId]/index.astro
+++ b/frontend/src/pages/support/consultations/[consultationId]/index.astro
@@ -17,6 +17,7 @@ import {
   getConsultationEvalUrl,
   getFinaliseThemesUrl,
   getSupportConsultationDeleteUrl,
+  getSupportConsultationImportThemesUrl,
   getApiConsultationUrl,
   getApiQuestionsUrl,
   Routes,
@@ -58,6 +59,11 @@ let questions = await fetchBackendApi<{ results: Question[] }>(
       <li>
         <Link href={getConsultationDetailUrl(consultationId)}
           >View on frontend (dashboard)</Link
+        >
+      </li>
+      <li>
+        <Link href={getSupportConsultationImportThemesUrl(consultationId)}
+          >Import finalised themes from another consultation</Link
         >
       </li>
       <li>


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We want to be able to import finalised themes one consultation to another. In doing so, it's helpful to be able to preview the proposed changes and the themes that will be imported before proceeding.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

* Create API endpoint to import finalised themes from another consultation with the option of a dry run to preview proposed changes
* Create UI to import finalised themes from another consultation and display proposed changes before proceeding

<img width="1542" height="727" alt="image" src="https://github.com/user-attachments/assets/dff2cb99-94a7-4b22-a76c-1c90868985bd" />

## QA

- [x] Import finalised themes from another consultation that shares the same questions
- [x] Check the UI displays the proposed changes
- [x] After clicking 'Confirm import':
  - [x] Selected themes exist in the database, preserving original timestamps and `last_modified_by_id`
  - [x] Can proceed to assigning themes from finalising themes and /data-pipeline page
  - [x] Assign themes runs successfully and can see theme frequencies in the dashboard
