### PR TITLE
PRO-399: Improve load more response in question page

### DIFF
--- a/backend/consultations/api/views/response.py
+++ b/backend/consultations/api/views/response.py
@@ -18,6 +18,11 @@ from consultations.api.serializers import (
     ThemeSerializer,
 )
 
+# Upper bound on how many responses a single bulk mark-read request may carry.
+# This matches the maximum page size so a full page can always be marked at once,
+# while still capping the work done per request.
+MAX_BULK_MARK_READ = 1000
+
 
 class BespokeResultsSetPagination(PageNumberPagination):
     page_size = 100
@@ -228,3 +233,58 @@ class ResponseViewSet(ModelViewSet):
                 "was_already_read": was_already_read,
             }
         )
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="mark-read-bulk",
+        permission_classes=[IsAuthenticated, CanSeeConsultation],
+    )
+    def mark_read_bulk(self, request, consultation_pk=None, **kwargs):
+        """Mark multiple responses as read by the current user in a single request"""
+        requested_response_ids = request.data.get("response_ids", [])
+        if not requested_response_ids:
+            return Response({"message": "No response IDs provided"}, status=400)
+
+        if len(requested_response_ids) > self.MAX_BULK_MARK_READ:
+            return Response(
+                {
+                    "message": (
+                        f"Too many response IDs provided. Maximum is {self.MAX_BULK_MARK_READ}."
+                    )
+                },
+                status=400,
+            )
+
+        valid_response_ids = []
+        for requested_id in requested_response_ids:
+            try:
+                valid_response_ids.append(uuid.UUID(str(requested_id)))
+            except (ValueError, AttributeError):
+                # Skip malformed IDs rather than failing the whole batch.
+                continue
+
+        # Restrict to responses that actually belong to this consultation (and, when
+        # nested under a question, that question) so a user cannot mark responses
+        # outside their access by passing arbitrary IDs.
+        accessible_response_filter = {
+            "id__in": valid_response_ids,
+            "question__consultation_id": consultation_pk,
+        }
+        question_pk = self.kwargs.get("question_pk")
+        if question_pk:
+            accessible_response_filter["question_id"] = question_pk
+
+        accessible_response_ids = models.Response.objects.filter(
+            **accessible_response_filter
+        ).values_list("id", flat=True)
+
+        read_by_records = [
+            models.ResponseReadBy(response_id=response_id, user=request.user)
+            for response_id in accessible_response_ids
+        ]
+        created_records = models.ResponseReadBy.objects.bulk_create(
+            read_by_records, ignore_conflicts=True
+        )
+
+        return Response({"message": f"{len(created_records)} responses marked as read"})

--- a/backend/consultations/api/views/response.py
+++ b/backend/consultations/api/views/response.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.db.models import Exists, OuterRef
+from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
@@ -244,16 +245,19 @@ class ResponseViewSet(ModelViewSet):
         """Mark multiple responses as read by the current user in a single request"""
         requested_response_ids = request.data.get("response_ids", [])
         if not requested_response_ids:
-            return Response({"message": "No response IDs provided"}, status=400)
+            return Response(
+                {"message": "No response IDs provided"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-        if len(requested_response_ids) > self.MAX_BULK_MARK_READ:
+        if len(requested_response_ids) > MAX_BULK_MARK_READ:
             return Response(
                 {
                     "message": (
-                        f"Too many response IDs provided. Maximum is {self.MAX_BULK_MARK_READ}."
+                        f"Too many response IDs provided. Maximum is {MAX_BULK_MARK_READ}."
                     )
                 },
-                status=400,
+                status=status.HTTP_400_BAD_REQUEST,
             )
 
         valid_response_ids = []
@@ -283,8 +287,9 @@ class ResponseViewSet(ModelViewSet):
             models.ResponseReadBy(response_id=response_id, user=request.user)
             for response_id in accessible_response_ids
         ]
-        created_records = models.ResponseReadBy.objects.bulk_create(
-            read_by_records, ignore_conflicts=True
-        )
+        # ignore_conflicts skips responses this user had already read. We don't report a
+        # count: with ignore_conflicts=True, bulk_create returns every object passed in
+        # (conflicting rows just have pk=None), so its length would overstate inserts.
+        models.ResponseReadBy.objects.bulk_create(read_by_records, ignore_conflicts=True)
 
-        return Response({"message": f"{len(created_records)} responses marked as read"})
+        return Response({"message": "Responses marked as read"})

--- a/backend/tests/unit/api/views/test_response_views.py
+++ b/backend/tests/unit/api/views/test_response_views.py
@@ -5,8 +5,11 @@ import orjson
 import pytest
 from django.urls import reverse
 
-from consultations.models import ResponseAnnotation, ResponseAnnotationTheme
+from consultations.api.views.response import ResponseViewSet
+from consultations.models import ResponseAnnotation, ResponseAnnotationTheme, ResponseReadBy
 from factories import (
+    ConsultationFactory,
+    QuestionFactory,
     RespondentFactory,
     ResponseAnnotationFactory,
     ResponseAnnotationFactoryNoThemes,
@@ -592,9 +595,7 @@ class TestResponseViewSet:
         Response.objects.create(
             question=free_text_question, respondent=respondent, free_text="some text"
         )
-        Response.objects.create(
-            question=free_text_question, respondent=respondent, free_text=None
-        )
+        Response.objects.create(question=free_text_question, respondent=respondent, free_text=None)
 
         url = reverse(
             "response-list",
@@ -1053,3 +1054,165 @@ class TestResponseViewSet:
 
         assert response.status_code == 200
         assert response.json()["all_respondents"][0]["themes"] == []
+
+    def test_mark_read_bulk_marks_all_responses(
+        self, client, staff_user, staff_user_token, free_text_question
+    ):
+        """Bulk endpoint marks every supplied response as read in a single request."""
+        responses = [ResponseFactory(question=free_text_question) for _ in range(3)]
+
+        url = reverse(
+            "response-mark-read-bulk",
+            kwargs={"consultation_pk": free_text_question.consultation.id},
+        )
+
+        api_response = client.post(
+            url,
+            data={"response_ids": [str(response.id) for response in responses]},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert api_response.status_code == 200
+        for response in responses:
+            assert response.is_read_by(staff_user)
+
+    def test_mark_read_bulk_is_idempotent(
+        self, client, staff_user, staff_user_token, free_text_question
+    ):
+        """Re-sending already-read responses does not error or create duplicate records."""
+        response = ResponseFactory(question=free_text_question)
+        response.mark_as_read_by(staff_user)
+
+        url = reverse(
+            "response-mark-read-bulk",
+            kwargs={"consultation_pk": free_text_question.consultation.id},
+        )
+
+        api_response = client.post(
+            url,
+            data={"response_ids": [str(response.id)]},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert api_response.status_code == 200
+        assert ResponseReadBy.objects.filter(response=response, user=staff_user).count() == 1
+
+    def test_mark_read_bulk_ignores_responses_outside_consultation(
+        self, client, staff_user, staff_user_token, free_text_question
+    ):
+        """Responses belonging to another consultation are not marked, even if their ID is sent."""
+        in_scope = ResponseFactory(question=free_text_question)
+
+        other_consultation = ConsultationFactory(title="Other", code="other-consultation")
+        other_question = QuestionFactory(consultation=other_consultation)
+        out_of_scope = ResponseFactory(question=other_question)
+
+        url = reverse(
+            "response-mark-read-bulk",
+            kwargs={"consultation_pk": free_text_question.consultation.id},
+        )
+
+        api_response = client.post(
+            url,
+            data={"response_ids": [str(in_scope.id), str(out_of_scope.id)]},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert api_response.status_code == 200
+        assert in_scope.is_read_by(staff_user)
+        assert not out_of_scope.is_read_by(staff_user)
+
+    def test_mark_read_bulk_rejects_empty_payload(
+        self, client, staff_user_token, free_text_question
+    ):
+        """An empty or missing response_ids list is rejected with a 400."""
+        url = reverse(
+            "response-mark-read-bulk",
+            kwargs={"consultation_pk": free_text_question.consultation.id},
+        )
+
+        empty_response = client.post(
+            url,
+            data={"response_ids": []},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+        assert empty_response.status_code == 400
+
+    def test_mark_read_bulk_skips_invalid_uuids(
+        self, client, staff_user, staff_user_token, free_text_question
+    ):
+        """Non-UUID values are skipped without erroring; valid IDs are still marked."""
+        valid_response = ResponseFactory(question=free_text_question)
+
+        url = reverse(
+            "response-mark-read-bulk",
+            kwargs={"consultation_pk": free_text_question.consultation.id},
+        )
+
+        api_response = client.post(
+            url,
+            data={"response_ids": ["not-a-uuid", str(valid_response.id)]},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert api_response.status_code == 200
+        assert valid_response.is_read_by(staff_user)
+
+    def test_mark_read_bulk_rejects_payload_over_limit(
+        self, client, staff_user_token, free_text_question
+    ):
+        """A payload exceeding the per-request cap is rejected with a 400."""
+        too_many_ids = [str(uuid4()) for _ in range(ResponseViewSet.MAX_BULK_MARK_READ + 1)]
+
+        url = reverse(
+            "response-mark-read-bulk",
+            kwargs={"consultation_pk": free_text_question.consultation.id},
+        )
+
+        api_response = client.post(
+            url,
+            data={"response_ids": too_many_ids},
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert api_response.status_code == 400
+
+    def test_mark_read_bulk_nested_under_question_scopes_to_that_question(
+        self, client, staff_user, staff_user_token, consultation
+    ):
+        """When nested under a question, only that question's responses are marked."""
+        question_in_scope = QuestionFactory(consultation=consultation, number=1)
+        question_other = QuestionFactory(consultation=consultation, number=2)
+
+        response_in_scope = ResponseFactory(question=question_in_scope)
+        response_other_question = ResponseFactory(question=question_other)
+
+        url = reverse(
+            "question-response-mark-read-bulk",
+            kwargs={
+                "consultation_pk": consultation.id,
+                "question_pk": question_in_scope.id,
+            },
+        )
+
+        api_response = client.post(
+            url,
+            data={
+                "response_ids": [
+                    str(response_in_scope.id),
+                    str(response_other_question.id),
+                ]
+            },
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert api_response.status_code == 200
+        assert response_in_scope.is_read_by(staff_user)
+        assert not response_other_question.is_read_by(staff_user)

--- a/backend/tests/unit/api/views/test_response_views.py
+++ b/backend/tests/unit/api/views/test_response_views.py
@@ -5,7 +5,7 @@ import orjson
 import pytest
 from django.urls import reverse
 
-from consultations.api.views.response import ResponseViewSet
+from consultations.api.views.response import MAX_BULK_MARK_READ
 from consultations.models import ResponseAnnotation, ResponseAnnotationTheme, ResponseReadBy
 from factories import (
     ConsultationFactory,
@@ -1167,7 +1167,7 @@ class TestResponseViewSet:
         self, client, staff_user_token, free_text_question
     ):
         """A payload exceeding the per-request cap is rejected with a 400."""
-        too_many_ids = [str(uuid4()) for _ in range(ResponseViewSet.MAX_BULK_MARK_READ + 1)]
+        too_many_ids = [str(uuid4()) for _ in range(MAX_BULK_MARK_READ + 1)]
 
         url = reverse(
             "response-mark-read-bulk",

--- a/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
@@ -2,7 +2,7 @@
   import clsx from "clsx";
 
   import { onMount, untrack } from "svelte";
-  import { SvelteURLSearchParams } from "svelte/reactivity";
+  import { SvelteSet, SvelteURLSearchParams } from "svelte/reactivity";
   import { slide, fly, fade } from "svelte/transition";
 
   import MaterialIcon from "../../MaterialIcon.svelte";
@@ -24,6 +24,7 @@
     getApiQuestionUrl,
     getConsultationDetailUrl,
     updateResponseReadStatus,
+    updateResponsesReadStatusBulk,
   } from "../../../global/routes.ts";
 
   import { createFetchStore } from "../../../global/stores.ts";
@@ -90,6 +91,7 @@
   let nextCursor: string | null = $state(null);
   let hasMorePages: boolean = $state(true);
   let responses: ResponseBody[] = $state([]);
+  let markedAsReadIds: SvelteSet<string> = new SvelteSet();
   let responseTotalCount: number | null = $state(null);
   let lastAggregationQs: string | null = $state(null);
 
@@ -208,6 +210,7 @@
     hasMorePages = true;
     isResponsesLoading = true;
     responseTotalCount = null;
+    markedAsReadIds = new SvelteSet();
   }
 
   const resetFilters = () => {
@@ -245,15 +248,36 @@
     untrack(() => loadData());
   });
 
-  async function markResponsesAsRead() {
-    if (responses.length === 0) return;
-    await Promise.all(
-      responses.map((response) =>
-        fetch(updateResponseReadStatus(consultationId, response.id), {
-          method: "POST",
-        }),
+  function markResponsesAsRead() {
+    // Only send responses the server has not already recorded as read and that we
+    // have not already sent in a previous "load more" click this session. The Set
+    // also drops any duplicate entries that can appear in the accumulated list.
+    const unreadResponseIds = [
+      ...new Set(
+        responses
+          .filter(
+            (response) =>
+              !response.is_read && !markedAsReadIds.has(response.id),
+          )
+          .map((response) => response.id),
       ),
-    );
+    ];
+
+    if (unreadResponseIds.length === 0) return;
+
+    // Optimistically record these as sent so rapid repeat clicks do not resend them.
+    unreadResponseIds.forEach((responseId) => markedAsReadIds.add(responseId));
+
+    fetch(updateResponsesReadStatusBulk(consultationId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ response_ids: unreadResponseIds }),
+    }).catch(() => {
+      // The request never reached the server — roll back so a later click retries.
+      unreadResponseIds.forEach((responseId) =>
+        markedAsReadIds.delete(responseId),
+      );
+    });
   }
 
   let demographics = $derived($demographicsStore.data || []);
@@ -529,6 +553,7 @@
                             ),
                             { method: "POST" },
                           );
+                          response.is_read = true;
                         }}
                       />
                     </div>
@@ -565,9 +590,9 @@
                   >
                     <Button
                       fullWidth={true}
-                      handleClick={() => {
+                      handleClick={async () => {
+                        await loadData();
                         markResponsesAsRead();
-                        loadData();
                       }}
                       size="sm"
                     >

--- a/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
+++ b/frontend/src/components/screens/QuestionDetail/QuestionDetail.svelte
@@ -272,12 +272,17 @@
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ response_ids: unreadResponseIds }),
-    }).catch(() => {
-      // The request never reached the server — roll back so a later click retries.
-      unreadResponseIds.forEach((responseId) =>
-        markedAsReadIds.delete(responseId),
-      );
-    });
+    })
+      .then((response) => {
+        // fetch only rejects on network failure, so surface error statuses too.
+        if (!response.ok) throw new Error();
+      })
+      .catch(() => {
+        // The request failed — roll back so a later click retries.
+        unreadResponseIds.forEach((responseId) =>
+          markedAsReadIds.delete(responseId),
+        );
+      });
   }
 
   let demographics = $derived($demographicsStore.data || []);

--- a/frontend/src/components/screens/QuestionDetail/QuestionDetail.test.ts
+++ b/frontend/src/components/screens/QuestionDetail/QuestionDetail.test.ts
@@ -215,6 +215,76 @@ describe("QuestionDetail", () => {
     }
   });
 
+  it("marks loaded responses as read in a single bulk request when loading more", async () => {
+    setupMocks();
+
+    render(QuestionDetail, {
+      consultationId: CONSULTATION_ID,
+      questionId: QUESTION_ID,
+    });
+
+    const loadMoreButton = await screen.findByRole("button", {
+      name: /load more/i,
+    });
+
+    const user = userEvent.setup();
+    await user.click(loadMoreButton);
+
+    await waitFor(() => {
+      const bulkCalls = fetchMock.callHistory
+        .calls()
+        .filter((call) => call.url.includes("mark-read-bulk"));
+      expect(bulkCalls).toHaveLength(1);
+    });
+
+    const [bulkCall] = fetchMock.callHistory
+      .calls()
+      .filter((call) => call.url.includes("mark-read-bulk"));
+    const sentResponseIds = JSON.parse(
+      bulkCall.options.body as string,
+    ).response_ids;
+
+    // Every sent ID is unique (no response is marked twice in one request)...
+    expect(new Set(sentResponseIds).size).toBe(sentResponseIds.length);
+    // ...and the first loaded response is among them.
+    expect(sentResponseIds).toContain(responses[0].id);
+  });
+
+  it("does not resend responses already marked as read on a later load more", async () => {
+    setupMocks();
+
+    render(QuestionDetail, {
+      consultationId: CONSULTATION_ID,
+      questionId: QUESTION_ID,
+    });
+
+    const loadMoreButton = await screen.findByRole("button", {
+      name: /load more/i,
+    });
+
+    const user = userEvent.setup();
+
+    // First click marks the currently loaded responses.
+    await user.click(loadMoreButton);
+    await waitFor(() => {
+      const bulkCalls = fetchMock.callHistory
+        .calls()
+        .filter((call) => call.url.includes("mark-read-bulk"));
+      expect(bulkCalls).toHaveLength(1);
+    });
+
+    // Second click loads the same (already-marked) responses, so nothing new is sent.
+    await user.click(loadMoreButton);
+    await waitFor(() => {
+      expect(screen.getByText("Free Text Responses")).toBeInTheDocument();
+    });
+
+    const bulkCalls = fetchMock.callHistory
+      .calls()
+      .filter((call) => call.url.includes("mark-read-bulk"));
+    expect(bulkCalls).toHaveLength(1);
+  });
+
   it("displays toggles specific to filtering free text responses", async () => {
     setupMocks();
 

--- a/frontend/src/components/screens/QuestionDetail/mocks.ts
+++ b/frontend/src/components/screens/QuestionDetail/mocks.ts
@@ -7,6 +7,7 @@ import {
   getApiQuestionUrl,
   getApiResponseUrl,
   updateResponseReadStatus,
+  updateResponsesReadStatusBulk,
 } from "../../../global/routes";
 import type { ResponseBody } from "../../../global/types";
 
@@ -330,6 +331,11 @@ export const responsesUpdateMock = {
   method: "POST",
 };
 
+export const responsesBulkUpdateMock = {
+  regexp: "*host" + updateResponsesReadStatusBulk(":consultationId"),
+  method: "POST",
+};
+
 export const responsesEditMock = {
   regexp: "*host" + getApiResponseUrl(":consultationId", ":answerId"),
   method: "PATCH",
@@ -383,6 +389,7 @@ export const mocks = {
   responsesEditMock,
   responsesMock,
   responsesUpdateMock,
+  responsesBulkUpdateMock,
   consultationMock,
   demoMock,
   flagMock,

--- a/frontend/src/global/routes.ts
+++ b/frontend/src/global/routes.ts
@@ -428,6 +428,16 @@ export const updateResponseReadStatus = (
   );
 };
 
+export const updateResponsesReadStatusBulk = (consultationId: string) => {
+  return urlJoin(
+    Routes.ApiConsultations,
+    consultationId,
+    Suffixes.Responses,
+    "mark-read-bulk",
+    "/",
+  );
+};
+
 export const getApiQuestionResponse = (
   consultationId: string,
   questionId: string,


### PR DESCRIPTION
## Context

When a user clicks "Load more" on the question detail page, the frontend fires one POST `/api/consultations/{id}/responses/{responseId}/mark-read/` request per response currently visible — up to 100 requests simultaneously (the page size).

For consultations with hundreds or thousands of responses this creates a request storm that:

Exhausts DB connection pool on the backend, causing intermittent 500 errors on the mark-read calls

Blocks the UI because the original `markResponsesAsRead()` used `await Promise.all(...)`, meaning the next page load waited for all N mark-read calls to settle

Produces confusing logs in AWS,  access logs show 200s for these requests and frontend  shows 500s for some of them in the same burst, because the response delayed a bit for the frontend.

Observed symptoms from frontend 
```
POST /api/consultations/{id}/responses/{responseId}/mark-read/  500 (Internal Server Error)
POST /api/consultations/{id}/responses/{responseId}/mark-read/  500 (Internal Server Error)
... (repeated for each visible response)
```
AWS logs confirm the backend succeeded for these requests in the same burst, proving the issue is load-related rather than a logic bug.

Root cause

`markResponsesAsRead()` in QuestionDetail.svelte:
```
// Before — fires N parallel requests
await Promise.all(
  responses.map((response) =>
    fetch(updateResponseReadStatus(consultationId, response.id), { method: "POST" })
  )
)
```
Each request hits ResponseViewSet.mark_read() which runs get_object() (permission check + DB query) and `get_or_create()` individually which means we take N DB round-trips for a single user action.

At 100 responses/page this is 100 simultaneous HTTP requests each doing 2 DB queries = 200 concurrent DB operations per "Load more" click.

## Changes proposed in this pull request
This PR introduces a 

- Backend bulk endpoint

```
POST /api/consultations/{id}/responses/mark-read-bulk/
```
 that:

Accepts `{ "response_ids": ["uuid", ...] }` in the request body

Validates all IDs are UUIDs and belong to the consultation (scoped query for the IDs not marked is_read)

- Frontend single fire-and-forget request

Changed `markResponsesAsRead()` to:

Call the bulk endpoint with all visible response IDs in one request that are not marked is

Drop `async/await` since the UI has no reason to block on marking responses read because it will only make users wait unnecessarily 

The individual per-response onInteract calls (when a user opens a response card) are unchanged  they are already single, fire-and-forget requests.

[Ticket](https://linear.app/iai-consult/issue/PRO-399/mark-read-request-storm-causes-500-errors-on-question-page-with-large)
