### PR TITLE
Add respondent number to respondent button for respondent-detail.e2e.ts

### DIFF
--- a/e2e_tests/tests/respondent-detail.e2e.ts
+++ b/e2e_tests/tests/respondent-detail.e2e.ts
@@ -37,7 +37,7 @@ test.describe("Respondent Detail Page", () => {
 
     await expect(page).toHaveURL(/\/consultations\/.*\/questions\/.*/);
 
-    const allRespondentButtons = page.getByTestId('respondent-button');
+    const allRespondentButtons = page.getByTestId('respondent-button-1');
 
     await expect(allRespondentButtons.first()).toBeVisible({ timeout: 10000 });
 

--- a/frontend/src/components/dashboard/ResponseCard/ResponseCard.svelte
+++ b/frontend/src/components/dashboard/ResponseCard/ResponseCard.svelte
@@ -178,7 +178,7 @@
             <div class="m-auto">
               <Button
                 size="xs"
-                testId="respondent-button"
+                testId="respondent-button-{respondentDisplayId}"
                 handleClick={() => {
                   location.href =
                     getRespondentDetailUrl(consultationId, respondentId) +


### PR DESCRIPTION
## Context

Respondent-detail tests are failing because the responses list isn't ordered by respondent ID, so we select a random respondent based on the response text order.

## Changes proposed in this pull request

- Select a respondent based on being ID # 1, rather than just the first one that appears
