### PR TITLE
pro-387: Add candidate themes and demographics to test fixture data

### DIFF
--- a/backend/consultations/test_support/load_test_fixtures.py
+++ b/backend/consultations/test_support/load_test_fixtures.py
@@ -3,7 +3,9 @@ from django.db import transaction
 
 from authentication.models import User
 from consultations.models import (
+    CandidateTheme,
     Consultation,
+    DemographicOption,
     MultiChoiceAnswer,
     Question,
     Respondent,
@@ -36,6 +38,15 @@ def create_response_from_fixtures(respondents, index, question_object, response_
             SelectedTheme.objects.filter(question=question_object, key__in=response_data["themes"])
         )
 
+    if "demographics" in response_data:
+        for key, value in response_data["demographics"].items():
+            option, _ = DemographicOption.objects.get_or_create(
+                    consultation=question_object.consultation,
+                    field_name=key,
+                    field_value=value,
+                )
+            respondents[index].demographics.add(option)
+
 
 def create_question_from_fixtures(consultation_object, respondents, question_data):
     question_object = Question.objects.create(
@@ -62,6 +73,18 @@ def create_question_from_fixtures(consultation_object, respondents, question_dat
                     key=t["key"],
                 )
                 for t in question_data["themes"]
+            ]
+        )
+
+    if "candidate_themes" in question_data:
+        CandidateTheme.objects.bulk_create(
+            [
+                CandidateTheme(
+                    question=question_object,
+                    name=t["name"],
+                    description=t["description"]
+                )
+                for t in question_data["candidate_themes"]
             ]
         )
 
@@ -115,6 +138,9 @@ def create_data_from_fixtures(fixtures):
 
             for question_data in consultation_data.get("questions", []):
                 create_question_from_fixtures(consultation_object, respondents, question_data)
+
+            # Make sure that demographic response counts are updated after all responses have been created
+            DemographicOption.update_response_counts(consultation_object)
 
     return {
         "consultation_ids": consultations,

--- a/e2e_tests/fixtures.ts
+++ b/e2e_tests/fixtures.ts
@@ -6,10 +6,16 @@ export type Theme = {
   key: string;
 };
 
+export type DemographicInfo = {
+  age_group: string;
+  nation: string;
+}
+
 export type Response = {
   free_text?: string;
   chosen_options?: string[];
   themes?: Theme["key"][];
+  demographics?: DemographicInfo;
 };
 
 export type Question = {
@@ -19,6 +25,7 @@ export type Question = {
   has_multiple_choice: boolean;
   multiple_choice_options?: string[];
   responses?: Response[];
+  candidate_themes?: Theme[];
   themes?: Theme[];
 };
 
@@ -72,26 +79,31 @@ const hybridQuestionResponses: Response[] = [
   {
     free_text: "",
     chosen_options: [hybridQuestionOptions[0]],
+    demographics: { age_group: "18-35", nation: "England" },
   },
   {
     free_text:
       "Yes, I agree with the proposal as it will create a standardized framework that benefits both consumers and manufacturers.",
     chosen_options: [hybridQuestionOptions[0]],
+    demographics: { age_group: "36-50", nation: "Wales" },
   },
   {
     free_text:
       "No, I do not agree because I feel the proposed categories are too restrictive and may stifle innovation in flavour development.",
     chosen_options: [hybridQuestionOptions[1]],
+    demographics: { age_group: "51-65", nation: "Scotland" },
   },
   {
     free_text:
       "I agree with the proposal, but I think there should be room for additional categories to accommodate future trends.",
     chosen_options: [hybridQuestionOptions[0], hybridQuestionOptions[2]],
+    demographics: { age_group: "18-35", nation: "Northern Ireland" },
   },
   {
     free_text:
       "I disagree with the proposal as it does not sufficiently account for regional flavour preferences across the UK.",
     chosen_options: [hybridQuestionOptions[1]],
+    demographics: { age_group: "36-50", nation: "England" },
   },
 ];
 
@@ -100,30 +112,35 @@ const hybridQuestionResponsesWithThemes: Response[] = [
     free_text: "",
     chosen_options: [hybridQuestionOptions[0]],
     themes: ["A", "B"],
+    demographics: { age_group: "18-35", nation: "England" },
   },
   {
     free_text:
       "Yes, I agree with the proposal as it will create a standardized framework that benefits both consumers and manufacturers.",
     chosen_options: [hybridQuestionOptions[0]],
     themes: ["A"],
+    demographics: { age_group: "36-50", nation: "Wales" },
   },
   {
     free_text:
       "No, I do not agree because I feel the proposed categories are too restrictive and may stifle innovation in flavour development.",
     chosen_options: [hybridQuestionOptions[1]],
     themes: ["B"],
+    demographics: { age_group: "51-65", nation: "Scotland" },
   },
   {
     free_text:
       "I agree with the proposal, but I think there should be room for additional categories to accommodate future trends.",
     chosen_options: [hybridQuestionOptions[0], hybridQuestionOptions[2]],
     themes: [],
+    demographics: { age_group: "18-35", nation: "Northern Ireland" },
   },
   {
     free_text:
       "I disagree with the proposal as it does not sufficiently account for regional flavour preferences across the UK.",
     chosen_options: [hybridQuestionOptions[1]],
     themes: ["A"],
+    demographics: { age_group: "36-50", nation: "England" },
   },
 ];
 
@@ -219,22 +236,27 @@ export const openQuestionThemes: Theme[] = [
 const openQuestionResponses: Response[] = [
   {
     free_text: "",
+    demographics: { age_group: "18-35", nation: "England" },
   },
   {
     free_text:
       "I believe the current regulations should include clearer guidelines on the sourcing of ingredients to ensure ethical practices and sustainability.",
+    demographics: { age_group: "36-50", nation: "Wales" },
   },
   {
     free_text:
       "The regulations could be improved by setting specific limits on sugar content to promote healthier options for consumers.",
+    demographics: { age_group: "51-65", nation: "Scotland" },
   },
   {
     free_text:
       "Consideration should be given to standardizing portion sizes to help consumers make informed choices and manage their calorie intake.",
+    demographics: { age_group: "18-35", nation: "Northern Ireland" },
   },
   {
     free_text:
       "It would be beneficial to include mandatory allergen warnings on all packaging to enhance consumer safety.",
+    demographics: { age_group: "36-50", nation: "England" },
   },
 ];
 
@@ -242,26 +264,31 @@ const openQuestionResponsesWithThemes: Response[] = [
   {
     free_text: "",
     themes: ["A", "B", "C"],
+    demographics: { age_group: "18-35", nation: "England" },
   },
   {
     free_text:
       "I believe the current regulations should include clearer guidelines on the sourcing of ingredients to ensure ethical practices and sustainability.",
     themes: ["A", "C"],
+    demographics: { age_group: "36-50", nation: "Wales" },
   },
   {
     free_text:
       "The regulations could be improved by setting specific limits on sugar content to promote healthier options for consumers.",
     themes: ["B", "C"],
+    demographics: { age_group: "51-65", nation: "Scotland" },
   },
   {
     free_text:
       "Consideration should be given to standardizing portion sizes to help consumers make informed choices and manage their calorie intake.",
     themes: ["C"],
+    demographics: { age_group: "18-35", nation: "Northern Ireland" },
   },
   {
     free_text:
       "It would be beneficial to include mandatory allergen warnings on all packaging to enhance consumer safety.",
     themes: [],
+    demographics: { age_group: "36-50", nation: "England" },
   },
 ];
 
@@ -286,6 +313,23 @@ export const setupConsultation: Consultation = {
   stage: "setup",
   users: [defaultUser.email],
   questions: [hybridQuestion, multChoiceQuestion, openQuestion],
+};
+
+export const finalisingThemesConsultation: Consultation = {
+  title: "Dummy Consultation at Finalising Themes Stage (with Candidate Themes)",
+  stage: "finalising_themes",
+  users: [defaultUser.email],
+  questions: [
+    {
+      ...hybridQuestion,
+      candidate_themes: hybridQuestionThemes,
+    },
+    multChoiceQuestion,
+    {
+      ...openQuestion,
+      candidate_themes: openQuestionThemes,
+    },
+  ],
 };
 
 export const analysisConsultation: Consultation = {


### PR DESCRIPTION
# Context
  
  The e2e test fixture system previously had no way to create CandidateTheme records or DemographicOption records via the create-test-data API endpoint. This meant e2e tests for the finalising themes UI (which shows candidate themes) and the response analysis filter sidebar (which filters by demographic) could not be properly set up with realistic data. 
  
# Changes proposed in this pull request
  
* backend/consultations/test_support/load_test_fixtures.py
  - Supports candidate_themes and demographics fields in fixture data, creating the corresponding model records
  - Calls DemographicOption.update_response_counts() after all questions are processed so filter sidebar counts are correct

* e2e_tests/fixtures.ts
  - Added demographics and candidate_themes to the Response and Question types
  - Added demographic data to all response arrays and a new finalisingThemesConsultation fixture with candidate themes
  
# Guidance to review

  - Demographic options use get_or_create so the same option is reused across questions rather than duplicated per response
  - Demographics are added to all response arrays so any fixture using them will have filter data available

