### PR TITLE
E2E Test Data Cleanup Improvements

### DIFF
--- a/e2e_tests/tests/consultations.e2e.ts
+++ b/e2e_tests/tests/consultations.e2e.ts
@@ -12,9 +12,8 @@ import {
 } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
 
-const cleanupManager = new CleanupManager();
-
 test.describe("Consultations - List Page", () => {
+  const cleanupManager = new CleanupManager();
   let testData: FixtureReference = {};
 
   test.beforeAll(async ({ request }) => {
@@ -73,6 +72,7 @@ test.describe("Consultations - List Page", () => {
 });
 
 test.describe("Consultations - Detail/Dashboard Page", () => {
+  const cleanupManager = new CleanupManager();
   let testData: FixtureReference = {};
   let consultationId: string;
 
@@ -150,6 +150,7 @@ test.describe("Consultations - Detail/Dashboard Page", () => {
 });
 
 test.describe("Consultations - Evaluation Page", () => {
+  const cleanupManager = new CleanupManager();
   let consultationId: string;
   let testData: FixtureReference = {};
 

--- a/e2e_tests/tests/consultations.e2e.ts
+++ b/e2e_tests/tests/consultations.e2e.ts
@@ -68,7 +68,7 @@ test.describe("Consultations - List Page", () => {
   });
 
   test.afterAll(async () => {
-    await deleteFixtureData(testData);
+    await cleanupManager.cleanup();
   });
 });
 
@@ -80,6 +80,7 @@ test.describe("Consultations - Detail/Dashboard Page", () => {
     testData = await createFixtureData(request, {
       consultations: [setupConsultation],
     });
+    cleanupManager.add(testData);
   });
 
   test.beforeEach(async ({ page }) => {
@@ -144,7 +145,7 @@ test.describe("Consultations - Detail/Dashboard Page", () => {
   });
 
   test.afterAll(async () => {
-    await deleteFixtureData(testData);
+    cleanupManager.cleanup();
   });
 });
 
@@ -156,6 +157,7 @@ test.describe("Consultations - Evaluation Page", () => {
     testData = await createFixtureData(request, {
       consultations: [setupConsultation],
     });
+    cleanupManager.add(testData);
   });
 
   test.beforeEach(async ({ page }) => {

--- a/e2e_tests/tests/consultations.e2e.ts
+++ b/e2e_tests/tests/consultations.e2e.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import {
+  CleanupManager,
   createFixtureData,
   deleteFixtureData,
   getFirstConsultationLink,
@@ -11,6 +12,8 @@ import {
 } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
 
+const cleanupManager = new CleanupManager();
+
 test.describe("Consultations - List Page", () => {
   let testData: FixtureReference = {};
 
@@ -18,6 +21,7 @@ test.describe("Consultations - List Page", () => {
     testData = await createFixtureData(request, {
       consultations: [setupConsultation, signOffConsultation],
     });
+    cleanupManager.add(testData);
   });
 
   test.beforeEach(async ({ page }) => {
@@ -212,6 +216,6 @@ test.describe("Consultations - Evaluation Page", () => {
   });
 
   test.afterAll(async () => {
-    await deleteFixtureData(testData);
+    await cleanupManager.cleanup();
   });
 });

--- a/e2e_tests/tests/consultations.e2e.ts
+++ b/e2e_tests/tests/consultations.e2e.ts
@@ -145,7 +145,7 @@ test.describe("Consultations - Detail/Dashboard Page", () => {
   });
 
   test.afterAll(async () => {
-    cleanupManager.cleanup();
+    await cleanupManager.cleanup();
   });
 });
 

--- a/e2e_tests/tests/finalise-themes-detail.e2e.ts
+++ b/e2e_tests/tests/finalise-themes-detail.e2e.ts
@@ -1,12 +1,14 @@
 import { test, expect, Page } from "@playwright/test";
 import {
+  CleanupManager,
   createFixtureData,
-  deleteFixtureData,
 } from "./helpers";
 import { signOffConsultation } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
 
 test.describe.configure({ mode: "serial" });
+
+const cleanupManager = new CleanupManager();
 
 async function createTheme(page: Page, title: string, description: string) {
   const createThemeButton = page.getByRole("button", { name: "Add Custom Theme" });
@@ -41,6 +43,7 @@ test.describe("Finalise Themes - Detail Page", () => {
     testData = await createFixtureData(request, {
       consultations: [signOffConsultation],
     });
+    cleanupManager.add(testData);
 
     // Navigate to consultations to find a consultation
     await page.goto("/consultations");
@@ -273,6 +276,6 @@ test.describe("Finalise Themes - Detail Page", () => {
   })
 
   test.afterEach(async () => {
-    await deleteFixtureData(testData);
+    await cleanupManager.cleanup();
   });
 });

--- a/e2e_tests/tests/helpers.ts
+++ b/e2e_tests/tests/helpers.ts
@@ -153,3 +153,52 @@ export async function getFirstConsultationLink(page: Page) {
   }
   return null;
 }
+
+interface CleanupManagerOptions {
+  maxAttempts?: number;
+  attemptFrequency?: number;
+}
+
+export class CleanupManager {
+  private fixtures: Fixture[] = [];
+  public maxAttempts: number;
+  public attemptFrequency: number;
+
+  constructor({ maxAttempts, attemptFrequency }: CleanupManagerOptions = {}) {
+    this.maxAttempts = maxAttempts || 5;
+    this.attemptFrequency = attemptFrequency || 1000;
+  }
+
+  async _attemptCleanup(maxAttempts: number, attemptFrequency: number, fixture: Fixture) {
+    let success = false;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await deleteFixtureData(fixture);
+        success = true;
+        break;
+      } catch {
+        await new Promise(resolve => setTimeout(resolve, attemptFrequency));
+      }
+    }
+
+    if (!success) {
+      console.error("Test fixture cleanup failed");
+    }
+  }
+
+  add(fixture: Fixture) {
+    this.fixtures.push(fixture);
+  }
+
+  reset() {
+    this.fixtures = [];
+  }
+
+  async cleanup() {
+    for (const fixture of this.fixtures) {
+      await this._attemptCleanup(this.maxAttempts, this.attemptFrequency, fixture);
+    }
+    this.reset();
+  }
+}

--- a/e2e_tests/tests/helpers.ts
+++ b/e2e_tests/tests/helpers.ts
@@ -2,7 +2,7 @@ import { request as apirequest } from "@playwright/test";
 import type { Page, APIRequestContext } from "@playwright/test";
 
 import { testAccessToken } from "../constants";
-import type { Fixture } from "../fixtures";
+import type { Fixture, FixtureReference } from "../fixtures";
 
 async function getToken(context: APIRequestContext) {
   const token_response = await context.fetch("/api/validate-token/", {
@@ -160,7 +160,7 @@ interface CleanupManagerOptions {
 }
 
 export class CleanupManager {
-  private fixtures: Fixture[] = [];
+  private fixtures: FixtureReference[] = [];
   public maxAttempts: number;
   public attemptFrequency: number;
 
@@ -169,7 +169,7 @@ export class CleanupManager {
     this.attemptFrequency = attemptFrequency || 1000;
   }
 
-  private async _attemptCleanup(maxAttempts: number, attemptFrequency: number, fixture: Fixture) {
+  private async _attemptCleanup(maxAttempts: number, attemptFrequency: number, fixture: FixtureReference) {
     let success = false;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -183,11 +183,14 @@ export class CleanupManager {
     }
 
     if (!success) {
-      console.error("Test fixture cleanup failed");
+      console.error(
+        "Test fixture cleanup failed for these consultations: ",
+        fixture.consultation_ids?.join(", "),
+      );
     }
   }
 
-  add(fixture: Fixture) {
+  add(fixture: FixtureReference) {
     this.fixtures.push(fixture);
   }
 

--- a/e2e_tests/tests/helpers.ts
+++ b/e2e_tests/tests/helpers.ts
@@ -169,7 +169,7 @@ export class CleanupManager {
     this.attemptFrequency = attemptFrequency || 1000;
   }
 
-  async _attemptCleanup(maxAttempts: number, attemptFrequency: number, fixture: Fixture) {
+  private async _attemptCleanup(maxAttempts: number, attemptFrequency: number, fixture: Fixture) {
     let success = false;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/e2e_tests/tests/questions.e2e.ts
+++ b/e2e_tests/tests/questions.e2e.ts
@@ -2,7 +2,6 @@ import { test, expect } from "@playwright/test";
 import {
   CleanupManager,
   createFixtureData,
-  deleteFixtureData,
   getFirstConsultationLink,
 } from "./helpers";
 import { analysisConsultation } from "../fixtures";

--- a/e2e_tests/tests/questions.e2e.ts
+++ b/e2e_tests/tests/questions.e2e.ts
@@ -1,11 +1,14 @@
 import { test, expect } from "@playwright/test";
 import {
+  CleanupManager,
   createFixtureData,
   deleteFixtureData,
   getFirstConsultationLink,
 } from "./helpers";
 import { analysisConsultation } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
+
+const cleanupManager = new CleanupManager();
 
 test.describe("Questions - Detail Page with Tabs", () => {
   let testData: FixtureReference = {};
@@ -14,6 +17,7 @@ test.describe("Questions - Detail Page with Tabs", () => {
     testData = await createFixtureData(request, {
       consultations: [analysisConsultation],
     });
+    cleanupManager.add(testData);
   });
 
   test.beforeEach(async ({ page }) => {
@@ -149,6 +153,6 @@ test.describe("Questions - Detail Page with Tabs", () => {
   });
 
   test.afterAll(async () => {
-    await deleteFixtureData(testData);
+    await cleanupManager.cleanup();
   });
 });

--- a/e2e_tests/tests/respondent-detail.e2e.ts
+++ b/e2e_tests/tests/respondent-detail.e2e.ts
@@ -2,7 +2,6 @@ import { test, expect } from "@playwright/test";
 import {
   CleanupManager,
   createFixtureData,
-  deleteFixtureData,
 } from "./helpers";
 import { analysisConsultation } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
@@ -257,8 +256,6 @@ test.describe("Respondent Detail Page", () => {
   });
 
   test.afterAll(async () => {
-    await deleteFixtureData(testData);
     await cleanupManager.cleanup();
   });
-
 });

--- a/e2e_tests/tests/respondent-detail.e2e.ts
+++ b/e2e_tests/tests/respondent-detail.e2e.ts
@@ -1,10 +1,13 @@
 import { test, expect } from "@playwright/test";
 import {
+  CleanupManager,
   createFixtureData,
   deleteFixtureData,
 } from "./helpers";
 import { analysisConsultation } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
+
+const cleanupManager = new CleanupManager();
 
 test.describe("Respondent Detail Page", () => {
   let testData: FixtureReference = {};
@@ -15,6 +18,7 @@ test.describe("Respondent Detail Page", () => {
     testData = await createFixtureData(request, {
       consultations: [analysisConsultation],
     });
+    cleanupManager.add(testData);
   });
 
   test.beforeEach(async ({ page }) => {
@@ -254,6 +258,7 @@ test.describe("Respondent Detail Page", () => {
 
   test.afterAll(async () => {
     await deleteFixtureData(testData);
+    await cleanupManager.cleanup();
   });
 
 });


### PR DESCRIPTION
## Context
For certain edge cases, test data fails to clean up following Playwright tests.

## Changes proposed in this pull request
This PR adds a CleanupManager class that can hold the fixture data during runtime, attempt to remove all existing ones instead of a single fixture, and retries several times if cleanup fails fails initially.

## Guidance to review
Confirm Playwright tests are passing.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
