### PR TITLE
perf: Switch gunicorn to threaded workers for better concurrency

### DIFF
--- a/backend/gunicorn_config.py
+++ b/backend/gunicorn_config.py
@@ -1,7 +1,7 @@
-import os
-
-workers = int(os.environ.get("GUNICORN_WORKERS", "1"))
+worker_class = "gthread"
+workers = 4
+threads = 4
 bind = "0.0.0.0:8000"
 accesslog = "-"
 errorlog = "-"
-timeout = int(os.environ.get("GUNICORN_TIMEOUT", "30"))
+timeout = 60

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -51,14 +51,6 @@ locals {
       value = "postgres://${module.rds.rds_instance_username}:${module.rds.rds_instance_db_password}@${module.rds.db_instance_address}/${module.rds.db_instance_name}"
     },
     {
-      name  = "GUNICORN_WORKERS"
-      value = "placeholder"
-    },
-    {
-      name  = "GUNICORN_TIMEOUT"
-      value = "placeholder"
-    },
-    {
       name  = "ADMIN_USERS"
       value = "placeholder"
     },


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Users were reporting seeing 504 errors and I saw the same thing on Consult prod. We are seeing fewer errors now that the number of workers have been bumped from 2 to 4. But I think, given we have ~16 concurrent users and each worker can only handle one request at a time, I think we should consider using threads.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Use gthread worker class with 4 threads per worker, allowing 16 concurrent requests (4 workers × 4 threads) instead of 4 serial ones. When a request is blocked waiting on a slow database query, other threads can continue serving users which hopefully prevents the cascading 504s we are seeing.

- Move config from Parameter Store to gunicorn_config.py — values are now version controlled, visible in PRs, and don't require AWS admin access to view or change
- Same config across all environments (dev/preprod/prod) so concurrency issues surface before production. Resource cost is negligible within our 4GB memory allocation
- Timeout set to 60s to prevent slow queries from being killed