### PR TITLE
fix: Add authReason checks to redirect users to sso when we receive TOKEN_EXPIRED

### DIFF
--- a/backend/consultations/api/views/auth.py
+++ b/backend/consultations/api/views/auth.py
@@ -18,6 +18,13 @@ client = AuthApiClient(
 )
 jwt_verifier = get_jwt_verifier()
 
+TOKEN_EXPIRED = "TOKEN_EXPIRED"
+
+
+def handle_authentication_error(logger, auth_reason, error_message, status_code=403):
+    logger.warning(error_message)
+    return JsonResponse(data={"detail": auth_reason}, status=status_code)
+
 
 @api_view(["POST"])
 @permission_classes([AllowAny])
@@ -34,7 +41,6 @@ def validate_token(request):
             try:
                 payload = jwt_verifier.verify_token(internal_access_token)
                 email = payload.get("email")
-
                 if not email:
                     logger.error("JWT token missing email claim")
                     return JsonResponse(data={"detail": "authentication failed"}, status=401)
@@ -49,12 +55,29 @@ def validate_token(request):
 
             user_authorisation_info = client.get_user_authorisation_info(internal_access_token)
             if not user_authorisation_info.is_authorised:
+                if user_authorisation_info.auth_reason == TOKEN_EXPIRED:
+                    return handle_authentication_error(
+                        logger,
+                        user_authorisation_info.auth_reason,
+                        "User token expired because {reason}".format(
+                            reason=user_authorisation_info.auth_reason
+                        ),
+                    )
+
                 logger.warning("User not authorized")
                 return JsonResponse(data={"detail": "authentication failed"}, status=403)
 
         elif HostingEnvironment.is_deployed():
             user_authorisation_info = client.get_user_authorisation_info(internal_access_token)
             if not user_authorisation_info.is_authorised:
+                if user_authorisation_info.auth_reason == TOKEN_EXPIRED:
+                    return handle_authentication_error(
+                        logger,
+                        user_authorisation_info.auth_reason,
+                        "User token expired because {reason}".format(
+                            reason=user_authorisation_info.auth_reason
+                        ),
+                    )
                 logger.warning("User not authenticated")
                 return JsonResponse(data={"detail": "authentication failed"}, status=403)
             email = user_authorisation_info.email
@@ -68,7 +91,7 @@ def validate_token(request):
         logger.warning("User does not exist")
         return JsonResponse(data={"detail": "authentication failed"}, status=403)
     except Exception:
-        logger.error("Error authenticating request")
+        logger.exception("Error authenticating request")
         return JsonResponse(data={"detail": "authentication failed"}, status=403)
 
     login(request, user)

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -16,6 +16,8 @@ const getCspValue = (): string => {
     .trim();
 };
 
+class TokenExpiredError extends Error {}
+
 export const onRequest: MiddlewareHandler = async (
   context: APIContext,
   next: MiddlewareNext,
@@ -58,7 +60,11 @@ export const onRequest: MiddlewareHandler = async (
     try {
       await validateUserToken(backendUrl, internalAccessToken, context);
     } catch (e: unknown) {
-      console.error("Unknown error signing in", e);
+      if (e instanceof TokenExpiredError) {
+        console.warn("[auth] SSO token expired, redirecting to logout");
+        return context.redirect(Routes.SignOut);
+      }
+      console.error("Unknown error signing in", JSON.stringify(e, null, 2));
       return context.redirect(Routes.SignInError);
     }
   } else {
@@ -73,7 +79,7 @@ export const onRequest: MiddlewareHandler = async (
     );
     userIsStaff = Boolean(resp.is_staff);
   } catch (e) {
-    console.error("Error accessing user info", e);
+    console.error("Error accessing user info", JSON.stringify(e, null, 2));
   }
 
   for (const protectedStaffRoute of protectedStaffRoutes) {
@@ -116,15 +122,26 @@ async function validateUserToken(
     headers: { "Content-Type": "application/json" },
   });
   const data = await response.json();
+  if (response.status === 403 && data.detail === "TOKEN_EXPIRED") {
+    throw new TokenExpiredError("SSO token has expired");
+  }
 
-  context.cookies.set("sessionId", data.sessionId, {
-    path: "/",
-    sameSite: "strict",
-  });
-  context.cookies.set("accessToken", data.access, {
-    path: "/",
-    sameSite: "strict",
-  });
+  if (!response.ok) {
+    throw new Error(
+      `Token validation failed with status ${response.status}: ${data.detail}`,
+    );
+  }
+
+  if (data?.sessionId && data?.access) {
+    context.cookies.set("sessionId", data?.sessionId, {
+      path: "/",
+      sameSite: "strict",
+    });
+    context.cookies.set("accessToken", data?.access, {
+      path: "/",
+      sameSite: "strict",
+    });
+  }
 }
 
 async function proxyToDjango(context: APIContext, backendUrl: string) {


### PR DESCRIPTION

## Changes proposed in this pull request

<!-- Why are you making this change? What might surprise someone about it? -->
This PR add changes that will invalidate old sessions of users who have old session as the result of the security breach that was reported by GDS Digital backbone that allows internal access of users to be impersonated and its now patched by GDS and we are using the new auth reason` TOKEN_EXPIRED` to clear and logout the users

A new client ID was also created to replace the old client ID which allows the auth api to invalidate the request using the old client ID
For more details check the [incident channel](https://i-dot-ai.slack.com/archives/C0B79K22MT7)