### PR TITLE
fix: Update theme and evidence-rich tags immediately after editing

### DIFF
--- a/frontend/src/components/dashboard/EditPanel/EditPanel.svelte
+++ b/frontend/src/components/dashboard/EditPanel/EditPanel.svelte
@@ -65,7 +65,7 @@
     );
 
     if (!$responseUpdateStore.error && !$responseUpdateStore.isLoading) {
-      resetData();
+      resetData(stagedThemes, stagedEvidenceRich);
     }
   }
 
@@ -76,7 +76,10 @@
     themes: ResponseTheme[];
     themeOptions: ResponseTheme[];
     evidenceRich: boolean | null;
-    resetData: () => void;
+    resetData: (
+      updatedThemes: ResponseTheme[],
+      updatedEvidenceRich: boolean | null,
+    ) => void;
     setEditing: (newValue: boolean) => void;
     updateResponseMock?: StoreFetch;
   }

--- a/frontend/src/components/dashboard/ResponseCard/ResponseCard.svelte
+++ b/frontend/src/components/dashboard/ResponseCard/ResponseCard.svelte
@@ -54,10 +54,10 @@
     onInteract = () => {},
   }: Props = $props();
 
-  let isFlagged = $state(isFlaggedProp);
-  let isEdited = $state(isEditedProp);
-  let themes = $state(themesProp);
-  let evidenceRich = $state(evidenceRichProp);
+  let isFlagged = $derived(isFlaggedProp);
+  let isEdited = $derived(isEditedProp);
+  let themes = $derived(themesProp);
+  let evidenceRich = $derived(evidenceRichProp);
 
   let editing: boolean = $state(false);
 </script>

--- a/frontend/src/components/dashboard/ResponseCard/ResponseCard.svelte
+++ b/frontend/src/components/dashboard/ResponseCard/ResponseCard.svelte
@@ -43,9 +43,9 @@
     respondentId = "",
     text = "",
     demoData = [],
-    evidenceRich = false,
+    evidenceRich: evidenceRichProp = false,
     multiAnswers = [],
-    themes = [],
+    themes: themesProp = [],
     themeOptions = [],
     skeleton = false,
     highlightText = "",
@@ -55,8 +55,9 @@
   }: Props = $props();
 
   let isFlagged = $state(isFlaggedProp);
-
   let isEdited = $state(isEditedProp);
+  let themes = $state(themesProp);
+  let evidenceRich = $state(evidenceRichProp);
 
   let editing: boolean = $state(false);
 </script>
@@ -153,11 +154,13 @@
             {answerId}
             {themeOptions}
             {evidenceRich}
-            resetData={() => {
+            {themes}
+            resetData={(updatedThemes, updatedEvidenceRich) => {
+              themes = updatedThemes;
+              evidenceRich = updatedEvidenceRich ?? false;
               isEdited = true;
               onInteract();
             }}
-            themes={themes || []}
             setEditing={(val: boolean) => (editing = val)}
           />
         {/if}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

One of our users were reporting that editing theme assignments weren't working. Turns out that they are saving but give off the impression they aren't because the changes aren't reflected on the response card in the page.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Pass saved values back from EditPanel to ResponseCard so changes are reflected without a page refresh.