### PR TITLE
PRO-365: e2e_tests - Add response analysis page tests

### DIFF
--- a/e2e_tests/tests/helpers.ts
+++ b/e2e_tests/tests/helpers.ts
@@ -1,5 +1,5 @@
 import { request as apirequest } from "@playwright/test";
-import type { APIRequestContext } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 
 import { testAccessToken } from "../constants";
 import type { Fixture, FixtureReference } from "../fixtures";
@@ -186,4 +186,14 @@ export class CleanupManager {
     }
     this.reset();
   }
+}
+
+/**
+  * Goes to a specific question in a consultation
+ */
+export async function goToConsultationQuestion(page: Page, consultationId: string, questionID: string) {
+    await page.goto(`/consultations/${consultationId}`);
+    await page.waitForLoadState('networkidle');
+    await page.goto(`consultations/${consultationId}/questions/${questionID}`);
+    await page.waitForLoadState('networkidle');
 }

--- a/e2e_tests/tests/response-analysis.e2e.ts
+++ b/e2e_tests/tests/response-analysis.e2e.ts
@@ -1,0 +1,218 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+import {
+  CleanupManager,
+  createFixtureData,
+  goToConsultationQuestion,
+} from './helpers';
+import { analysisConsultation } from '../fixtures';
+import type { FixtureReference } from '../fixtures';
+
+const sleep = () => new Promise<void>(resolve => setTimeout(resolve, 1000));
+
+const getFreeTextResponses = (page: Page) =>
+  page
+    .locator('section')
+    .filter({ has: page.getByRole('heading', { name: 'Free Text Responses' }) })
+    .locator('ul li');
+
+function getFilterButton(
+  page: Page,
+  containerSelector: string,
+  filter: string,
+  labelSelector?: string,
+) {
+  if (labelSelector) {
+    return page
+      .locator(containerSelector)
+      .locator('button, [role="button"]')
+      .filter({ has: page.locator(labelSelector).filter({ hasText: new RegExp(`^${filter}$`) }) });
+  }
+  return page.locator(containerSelector).getByRole('button', { name: new RegExp(`^${filter}`) });
+}
+
+async function testFilter(
+  page: Page,
+  filterNames: string[],
+  sameGroupFilters: string[],
+  totalCount: number,
+  {
+    operator = 'OR',
+    countSelector = 'span.text-right',
+    containerSelector = 'aside',
+    labelSelector,
+  }: {
+    operator?: 'AND' | 'OR';
+    countSelector?: string;
+    containerSelector?: string;
+    labelSelector?: string;
+  } = {},
+) {
+  const expectedCounts = [];
+
+  // AND option only allowed for max two filters (one in each group)
+  if (operator === 'AND' && filterNames.length != 2) {
+    throw new Error('AND operator only supported for two filters');
+  }
+
+  // When we click multiple filters in the same group an unclicked filter will show zero before clicking and
+  // then the true value after clicking - so we need to get the expected count for each filter before clicking any of them
+  for (const filter of filterNames) {
+    const filterButton = getFilterButton(page, containerSelector, filter, labelSelector);
+
+    const countText = await filterButton.locator(countSelector).textContent();
+    expectedCounts.push(parseInt(countText!.trim()));
+  }
+
+  // Now click each filter in turn and check count is correct after each click (should be same as before clicking)
+  for (const [i, filter] of filterNames.entries()) {
+    const filterButton = getFilterButton(page, containerSelector, filter, labelSelector);
+
+    // For AND we do need to update expected counts for second filter as the value will change after
+    // first filter is applied. For OR our previous expected counts should not be affected.
+    if (operator === 'AND' && i === 1) {
+      expectedCounts[1] = await filterButton
+        .locator(countSelector)
+        .textContent()
+        .then((text) => parseInt(text!.trim()));
+    }
+
+    await filterButton.click();
+    await page.waitForLoadState('networkidle');
+    await sleep();
+
+    await expect(filterButton.locator(countSelector)).toHaveText(String(expectedCounts[i]));
+  }
+
+  // Response list should show only matching responses
+  if (operator === 'AND') {
+    // For AND, count should be same as last filter clicked (most specific)
+    await expect(getFreeTextResponses(page)).toHaveCount(expectedCounts.at(-1)!);
+  }
+  else if (operator === 'OR') {
+    // For OR, count should be sum of all selected filters (no overlap in our test data so just sum)
+    await expect(getFreeTextResponses(page)).toHaveCount(expectedCounts.reduce((a, b) => a + b, 0));
+  }
+
+  // All other filters in the same group should show 0
+  for (const other of sameGroupFilters) {
+    if (filterNames.includes(other)) continue; // Skip the filters we selected
+    const otherCountText = await getFilterButton(page, containerSelector, other, labelSelector)
+      .locator(countSelector)
+      .textContent();
+    expect(parseInt(otherCountText!.trim())).toBe(0);
+  }
+
+  // Reset and confirm full list is restored
+  for (const filter of filterNames) {
+    await getFilterButton(page, containerSelector, filter, labelSelector).click();
+    await page.waitForLoadState('networkidle');
+    await sleep();
+  }
+  await expect(getFreeTextResponses(page)).toHaveCount(totalCount);
+}
+
+test.describe('Response Analysis Page', () => {
+  const cleanupManager = new CleanupManager();
+  let testData: FixtureReference = {};
+
+  test.beforeAll(async ({ request }) => {
+    testData = await createFixtureData(request, {
+      consultations: [analysisConsultation],
+    });
+    cleanupManager.add(testData);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await goToConsultationQuestion(page, testData.consultation_ids![0], testData.question_ids![0]);
+  });
+
+  test('demographic filters show correct response counts', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Filters/i })).toBeVisible();
+
+    const totalCount = await getFreeTextResponses(page).count();
+
+    const nationFilters = ['England', 'Wales', 'Scotland', 'Northern Ireland'];
+    const ageGroupFilters = ['18-35', '36-50', '51-65'];
+
+    for (const filter of nationFilters) {
+      await testFilter(page, [filter], nationFilters, totalCount);
+    }
+    for (const filter of ageGroupFilters) {
+      await testFilter(page, [filter], ageGroupFilters, totalCount);
+    }
+
+    // Check two filters in same group (e.g. England + Wales) - should show responses matching either filter
+    await testFilter(page, ['England', 'Wales'], nationFilters, totalCount);
+
+    // Check combined filters (e.g. England + 18-35) - should show only responses matching both
+    await testFilter(page, ['England', '18-35'], [...nationFilters, ...ageGroupFilters], totalCount, {
+      operator: 'AND',
+    });
+  });
+
+  test('filters on categorical question show correct response counts', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Multiple Choice Answers/i })).toBeVisible();
+
+    const totalCount = await getFreeTextResponses(page).count();
+    const options = ['Yes', 'No', "Don't know", 'No answer'];
+
+    for (const option of options) {
+      // Multichoice options may be overlapping so we cannot assume that other options will be zero
+      await testFilter(page, [option], [], totalCount, {
+        countSelector: 'span[class~="sm:hidden"]',
+        containerSelector: 'section:has-text("Multiple Choice Answers")',
+        labelSelector: 'h3',
+      });
+    }
+  });
+
+  test('select theme filters show correct response counts', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Theme analysis/i })).toBeVisible();
+
+    const totalCount = await getFreeTextResponses(page).count();
+    const themes = ['Standardized framework', 'Innovation'];
+
+    for (const theme of themes) {
+      // Theme filters may be overlapping so we cannot assume that other themes will be zero
+      await testFilter(page, [theme], [], totalCount, {
+        containerSelector: 'section:has-text("Theme analysis") table',
+        countSelector: 'td:nth-child(2)',
+      });
+    }
+  });
+
+  test('flagged toggle shows only flagged responses', async ({ page }) => {
+    // Flag the first response
+    await getFreeTextResponses(page).first().getByTitle('Flag response').click();
+    await page.waitForLoadState('networkidle');
+
+    // Enable the flagged-only toggle
+    await page.getByRole('switch', { name: /Flagged/i }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Only the flagged response should be visible
+    await expect(getFreeTextResponses(page)).toHaveCount(1);
+
+    // Unflag to clean up, then disable toggle
+    await getFreeTextResponses(page).first().getByTitle('Flag response').click();
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('switch', { name: /Flagged/i }).click();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('click respondent goes to respondent details page', async ({ page }) => {
+    // Click the respondent button on the first response
+    const firstResponse = getFreeTextResponses(page).first();
+    await firstResponse.getByTestId(/^respondent-button/).click();
+
+    // Should navigate to the respondent detail page
+    await page.waitForURL(/\/respondent\/[0-9a-f-]+/);
+    await expect(page.getByText(new RegExp(`Respondent\\s*\\d+`))).toBeVisible();
+  });
+
+  test.afterAll(async () => {
+    await cleanupManager.cleanup();
+  });
+});


### PR DESCRIPTION
# Context
  
  Adds E2E test coverage for the response analysis page (question detail view). The page has several interactive filtering
  mechanisms — demographic filters, multichoice answer filters, theme filters, flagged toggle — none of which had automated tests.
  
#  Changes proposed in this pull request

  New file e2e_tests/tests/response-analysis.e2e.ts with:
  
  - testFilter helper — reusable function that clicks a filter, verifies the count displayed on the filter button is unchanged after selection, checks the response list shows the expected number of results, verifies other filters in the same group drop to zero,  then resets and confirms the full list is restored. Supports OR (same-group) and AND (cross-group) operators.
  - getFilterButton helper — resolves filter buttons either by accessible name (demographic filters, theme filters) or by a scoped label selector (multichoice answer filters, where button names like "No" would otherwise match "No answer").
  - Demographic filter tests — checks each nation and age group filter individually, two filters in the same group (OR), and two filters across groups (AND).
  - Multichoice answer filter tests — checks each answer option filter; uses span[class~="sm:hidden"] for the count since the  multichoice buttons have a different DOM structure to demographic filter buttons.
  - Theme filter tests — checks each theme filter using the ThemesTable's td:nth-child(2) for the count column, scoped to the table element to avoid matching theme chip buttons on response cards.
  - Flagged toggle test — flags the first response, enables the flagged-only toggle, asserts exactly one response is shown, then cleans up.
  - Respondent navigation test — clicks the respondent button on the first response and asserts navigation to the respondent detail page.
  
# Guidance to review

The selector choices are non-obvious in places:

  - containerSelector: 'section:has-text("Multiple Choice Answers")' — scopes multichoice filter buttons away from demographic  filters in the aside.
  - containerSelector: 'section:has-text("Theme analysis") table' — scopes to the table specifically to exclude theme chip buttons  on response cards, which share the same name.
  - labelSelector: 'h3' on multichoice filters — matches buttons by their inner heading text rather than accessible name, which  avoids "No" matching "No answer".
  - getByRole('switch', ...) for the flagged toggle — the melt-ui Switch component renders role="switch" via melt-ui.

# Notes

The testFilter helper function got quite complex in order to handle all of the different ways in which I wanted to use it. Open to ideas on how to simplify. Also happy to move any of the local helpers to `helpers.ts` if it is thought they would be useful elsehwere.
  
  ▎ 🤖 PR description mostly generated with Claude Code (https://claude.ai/claude-code)