### PR TITLE
perf: Compute question response counts in bulk instead of per-row subqueries

### DIFF
--- a/backend/consultations/api/serializers.py
+++ b/backend/consultations/api/serializers.py
@@ -72,10 +72,10 @@ class QuestionSerializer(serializers.HyperlinkedModelSerializer):
     multi_choice_respondent_count = serializers.SerializerMethodField()
 
     def get_total_responses(self, obj) -> int:
-        return obj.prefetched_total_responses
+        return getattr(obj, "prefetched_total_responses", 0)
 
     def get_multi_choice_respondent_count(self, obj) -> int:
-        return obj.prefetched_multi_choice_respondent_count
+        return getattr(obj, "prefetched_multi_choice_respondent_count", 0)
 
     def get_proportion_of_audited_answers(self, obj) -> float:
         if not obj.has_free_text or not obj.total_responses:

--- a/backend/consultations/api/views/question.py
+++ b/backend/consultations/api/views/question.py
@@ -1,5 +1,4 @@
-from django.db.models import Count, OuterRef, Prefetch, Q, Subquery, Value
-from django.db.models.functions import Coalesce
+from django.db.models import Count, Q
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
@@ -37,68 +36,89 @@ class QuestionViewSet(ModelViewSet):
         if not self.request.user.is_staff:
             queryset = queryset.filter(consultation__users=self.request.user)
 
-        # Total responses per question (correlated subquery to avoid full-table JOIN)
-        question_response_count = Subquery(
-            models.Response.objects.filter(question_id=OuterRef("pk"))
-            .order_by()
-            .values("question_id")
+        # Per-question/option response counts are computed in bulk via grouped queries
+        # (see _annotate_response_counts) rather than per-row correlated subqueries, so
+        # the cost is independent of the number of questions in the list.
+        return queryset.prefetch_related("multichoiceanswer_set").order_by("number")
+
+    def _annotate_response_counts(self, questions):
+        """Attach response-count annotations to a batch of questions in bulk.
+
+        Replaces the previous correlated subqueries (one execution per question/option)
+        with a fixed handful of GROUP BY queries. The resulting attribute names match
+        exactly what ``QuestionSerializer`` reads, so the serialized output is unchanged.
+        """
+        question_ids = [question.id for question in questions]
+        if not question_ids:
+            return questions
+
+        through = models.Response.chosen_options.through
+
+        # Total responses per question (all responses, matching the previous semantics).
+        total_responses = dict(
+            models.Response.objects.filter(question_id__in=question_ids)
+            .values_list("question_id")
             .annotate(c=Count("*"))
-            .values("c")
+            .values_list("question_id", "c")
         )
-        # Count of distinct responses that selected at least one multi-choice option
-        multi_choice_respondent_count = Subquery(
-            models.Response.chosen_options.through.objects.filter(
-                response__question_id=OuterRef("pk")
-            )
-            .order_by()
-            .values("response__question_id")
+        # Distinct responses that selected at least one multi-choice option, per question.
+        multi_choice_respondents = dict(
+            through.objects.filter(response__question_id__in=question_ids)
+            .values_list("response__question_id")
             .annotate(c=Count("response_id", distinct=True))
-            .values("c")
+            .values_list("response__question_id", "c")
         )
-
-        queryset = queryset.annotate(
-            prefetched_total_responses=Coalesce(question_response_count, Value(0)),
-            prefetched_multi_choice_respondent_count=Coalesce(multi_choice_respondent_count, Value(0)),
-        )
-
-        # Response count per multi-choice answer (correlated subquery to avoid full-table JOIN)
-        multichoice_response_count = Subquery(
-            models.Response.chosen_options.through.objects.filter(
-                multichoiceanswer_id=OuterRef("pk")
-            )
-            .order_by()
-            .values("multichoiceanswer_id")
+        # Response count per multi-choice option.
+        option_counts = dict(
+            through.objects.filter(multichoiceanswer__question_id__in=question_ids)
+            .values_list("multichoiceanswer_id")
             .annotate(c=Count("*"))
-            .values("c")
-        )
-        queryset = queryset.prefetch_related(
-            Prefetch(
-                "multichoiceanswer_set",
-                queryset=models.MultiChoiceAnswer.objects.annotate(
-                    prefetched_response_count=Coalesce(multichoice_response_count, Value(0))
-                ),
-            )
+            .values_list("multichoiceanswer_id", "c")
         )
 
-        # Reviewed responses per question (only when explicitly requested)
-        if "proportion_of_audited_answers" in self.request.query_params.get("include", ""):
-            reviewed_response_count = Subquery(
+        include = self.request.query_params.get("include", "")
+        want_reviewed = "proportion_of_audited_answers" in include
+        reviewed_responses = {}
+        if want_reviewed:
+            reviewed_responses = dict(
                 models.Response.objects.filter(
-                    question_id=OuterRef("pk"),
+                    question_id__in=question_ids,
                     free_text__isnull=False,
                     free_text__gt="",
                     annotation__human_reviewed=True,
                 )
-                .order_by()
-                .values("question_id")
+                .values_list("question_id")
                 .annotate(c=Count("*"))
-                .values("c")
-            )
-            queryset = queryset.annotate(
-                prefetched_reviewed_responses=Coalesce(reviewed_response_count, Value(0)),
+                .values_list("question_id", "c")
             )
 
-        return queryset.order_by("number")
+        for question in questions:
+            question.prefetched_total_responses = total_responses.get(question.id, 0)
+            question.prefetched_multi_choice_respondent_count = multi_choice_respondents.get(
+                question.id, 0
+            )
+            if want_reviewed:
+                question.prefetched_reviewed_responses = reviewed_responses.get(question.id, 0)
+            for option in question.multichoiceanswer_set.all():
+                option.prefetched_response_count = option_counts.get(option.id, 0)
+
+        return questions
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        questions = page if page is not None else list(queryset)
+        self._annotate_response_counts(questions)
+        serializer = self.get_serializer(questions, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        # Keep response counts populated on the serialized (PATCH) response, since
+        # get_object() no longer carries them.
+        self._annotate_response_counts([serializer.instance])
 
     def retrieve(self, request, *args, **kwargs):
         """
@@ -106,6 +126,7 @@ class QuestionViewSet(ModelViewSet):
         when filters are applied.
         """
         question = self.get_object()
+        self._annotate_response_counts([question])
 
         # Check if any filters are applied
         filter_params = [

--- a/backend/tests/unit/api/views/test_question_views.py
+++ b/backend/tests/unit/api/views/test_question_views.py
@@ -1,4 +1,6 @@
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework_simplejwt.tokens import RefreshToken
 
@@ -9,6 +11,7 @@ from factories import (
     RespondentFactory,
     ResponseAnnotationFactoryNoThemes,
     ResponseFactory,
+    ReviewedResponseAnnotationFactory,
 )
 
 
@@ -562,6 +565,74 @@ class TestQuestionViewSet:
 
         assert response.status_code == 200
         assert response.json()["theme_status"] == "confirmed"
+
+    def _build_counted_question(self, consultation, number, *, reviewed=0):
+        """Create a hybrid question with 3 free-text responses, an option chosen by
+        the first two responses, and ``reviewed`` human-reviewed annotations."""
+        question = QuestionFactory(
+            consultation=consultation,
+            has_free_text=True,
+            has_multiple_choice=True,
+            number=number,
+        )
+        option = MultiChoiceAnswerFactory.create(question=question, text="red")
+        responses = []
+        for i in range(3):
+            respondent = RespondentFactory(consultation=consultation)
+            responses.append(
+                ResponseFactory(question=question, respondent=respondent, free_text=f"r{i}")
+            )
+        responses[0].chosen_options.add(option)
+        responses[1].chosen_options.add(option)
+        for response in responses[:reviewed]:
+            ReviewedResponseAnnotationFactory(response=response)
+        question.update_total_responses()
+        return question
+
+    def test_question_list_returns_correct_counts(self, client, staff_user_token, consultation):
+        """List endpoint returns the same per-question counts the detail view does,
+        now computed in bulk."""
+        self._build_counted_question(consultation, number=1, reviewed=1)
+
+        url = reverse("question-list", kwargs={"consultation_pk": consultation.id})
+        response = client.get(
+            url,
+            {"include": "proportion_of_audited_answers"},
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert response.status_code == 200
+        [data] = response.json()["results"]
+        assert data["total_responses"] == 3
+        assert data["multi_choice_respondent_count"] == 2
+        option_counts = {o["text"]: o["response_count"] for o in data["multiple_choice_answer"]}
+        assert option_counts == {"red": 2}
+        # 1 of 3 free-text responses human-reviewed
+        assert data["proportion_of_audited_answers"] == pytest.approx(1 / 3)
+
+    def test_question_list_query_count_is_constant(self, client, staff_user_token, consultation):
+        """The list endpoint must not run per-question queries: adding more questions
+        (each with responses and options) must not increase the query count. This is
+        the guard against regressing to correlated-subquery-per-row behaviour."""
+        url = reverse("question-list", kwargs={"consultation_pk": consultation.id})
+        headers = {"Authorization": f"Bearer {staff_user_token}"}
+        query_params = {"include": "proportion_of_audited_answers"}
+
+        self._build_counted_question(consultation, number=1, reviewed=1)
+        with CaptureQueriesContext(connection) as small:
+            assert client.get(url, query_params, headers=headers).status_code == 200
+
+        for number in range(2, 7):
+            self._build_counted_question(consultation, number=number, reviewed=1)
+        with CaptureQueriesContext(connection) as large:
+            response = client.get(url, query_params, headers=headers)
+            assert response.status_code == 200
+
+        assert len(response.json()["results"]) == 6
+        assert len(large.captured_queries) == len(small.captured_queries), (
+            "Query count grew with the number of questions: "
+            f"{len(small.captured_queries)} -> {len(large.captured_queries)}"
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

`GET /api/consultations/{id}/questions/` is slow for large consultations. It powers the support console, the evaluations questions list, and the analysis/dashboard screens.

The list queryset annotated **every** question with correlated subqueries:
- total responses per question
- distinct multi-choice respondents per question
- response count per multi-choice option
- (when `include=proportion_of_audited_answers`) human-reviewed responses per question

Each subquery re-executes **once per question/option row**, so cost scales with the number of questions. For a consultation with ~300 questions × ~20k responses (~6M `Response` rows), the dominant cost is the reviewed-count subquery doing ~6M nested-loop probes into `ResponseAnnotation`, executed 300×.

## Fix

Replace the per-row correlated subqueries with a fixed handful of `GROUP BY` queries computed **once** for the paginated set of questions, then stitch the results onto the question/option instances under the same attribute names the serializer already reads.

- Per-request query count is now **independent of the number of questions**.
- The reviewed-count correlated nested-loop join becomes a single hash-joined aggregate.

## Contract

Identical JSON output and identical count semantics — `COUNT(DISTINCT)` for multi-choice respondents, default `0`, and the `include=proportion_of_audited_answers` gating are all preserved. **No model change, no migration, no serializer-contract change, no frontend change.**

## Changes
- `views/question.py`: lean `get_queryset()` (plain `multichoiceanswer_set` prefetch); new `_annotate_response_counts()` bulk helper; annotate at each serialization entry point (`list`, `retrieve`, `perform_update`).
- `serializers.py`: count getters default to `0` (faithful to the old `Coalesce(..., Value(0))`, and consistent with the existing `proportion`/`response_count` guards).
- `tests`: assert list-payload counts are correct, and **assert the query count stays constant as the number of questions grows** (regression guard against correlated-subquery-per-row behaviour).

## Verification
`tests/unit/api/`, `tests/unit/models/test_question.py` all pass (215 passed). The new `test_question_list_query_count_is_constant` proves no per-question query growth.

## Follow-ups (not in this PR)
- Gate the count annotations behind `include` so pages that don't display them (e.g. the support console) skip the work entirely.
- Parallelize the two sequential server-side fetches in the evaluations Astro page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)