### PR TITLE
feat: Add user filter to evaluation dashboard

### DIFF
--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -894,6 +894,13 @@ class ConsultationViewSet(ModelViewSet):
         consultation = self.get_object()
         free_text_questions = Question.objects.filter(consultation=consultation, has_free_text=True)
 
+        user_ids_param = request.query_params.get("user_ids")
+        if user_ids_param:
+            user_ids = [uid.strip() for uid in user_ids_param.split(",") if uid.strip()]
+            read_by_filter = Q(response__responsereadby__user_id__in=user_ids)
+        else:
+            read_by_filter = Q(response__responsereadby__user__is_staff=False)
+
         generic_themes = set(
             SelectedTheme.objects.filter(
                 question__consultation=consultation,
@@ -905,8 +912,8 @@ class ConsultationViewSet(ModelViewSet):
         all_read_annotations = list(
             ResponseAnnotation.objects.filter(
                 response__question__in=free_text_questions,
-                response__responsereadby__user__is_staff=False,
             )
+            .filter(read_by_filter)
             .distinct()
             .prefetch_related("responseannotationtheme_set")
             .select_related("response")
@@ -989,6 +996,15 @@ class ConsultationViewSet(ModelViewSet):
         summary_f1 = compute_f1_stats(all_f1_scores)
         summary_f1_all_themes = compute_f1_stats(all_f1_scores_all_themes)
 
+        available_users = (
+            User.objects.filter(
+                responsereadby__response__question__consultation=consultation,
+                is_staff=False,
+            )
+            .distinct()
+            .values_list("id", "email")
+        )
+
         return Response(
             {
                 "id": str(consultation.id),
@@ -997,6 +1013,7 @@ class ConsultationViewSet(ModelViewSet):
                     "benchmark_f1": EVALUATION_BENCHMARK_F1,
                     "min_sample_size": EVALUATION_MIN_SAMPLE_SIZE,
                 },
+                "users": [{"id": str(uid), "email": email} for uid, email in available_users],
                 "summary": {
                     "status": get_evaluation_status(len(all_f1_scores), summary_f1),
                     "responses": total_response_count,

--- a/backend/tests/unit/api/views/test_consultation_views.py
+++ b/backend/tests/unit/api/views/test_consultation_views.py
@@ -1545,6 +1545,95 @@ class TestEvaluationEndpoint:
         assert f1_data["ci_upper"] is None
         assert f1_data["approximate"] is False
 
+    def test_filter_by_user_ids(self, client, staff_user_token):
+        """Filters evaluation stats to only responses read by specified users."""
+        consultation = ConsultationFactory()
+        question = QuestionFactory(
+            consultation=consultation, has_free_text=True, free_text_response_count=4
+        )
+
+        user_a = UserFactory(is_staff=False)
+        user_b = UserFactory(is_staff=False)
+        theme = SelectedThemeFactory(question=question)
+        other_theme = SelectedThemeFactory(question=question)
+
+        # user_a reads 2 responses — perfect agreement
+        for _ in range(2):
+            respondent = RespondentFactory(consultation=consultation)
+            resp_obj = ResponseFactory(question=question, respondent=respondent, free_text="text")
+            ResponseReadBy.objects.create(response=resp_obj, user=user_a)
+            annotation = ResponseAnnotation.objects.create(response=resp_obj)
+            annotation.add_original_ai_themes([theme])
+            annotation.set_human_reviewed_themes([theme], user_a)
+
+        # user_b reads 2 responses — no agreement
+        for _ in range(2):
+            respondent = RespondentFactory(consultation=consultation)
+            resp_obj = ResponseFactory(question=question, respondent=respondent, free_text="text")
+            ResponseReadBy.objects.create(response=resp_obj, user=user_b)
+            annotation = ResponseAnnotation.objects.create(response=resp_obj)
+            annotation.add_original_ai_themes([theme])
+            annotation.set_human_reviewed_themes([other_theme], user_b)
+
+        url = reverse("consultations-evaluation", kwargs={"pk": consultation.id})
+
+        # Filter to user_a only — should show F1=1.0
+        resp = client.get(
+            url,
+            query_params={"user_ids": str(user_a.id)},
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["responses_read"] == 2
+        assert data["questions"][0]["f1"]["mean"] == 1.0
+
+        # Filter to user_b only — should show F1=0.0
+        resp = client.get(
+            url,
+            query_params={"user_ids": str(user_b.id)},
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["responses_read"] == 2
+        assert data["questions"][0]["f1"]["mean"] == 0.0
+
+        # No filter — should show all 4 reads, blended F1
+        resp = client.get(
+            url,
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["responses_read"] == 4
+        assert data["questions"][0]["f1"]["mean"] == 0.5
+
+    def test_returns_available_users(self, client, staff_user_token):
+        """Response includes list of non-staff users who have read responses."""
+        consultation = ConsultationFactory()
+        question = QuestionFactory(consultation=consultation, has_free_text=True)
+
+        user_a = UserFactory(is_staff=False, email="alice@example.com")
+        user_b = UserFactory(is_staff=False, email="bob@example.com")
+        user_c = UserFactory(is_staff=True, email="staff@example.com")
+
+        respondent = RespondentFactory(consultation=consultation)
+        resp_obj = ResponseFactory(question=question, respondent=respondent, free_text="text")
+        ResponseReadBy.objects.create(response=resp_obj, user=user_a)
+        ResponseReadBy.objects.create(response=resp_obj, user=user_b)
+        ResponseReadBy.objects.create(response=resp_obj, user=user_c)
+
+        url = reverse("consultations-evaluation", kwargs={"pk": consultation.id})
+        resp = client.get(url, headers={"Authorization": f"Bearer {staff_user_token}"})
+
+        assert resp.status_code == 200
+        users = resp.json()["users"]
+        user_emails = {u["email"] for u in users}
+        assert "alice@example.com" in user_emails
+        assert "bob@example.com" in user_emails
+        assert "staff@example.com" not in user_emails
+
     def test_requires_admin(self, client):
         """Non-admin users added to the consultation cannot access evaluation endpoint."""
         from rest_framework_simplejwt.tokens import RefreshToken

--- a/frontend/src/components/inputs/SearchableSelect.svelte
+++ b/frontend/src/components/inputs/SearchableSelect.svelte
@@ -24,6 +24,7 @@
   export let options: SearchableSelectOption<unknown>[] = [];
   export let selectedValues: unknown[] = [];
   export let hideArrow: boolean = false;
+  export let placeholder: string = "Select themes...";
   export let notFoundMessage: string = "No results found";
 
   const toOption = (
@@ -96,7 +97,7 @@
         "border-neutral-300",
         "pl-8",
       ])}
-      placeholder="Select themes..."
+      {placeholder}
     />
     {#if !hideArrow}
       <div

--- a/frontend/src/components/screens/Evaluation/Evaluation.svelte
+++ b/frontend/src/components/screens/Evaluation/Evaluation.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+  import { getApiConsultationEvaluationUrl } from "../../../global/routes";
+  import type { SearchableSelectOption } from "../../../global/types";
+  import SearchableSelect from "../../inputs/SearchableSelect.svelte";
+  import type {
+    ConsultationEval,
+    EvalUser,
+    F1Stats,
+    QuestionEval,
+  } from "./types";
+
+  interface Props {
+    consultationId: string;
+    initialData: ConsultationEval;
+    questionDetailBaseUrl: string;
+  }
+
+  let { consultationId, initialData, questionDetailBaseUrl }: Props = $props();
+
+  const availableUsers: EvalUser[] = initialData.users;
+  let data: ConsultationEval = $state(initialData);
+  let selectedUserIds: string[] = $state([]);
+  let isLoading = $state(false);
+  let error: string | null = $state(null);
+
+  async function fetchEvaluation() {
+    isLoading = true;
+    error = null;
+    const baseUrl = getApiConsultationEvaluationUrl(consultationId);
+    const params =
+      selectedUserIds.length > 0
+        ? `?user_ids=${selectedUserIds.join(",")}`
+        : "";
+    const response = await fetch(`${baseUrl}${params}`);
+    if (response.ok) {
+      data = await response.json();
+    } else {
+      error = "Failed to load evaluation data. Please try again.";
+    }
+    isLoading = false;
+  }
+
+  const formatPercent = (numerator: number, denominator: number): string => {
+    if (denominator === 0) return "0%";
+    return `${Math.round((numerator / denominator) * 100)}%`;
+  };
+
+  const formatCount = (count: number, total: number): string => {
+    return `${count} (${formatPercent(count, total)})`;
+  };
+
+  const formatF1 = (f1: F1Stats | null): string => {
+    if (!f1) return "—";
+    const prefix = f1.approximate ? "~" : "";
+    const ci =
+      f1.ci_lower !== null && f1.ci_upper !== null
+        ? ` (${f1.ci_lower}–${f1.ci_upper})`
+        : "";
+    return `${prefix}${f1.mean}${ci}`;
+  };
+
+  let bannerTitle = $derived.by(() => {
+    const { status, f1 } = data.summary;
+    switch (status) {
+      case "insufficient_data":
+        return "More responses need to be read";
+      case "below_benchmark":
+        return `Consult's theme assignment is below human-level alignment (F1 = ${f1!.mean})`;
+      case "meets_benchmark":
+        return `Consult's theme assignment is at or above human-level alignment (F1 = ${f1!.mean})`;
+    }
+  });
+
+  let bannerDetail = $derived.by(() => {
+    const { status, responses_read } = data.summary;
+    const { config } = data;
+    switch (status) {
+      case "insufficient_data":
+        if (responses_read < config.min_sample_size) {
+          return `Only ${responses_read} responses have been read so far. At least ${config.min_sample_size} are needed for reliable scores.`;
+        }
+        return `While ${responses_read} responses have been read, not enough had non-generic themes to compare. At least ${config.min_sample_size} are needed for reliable scores.`;
+      case "below_benchmark":
+        return `Our meta-analysis found that when two humans independently assign themes to the same responses, they agree at an F1 of ${config.benchmark_f1}. This consultation is below that benchmark. Review the per-question breakdown below to identify which questions need more attention.`;
+      case "meets_benchmark":
+        return `Our meta-analysis found that when two humans independently assign themes to the same responses, they agree at an F1 of ${config.benchmark_f1}. This consultation meets or exceeds that benchmark.`;
+    }
+  });
+
+  let questionsNeedingMoreReads = $derived(
+    data.questions.filter((q) => q.status === "insufficient_data").length,
+  );
+  let questionsBelowBenchmark = $derived(
+    data.questions.filter((q) => q.status === "below_benchmark").length,
+  );
+  let questionsAboveBenchmark = $derived(
+    data.questions.filter((q) => q.status === "meets_benchmark").length,
+  );
+
+  function getQuestionWarning(q: QuestionEval): string | null {
+    switch (q.status) {
+      case "insufficient_data":
+        if (q.responses_read < data.config.min_sample_size) {
+          return `Only ${q.responses_read} responses read — at least ${data.config.min_sample_size} needed for reliable scores.`;
+        }
+        return `More responses need to be read — not enough had non-generic themes to compare (at least ${data.config.min_sample_size} needed).`;
+      case "below_benchmark":
+        return `F1 score is below human-level benchmark (${data.config.benchmark_f1}).`;
+      default:
+        return null;
+    }
+  }
+</script>
+
+<div class={isLoading ? "opacity-60 transition-opacity" : ""}>
+  {#if error}
+    <p
+      class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700"
+    >
+      {error}
+    </p>
+  {/if}
+  {#if availableUsers.length > 0}
+    <div class="mb-6 flex items-start justify-end">
+      <div class="w-64">
+        <SearchableSelect
+          label="Filter by user"
+          placeholder="Select users..."
+          options={availableUsers.map((user) => ({
+            value: user.id,
+            label: user.email,
+            disabled: false,
+          }))}
+          selectedValues={selectedUserIds}
+          handleChange={(option: SearchableSelectOption<string>) => {
+            if (selectedUserIds.includes(option.value)) {
+              selectedUserIds = selectedUserIds.filter(
+                (id) => id !== option.value,
+              );
+            } else {
+              selectedUserIds = [...selectedUserIds, option.value];
+            }
+            fetchEvaluation();
+          }}
+        />
+        {#if selectedUserIds.length > 0}
+          <div class="mt-2 flex flex-wrap gap-1">
+            {#each selectedUserIds as userId (userId)}
+              {@const user = availableUsers.find((u) => u.id === userId)}
+              {#if user}
+                <span
+                  class="inline-flex items-center gap-1 rounded-full border border-neutral-200 bg-neutral-50 px-2 py-0.5 text-xs text-neutral-700"
+                >
+                  {user.email}
+                  <button
+                    class="text-neutral-400 hover:text-neutral-600"
+                    onclick={() => {
+                      selectedUserIds = selectedUserIds.filter(
+                        (id) => id !== userId,
+                      );
+                      fetchEvaluation();
+                    }}
+                  >
+                    &times;
+                  </button>
+                </span>
+              {/if}
+            {/each}
+            <button
+              class="text-xs text-neutral-400 underline hover:text-neutral-600"
+              onclick={() => {
+                selectedUserIds = [];
+                fetchEvaluation();
+              }}
+            >
+              Clear all
+            </button>
+          </div>
+          <p class="mt-2 text-xs text-neutral-500">
+            Showing only responses read by {selectedUserIds.length === 1
+              ? "this user"
+              : "these users"}. F1 compares original AI assignments against
+            current themes, which may include edits by other users.
+          </p>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+  <div
+    class="my-6 rounded-lg border-l-4 p-5 {data.summary.status ===
+    'insufficient_data'
+      ? 'border-amber-500 bg-amber-50'
+      : data.summary.status === 'below_benchmark'
+        ? 'border-red-600 bg-red-50'
+        : 'border-green-600 bg-green-50'}"
+  >
+    <p
+      class="text-lg font-bold {data.summary.status === 'insufficient_data'
+        ? 'text-amber-900'
+        : data.summary.status === 'below_benchmark'
+          ? 'text-red-900'
+          : 'text-green-900'}"
+    >
+      {bannerTitle}
+    </p>
+    <ul
+      class="mt-3 list-disc space-y-1 pl-5 text-sm {data.summary.status ===
+      'insufficient_data'
+        ? 'text-amber-800'
+        : data.summary.status === 'below_benchmark'
+          ? 'text-red-800'
+          : 'text-green-800'}"
+    >
+      <li>
+        Theme assignment is the step where Consult classifies each response
+        against the finalised themes. Accurate assignments are essential for
+        understanding theme prevalence, comparing themes across groups, and
+        finding relevant responses to read when exploring a particular theme.
+      </li>
+      <li>
+        Performance is measured by how often human reviewers agreed with
+        Consult's theme assignments. When a reviewer reads a response, they can
+        edit the assigned themes if they disagree. The fewer edits, the higher
+        the alignment score.
+      </li>
+      <li>{bannerDetail}</li>
+    </ul>
+  </div>
+
+  <h2 class="mb-4 mt-8 text-xl font-semibold">Summary</h2>
+
+  <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
+    <div class="rounded-lg border p-4">
+      <div class="text-2xl font-bold">{data.summary.responses_read}</div>
+      <div class="text-sm text-neutral-500">
+        of {data.summary.responses} responses read ({formatPercent(
+          data.summary.responses_read,
+          data.summary.responses,
+        )})
+      </div>
+    </div>
+    <div class="rounded-lg border p-4">
+      <div class="text-2xl font-bold">{data.summary.responses_edited}</div>
+      <div class="text-sm text-neutral-500">
+        of {data.summary.responses_read} read were edited ({formatPercent(
+          data.summary.responses_edited,
+          data.summary.responses_read,
+        )})
+      </div>
+    </div>
+    <div class="rounded-lg border p-4">
+      <div class="text-2xl font-bold">{formatF1(data.summary.f1)}</div>
+      <div class="text-sm text-neutral-500">F1 score</div>
+    </div>
+    <div class="rounded-lg border p-4">
+      <div class="text-2xl font-bold">
+        {formatF1(data.summary.f1_all_themes)}
+      </div>
+      <div class="text-sm text-neutral-500">F1 score (all themes)</div>
+    </div>
+  </div>
+
+  <h2 class="mt-10 text-xl font-semibold">Per Question</h2>
+
+  <div class="mt-3 flex flex-wrap items-center gap-4 text-sm">
+    {#if questionsAboveBenchmark > 0}
+      <span class="rounded-full bg-green-100 px-3 py-1 text-green-800">
+        {questionsAboveBenchmark} questions performing well
+      </span>
+    {/if}
+    {#if questionsBelowBenchmark > 0}
+      <span class="rounded-full bg-red-100 px-3 py-1 text-red-800">
+        {questionsBelowBenchmark} questions need attention (F1 &lt; {data.config
+          .benchmark_f1})
+      </span>
+    {/if}
+    {#if questionsNeedingMoreReads > 0}
+      <span class="rounded-full bg-neutral-100 px-3 py-1 text-neutral-600">
+        {questionsNeedingMoreReads} questions need more responses read
+      </span>
+    {/if}
+    <a
+      href="#methodology"
+      class="ml-auto text-base text-primary hover:underline"
+    >
+      How are these scores calculated? &darr;
+    </a>
+  </div>
+
+  <div class="mt-4 overflow-x-auto">
+    <table class="w-full text-left">
+      <thead class="border-b font-medium">
+        <tr>
+          <th class="py-2 pl-2 pr-4">Q</th>
+          <th class="py-2 pr-4">Question</th>
+          <th class="py-2 pr-4">Responses</th>
+          <th class="py-2 pr-4">Read</th>
+          <th class="py-2 pr-4">Edited</th>
+          <th class="py-2 pr-4">F1</th>
+          <th class="py-2 pr-4">F1 (all themes)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.questions as question (question.id)}
+          {@const warning = getQuestionWarning(question)}
+          <tr
+            class="border-b {question.status === 'below_benchmark'
+              ? 'border-l-4 border-l-red-500'
+              : ''}"
+          >
+            <td class="py-2 pl-2 pr-4">{question.number}</td>
+            <td class="max-w-md py-2 pr-4">
+              <a
+                href="{questionDetailBaseUrl}/{question.id}"
+                class="text-primary hover:underline"
+              >
+                {question.text}
+              </a>
+              {#if warning}
+                <p class="mt-1 text-sm italic text-neutral-500">{warning}</p>
+              {/if}
+            </td>
+            <td class="py-2 pr-4">{question.responses}</td>
+            <td class="py-2 pr-4"
+              >{formatCount(question.responses_read, question.responses)}</td
+            >
+            <td class="py-2 pr-4"
+              >{formatCount(
+                question.responses_edited,
+                question.responses_read,
+              )}</td
+            >
+            <td class="py-2 pr-4">{formatF1(question.f1)}</td>
+            <td class="py-2 pr-4">{formatF1(question.f1_all_themes)}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/frontend/src/components/screens/Evaluation/types.ts
+++ b/frontend/src/components/screens/Evaluation/types.ts
@@ -1,0 +1,47 @@
+export type EvalStatus =
+  | "insufficient_data"
+  | "below_benchmark"
+  | "meets_benchmark";
+
+export type F1Stats = {
+  mean: number;
+  ci_lower: number | null;
+  ci_upper: number | null;
+  approximate: boolean;
+};
+
+export type QuestionEval = {
+  id: string;
+  number: number;
+  text: string;
+  status: EvalStatus;
+  responses: number;
+  responses_read: number;
+  responses_edited: number;
+  f1: F1Stats | null;
+  f1_all_themes: F1Stats | null;
+};
+
+export type EvalUser = {
+  id: string;
+  email: string;
+};
+
+export type ConsultationEval = {
+  id: string;
+  title: string;
+  config: {
+    benchmark_f1: number;
+    min_sample_size: number;
+  };
+  users: EvalUser[];
+  summary: {
+    status: EvalStatus;
+    responses: number;
+    responses_read: number;
+    responses_edited: number;
+    f1: F1Stats | null;
+    f1_all_themes: F1Stats | null;
+  };
+  questions: QuestionEval[];
+};

--- a/frontend/src/pages/support/consultations/[consultationId]/evaluation.astro
+++ b/frontend/src/pages/support/consultations/[consultationId]/evaluation.astro
@@ -6,9 +6,10 @@ import Layout from "../../../../layouts/Layout.astro";
 import Section from "../../../../components/Section/Section.svelte";
 import Link from "../../../../components/Link.svelte";
 import Title from "../../../../components/Title.svelte";
+import EvaluationDashboard from "../../../../components/screens/Evaluation/Evaluation.svelte";
+import type { ConsultationEval } from "../../../../components/screens/Evaluation/types";
 import {
   getApiConsultationEvaluationUrl,
-  getQuestionDetailUrl,
   getSupportConsultationDetails,
 } from "../../../../global/routes";
 
@@ -20,318 +21,30 @@ if (!consultationId) {
   );
 }
 
-type EvalStatus = "insufficient_data" | "below_benchmark" | "meets_benchmark";
-
-type F1Stats = {
-  mean: number;
-  ci_lower: number | null;
-  ci_upper: number | null;
-  approximate: boolean;
-};
-
-type QuestionEval = {
-  id: string;
-  number: number;
-  text: string;
-  status: EvalStatus;
-  responses: number;
-  responses_read: number;
-  responses_edited: number;
-  f1: F1Stats | null;
-  f1_all_themes: F1Stats | null;
-};
-
-type ConsultationEval = {
-  id: string;
-  title: string;
-  config: {
-    benchmark_f1: number;
-    min_sample_size: number;
-  };
-  summary: {
-    status: EvalStatus;
-    responses: number;
-    responses_read: number;
-    responses_edited: number;
-    f1: F1Stats | null;
-    f1_all_themes: F1Stats | null;
-  };
-  questions: QuestionEval[];
-};
-
 const data = await fetchBackendApi<ConsultationEval>(
   Astro,
   getApiConsultationEvaluationUrl(consultationId),
 );
 
-const { config } = data;
-
-const getBannerTitle = (): string => {
-  const { status, f1 } = data.summary;
-
-  switch (status) {
-    case "insufficient_data":
-      return "More responses need to be read";
-    case "below_benchmark":
-      return `Consult's theme assignment is below human-level alignment (F1 = ${f1!.mean})`;
-    case "meets_benchmark":
-      return `Consult's theme assignment is at or above human-level alignment (F1 = ${f1!.mean})`;
-  }
-};
-
-const getBannerDetail = (): string => {
-  const { status, responses_read } = data.summary;
-
-  switch (status) {
-    case "insufficient_data":
-      if (responses_read < config.min_sample_size) {
-        return `Only ${responses_read} responses have been read so far. At least ${config.min_sample_size} are needed for reliable scores.`;
-      }
-      return `While ${responses_read} responses have been read, not enough had non-generic themes to compare. At least ${config.min_sample_size} are needed for reliable scores.`;
-    case "below_benchmark":
-      return `Our meta-analysis found that when two humans independently assign themes to the same responses, they agree at an F1 of ${config.benchmark_f1}. This consultation is below that benchmark. Review the per-question breakdown below to identify which questions need more attention.`;
-    case "meets_benchmark":
-      return `Our meta-analysis found that when two humans independently assign themes to the same responses, they agree at an F1 of ${config.benchmark_f1}. This consultation meets or exceeds that benchmark.`;
-  }
-};
-
-const getQuestionWarning = (q: QuestionEval): string | null => {
-  switch (q.status) {
-    case "insufficient_data":
-      if (q.responses_read < config.min_sample_size) {
-        return `Only ${q.responses_read} responses read — at least ${config.min_sample_size} needed for reliable scores.`;
-      }
-      return `More responses need to be read — not enough had non-generic themes to compare (at least ${config.min_sample_size} needed).`;
-    case "below_benchmark":
-      return `F1 score is below human-level benchmark (${config.benchmark_f1}).`;
-    default:
-      return null;
-  }
-};
-
-const formatPercent = (numerator: number, denominator: number): string => {
-  if (denominator === 0) return "0%";
-  return `${Math.round((numerator / denominator) * 100)}%`;
-};
-
-const formatCount = (count: number, total: number): string => {
-  return `${count} (${formatPercent(count, total)})`;
-};
-
-const formatF1 = (f1: F1Stats | null): string => {
-  if (!f1) return "—";
-  const prefix = f1.approximate ? "~" : "";
-  const ci =
-    f1.ci_lower !== null && f1.ci_upper !== null
-      ? ` (${f1.ci_lower}–${f1.ci_upper})`
-      : "";
-  return `${prefix}${f1.mean}${ci}`;
-};
-
-const bannerTitle = getBannerTitle();
-const bannerDetail = getBannerDetail();
-
-const questionsNeedingMoreReads = data.questions.filter(
-  (q) => q.status === "insufficient_data",
-).length;
-const questionsBelowBenchmark = data.questions.filter(
-  (q) => q.status === "below_benchmark",
-).length;
-const questionsAboveBenchmark = data.questions.filter(
-  (q) => q.status === "meets_benchmark",
-).length;
+const questionDetailBaseUrl = `/consultations/${consultationId}/questions`;
 ---
 
 <Layout>
   <Section>
     <div class="mb-4">
       <Link href={getSupportConsultationDetails(consultationId)}>
-        ← Back to consultation
+        &larr; Back to consultation
       </Link>
     </div>
 
     <Title level={1} text={`Evaluation: ${data.title}`} />
 
-    <div
-      class:list={[
-        "my-6 rounded-lg border-l-4 p-5",
-        {
-          "border-amber-500 bg-amber-50":
-            data.summary.status === "insufficient_data",
-          "border-red-600 bg-red-50": data.summary.status === "below_benchmark",
-          "border-green-600 bg-green-50":
-            data.summary.status === "meets_benchmark",
-        },
-      ]}
-    >
-      <p
-        class:list={[
-          "text-lg font-bold",
-          {
-            "text-amber-900": data.summary.status === "insufficient_data",
-            "text-red-900": data.summary.status === "below_benchmark",
-            "text-green-900": data.summary.status === "meets_benchmark",
-          },
-        ]}
-      >
-        {bannerTitle}
-      </p>
-      <ul
-        class:list={[
-          "mt-3 list-disc space-y-1 pl-5 text-sm",
-          {
-            "text-amber-800": data.summary.status === "insufficient_data",
-            "text-red-800": data.summary.status === "below_benchmark",
-            "text-green-800": data.summary.status === "meets_benchmark",
-          },
-        ]}
-      >
-        <li>
-          Theme assignment is the step where Consult classifies each response
-          against the finalised themes. Accurate assignments are essential for
-          understanding theme prevalence, comparing themes across groups, and
-          finding relevant responses to read when exploring a particular theme.
-        </li>
-        <li>
-          Performance is measured by how often human reviewers agreed with
-          Consult's theme assignments. When a reviewer reads a response, they
-          can edit the assigned themes if they disagree. The fewer edits, the
-          higher the alignment score.
-        </li>
-        <li>{bannerDetail}</li>
-      </ul>
-    </div>
-
-    <h2 class="mb-4 mt-8 text-xl font-semibold">Summary</h2>
-
-    <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
-      <div class="rounded-lg border p-4">
-        <div class="text-2xl font-bold">{data.summary.responses_read}</div>
-        <div class="text-sm text-neutral-500">
-          of {data.summary.responses} responses read ({
-            formatPercent(data.summary.responses_read, data.summary.responses)
-          })
-        </div>
-      </div>
-      <div class="rounded-lg border p-4">
-        <div class="text-2xl font-bold">{data.summary.responses_edited}</div>
-        <div class="text-sm text-neutral-500">
-          of {data.summary.responses_read} read were edited ({
-            formatPercent(
-              data.summary.responses_edited,
-              data.summary.responses_read,
-            )
-          })
-        </div>
-      </div>
-      <div class="rounded-lg border p-4">
-        <div class="text-2xl font-bold">
-          {formatF1(data.summary.f1)}
-        </div>
-        <div class="text-sm text-neutral-500">F1 score</div>
-      </div>
-      <div class="rounded-lg border p-4">
-        <div class="text-2xl font-bold">
-          {formatF1(data.summary.f1_all_themes)}
-        </div>
-        <div class="text-sm text-neutral-500">F1 score (all themes)</div>
-      </div>
-    </div>
-
-    <h2 class="mt-10 text-xl font-semibold">Per Question</h2>
-
-    <div class="mt-3 flex flex-wrap items-center gap-4 text-sm">
-      {
-        questionsAboveBenchmark > 0 && (
-          <span class="rounded-full bg-green-100 px-3 py-1 text-green-800">
-            {questionsAboveBenchmark} questions performing well
-          </span>
-        )
-      }
-      {
-        questionsBelowBenchmark > 0 && (
-          <span class="rounded-full bg-red-100 px-3 py-1 text-red-800">
-            {questionsBelowBenchmark} questions need attention (F1 &lt;
-            {config.benchmark_f1})
-          </span>
-        )
-      }
-      {
-        questionsNeedingMoreReads > 0 && (
-          <span class="rounded-full bg-neutral-100 px-3 py-1 text-neutral-600">
-            {questionsNeedingMoreReads} questions need more responses read
-          </span>
-        )
-      }
-      <a
-        href="#methodology"
-        class="ml-auto text-base text-primary hover:underline"
-      >
-        How are these scores calculated? ↓
-      </a>
-    </div>
-
-    <div class="mt-4 overflow-x-auto">
-      <table class="w-full text-left">
-        <thead class="border-b font-medium">
-          <tr>
-            <th class="py-2 pl-2 pr-4">Q</th>
-            <th class="py-2 pr-4">Question</th>
-            <th class="py-2 pr-4">Responses</th>
-            <th class="py-2 pr-4">Read</th>
-            <th class="py-2 pr-4">Edited</th>
-            <th class="py-2 pr-4">F1</th>
-            <th class="py-2 pr-4">F1 (all themes)</th>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            data.questions.map((question) => {
-              const warning = getQuestionWarning(question);
-
-              return (
-                <tr
-                  class:list={[
-                    "border-b",
-                    {
-                      "border-l-4 border-l-red-500":
-                        question.status === "below_benchmark",
-                    },
-                  ]}
-                >
-                  <td class="py-2 pl-2 pr-4">{question.number}</td>
-                  <td class="max-w-md py-2 pr-4">
-                    <a
-                      href={getQuestionDetailUrl(consultationId!, question.id)}
-                      class="text-primary hover:underline"
-                    >
-                      {question.text}
-                    </a>
-                    {warning && (
-                      <p class="mt-1 text-sm italic text-neutral-500">
-                        {warning}
-                      </p>
-                    )}
-                  </td>
-                  <td class="py-2 pr-4">{question.responses}</td>
-                  <td class="py-2 pr-4">
-                    {formatCount(question.responses_read, question.responses)}
-                  </td>
-                  <td class="py-2 pr-4">
-                    {formatCount(
-                      question.responses_edited,
-                      question.responses_read,
-                    )}
-                  </td>
-                  <td class="py-2 pr-4">{formatF1(question.f1)}</td>
-                  <td class="py-2 pr-4">{formatF1(question.f1_all_themes)}</td>
-                </tr>
-              );
-            })
-          }
-        </tbody>
-      </table>
-    </div>
+    <EvaluationDashboard
+      client:load
+      {consultationId}
+      initialData={data}
+      {questionDetailBaseUrl}
+    />
 
     <h2 id="methodology" class="mb-4 mt-10 scroll-mt-8 text-xl font-semibold">
       Methodology


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We need to make some quick changes to the dashboard to include a user filter so we can scope the responses read, edited and F1 scores to only users specified.

Because this is needed pretty urgently, what I've implemented isn't the highest quality code (e.g., ideally we would have a separate endpoint to get available users) and isn't the prettiest (just reused an existing component for selecting users). We can always revisit this when we work on making the real-time evaluation dashboard user-facing.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

**Before**
<img width="1501" height="476" alt="image" src="https://github.com/user-attachments/assets/7ddfc1c6-a1da-40c9-9e79-05880ec5c064" />

**After**
<img width="1516" height="480" alt="image" src="https://github.com/user-attachments/assets/7dde769d-cfc4-46a5-b604-9914747a2380" />

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
