### PR TITLE
Bump ECS module to v7.0.1

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -30,7 +30,7 @@ module "backend" {
   # checkov:skip=CKV_SECRET_4:Skip secret check as these have to be used within the Github Action
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
-  source                        = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.1-ecs"
+  source                        = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v7.0.1-ecs"
   image_tag                     = data.aws_ssm_parameter.image_tags["backend"].value
   ecr_repository_uri            = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/${var.project_name}-backend"
   vpc_id                        = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -97,7 +97,7 @@ module "frontend" {
   # checkov:skip=CKV_SECRET_4:Skip secret check as these have to be used within the Github Action
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
-  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.1-ecs"
+  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v7.0.1-ecs"
   image_tag                    = data.aws_ssm_parameter.image_tags["frontend"].value
   ecr_repository_uri           = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/${var.project_name}-frontend"
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -158,7 +158,7 @@ module "worker" {
   # checkov:skip=CKV_SECRET_4:Skip secret check as these have to be used within the Github Action
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
-  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v6.0.1-ecs"
+  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v7.0.1-ecs"
   image_tag                    = data.aws_ssm_parameter.image_tags["backend"].value
   ecr_repository_uri           = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/${var.project_name}-backend"
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id


### PR DESCRIPTION
## What

Bumps the `backend`, `frontend` and `worker` ECS modules from `v6.0.1-ecs` to `v7.0.1-ecs`.

## Why

Brings Consult onto the current ECS module line. From `v7.0.0` the ALB auth listener `session_timeout` is driven by the module's `user_session_timeout` variable instead of a hardcoded value.

## Behaviour note

Prior to `v7.0.0` the module hardcoded `session_timeout = 604800` (7 days). From `v7.0.0` it defaults to `43200` (12 hours). We intentionally rely on that default — no `user_session_timeout` override is set — so user sessions will now time out after 12 hours rather than 7 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)