### PR TITLE
feat: Order users list by most recently created first

### DIFF
--- a/backend/consultations/api/views/user.py
+++ b/backend/consultations/api/views/user.py
@@ -43,7 +43,7 @@ class UserViewSet(ModelViewSet):
         return super().create(request, *args, **kwargs)
 
     def get_queryset(self):
-        queryset = models.User.objects.all()
+        queryset = models.User.objects.all().order_by("-created_at")
         filterset = self.filterset_class(self.request.GET, queryset=queryset, request=self.request)
         return filterset.qs.distinct()
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We have too many users to list on prod. We will come up with a better solution for this in the long-term but in the short-term, we can just list the users by most recently created first because it's the most recently created users that you want to see to verify they have been crated.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

* Order users on /support/users by most recently created at first

