### PR TITLE
refactor: Refactor auth reason to centralised source of truth

### DIFF
--- a/backend/consultations/api/views/auth.py
+++ b/backend/consultations/api/views/auth.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
 from django.http import JsonResponse
 from i_dot_ai_utilities.auth.auth_api import AuthApiClient
+from i_dot_ai_utilities.auth.auth_reason import AuthReason
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework_simplejwt.tokens import AccessToken
@@ -18,12 +19,26 @@ client = AuthApiClient(
 )
 jwt_verifier = get_jwt_verifier()
 
-TOKEN_EXPIRED = "TOKEN_EXPIRED"
-
 
 def handle_authentication_error(logger, auth_reason, error_message, status_code=403):
     logger.warning(error_message)
-    return JsonResponse(data={"detail": auth_reason}, status=status_code)
+    return JsonResponse(data={"detail": auth_reason.value}, status=status_code)
+
+
+def _check_authorisation(token: str, unauthorised_log_message: str):
+    user_authorisation_info = client.get_user_authorisation_info(token)
+    if not user_authorisation_info.is_authorised:
+        if user_authorisation_info.auth_reason == AuthReason.TOKEN_EXPIRED:
+            return user_authorisation_info, handle_authentication_error(
+                logger,
+                user_authorisation_info.auth_reason,
+                f"User token expired because {user_authorisation_info.auth_reason}",
+            )
+        logger.warning(unauthorised_log_message)
+        return user_authorisation_info, JsonResponse(
+            data={"detail": "authentication failed"}, status=403
+        )
+    return user_authorisation_info, None
 
 
 @api_view(["POST"])
@@ -53,33 +68,16 @@ def validate_token(request):
                 logger.warning("JWT token verification failed")
                 return JsonResponse(data={"detail": "invalid token"}, status=401)
 
-            user_authorisation_info = client.get_user_authorisation_info(internal_access_token)
-            if not user_authorisation_info.is_authorised:
-                if user_authorisation_info.auth_reason == TOKEN_EXPIRED:
-                    return handle_authentication_error(
-                        logger,
-                        user_authorisation_info.auth_reason,
-                        "User token expired because {reason}".format(
-                            reason=user_authorisation_info.auth_reason
-                        ),
-                    )
-
-                logger.warning("User not authorized")
-                return JsonResponse(data={"detail": "authentication failed"}, status=403)
+            _, error = _check_authorisation(internal_access_token, "User not authorized")
+            if error:
+                return error
 
         elif HostingEnvironment.is_deployed():
-            user_authorisation_info = client.get_user_authorisation_info(internal_access_token)
-            if not user_authorisation_info.is_authorised:
-                if user_authorisation_info.auth_reason == TOKEN_EXPIRED:
-                    return handle_authentication_error(
-                        logger,
-                        user_authorisation_info.auth_reason,
-                        "User token expired because {reason}".format(
-                            reason=user_authorisation_info.auth_reason
-                        ),
-                    )
-                logger.warning("User not authenticated")
-                return JsonResponse(data={"detail": "authentication failed"}, status=403)
+            user_authorisation_info, error = _check_authorisation(
+                internal_access_token, "User not authenticated"
+            )
+            if error:
+                return error
             email = user_authorisation_info.email
 
         else:
@@ -102,12 +100,7 @@ def validate_token(request):
 
     logger.info("User authenticated successfully")
 
-    return JsonResponse(
-        {
-            "access": str(access_token),
-            "sessionId": request.session.session_key,
-        }
-    )
+    return JsonResponse({"access": str(access_token), "sessionId": request.session.session_key})
 
 
 @api_view(["POST"])

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 
 [tool.uv]
 exclude-newer = "P14D"
+exclude-newer-package = {"i-dot-ai-utilities" = "2026-06-04"}
 
 [tool.ruff]
 line-length = 100

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,8 +3,11 @@ revision = 3
 requires-python = "==3.12.*"
 
 [options]
-exclude-newer = "2026-04-01T06:24:06.967684Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
+
+[options.exclude-newer-package]
+i-dot-ai-utilities = "2026-06-04T23:00:00Z"
 
 [[package]]
 name = "annotated-types"
@@ -684,7 +687,7 @@ wheels = [
 
 [[package]]
 name = "i-dot-ai-utilities"
-version = "0.4.4"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -692,9 +695,9 @@ dependencies = [
     { name = "structlog" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/75/c9607008b9172f1b211e8dcdb222f989ef089ccba9c35e58eced4e57eae4/i_dot_ai_utilities-0.4.4.tar.gz", hash = "sha256:03fb7cf8bcda5b61ce3224d9a10a4834b095f355ae78a172d43fea9a8147aaa0", size = 219005, upload-time = "2025-11-10T09:05:36.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/0f/99ebbb3c571563badf8b7205af730a29face73fa9344e06d3e805779fca4/i_dot_ai_utilities-0.6.0.tar.gz", hash = "sha256:c8e3dbbcea715cab146cab1054b68ffca92ed9ef0c035f0250c53087771c1f14", size = 219387, upload-time = "2026-06-03T09:44:45.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/30/f84a0fd857abcf1daa89841b9e6144f71ce456f92c979f0de605ae6fc994/i_dot_ai_utilities-0.4.4-py3-none-any.whl", hash = "sha256:2034c96673836399873b00b76c689dd19d663f8e610f167da39070b229076006", size = 51014, upload-time = "2025-11-10T09:05:35.07Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0c/49a020be275c7705d6c6539fb69a51e4ce3a0655399b2d2bb69a0b2c22c7/i_dot_ai_utilities-0.6.0-py3-none-any.whl", hash = "sha256:2cf1df3ae078d931cd54e3f4697ae4e6e0dadbdb9444762dbbdc583c6d884877", size = 51599, upload-time = "2026-06-03T09:44:44.475Z" },
 ]
 
 [package.optional-dependencies]

--- a/frontend/src/global/types.ts
+++ b/frontend/src/global/types.ts
@@ -1,5 +1,6 @@
 import type { SvelteURLSearchParams } from "svelte/reactivity";
 
+// Keep in sync with AuthReason in i-dot-ai-utilities (i_dot_ai_utilities/auth/auth_reason.py)
 export const AuthReasons = {
   UNKNOWN: "UNKNOWN",
   TOKEN_EXPIRED: "TOKEN_EXPIRED",

--- a/frontend/src/global/types.ts
+++ b/frontend/src/global/types.ts
@@ -1,5 +1,20 @@
 import type { SvelteURLSearchParams } from "svelte/reactivity";
 
+export const AuthReasons = {
+  UNKNOWN: "UNKNOWN",
+  TOKEN_EXPIRED: "TOKEN_EXPIRED",
+  NO_SUCH_APPLICATION: "NO_SUCH_APPLICATION",
+  NO_MATCHING_RULE: "NO_MATCHING_RULE",
+  JWT_GLOBAL_ACCESS_CLAIM: "JWT_GLOBAL_ACCESS_CLAIM",
+  JWT_CLAIM_MATCHES_APP: "JWT_CLAIM_MATCHES_APP",
+  ACL_MATCHING_EMAIL: "ACL_MATCHING_EMAIL",
+  ACL_MATCHING_DOMAIN: "ACL_MATCHING_DOMAIN",
+  ACL_GLOBAL_ACCESS_EMAIL: "ACL_GLOBAL_ACCESS_EMAIL",
+  ACL_GLOBAL_ACCESS_DOMAIN: "ACL_GLOBAL_ACCESS_DOMAIN",
+} as const;
+
+export type AuthReason = (typeof AuthReasons)[keyof typeof AuthReasons];
+
 export interface NavItem {
   text: string;
   url: string;

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,6 +2,7 @@ import type { APIContext, MiddlewareHandler, MiddlewareNext } from "astro";
 import { Routes } from "./global/routes";
 import { fetchBackendApi } from "./global/api";
 import { getBackendUrl, getEnv } from "./global/utils";
+import { AuthReasons } from "./global/types";
 
 const getCspValue = (): string => {
   return `
@@ -122,7 +123,7 @@ async function validateUserToken(
     headers: { "Content-Type": "application/json" },
   });
   const data = await response.json();
-  if (response.status === 403 && data.detail === "TOKEN_EXPIRED") {
+  if (response.status === 403 && data.detail === AuthReasons.TOKEN_EXPIRED) {
     throw new TokenExpiredError("SSO token has expired");
   }
 


### PR DESCRIPTION
This PR introduced a refactor that centralised the auth reasons from SSO so that we can have a single source of truth for the python code 

The recent security breach that we needed to invalidate some of the sessions resulting to consumer apps making changes to check for the auth reason `TOKEN_EXPIRED` in their call site. This will allow change to happen in a single place without making changes in many places of the same values.