### PR TITLE
fix: Hide free text reponse count while loading

### DIFF
--- a/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
@@ -396,8 +396,9 @@
           <TitleRow
             level={2}
             title="Free Text Responses"
-            subtitle="{$questionStore.data?.free_text_response_count ||
-              0} responses"
+            subtitle={$questionStore.isLoading
+              ? ""
+              : `${$questionStore.data?.free_text_response_count || 0} responses`}
           >
             <Finance slot="icon" />
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Noticed this whilst playing around on prod.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Hide free text response count while loading.
