### PR TITLE
PRO-359: Add e2e test for finalising themes page

### DIFF
--- a/e2e_tests/tests/finalise-themes-detail.e2e.ts
+++ b/e2e_tests/tests/finalise-themes-detail.e2e.ts
@@ -3,6 +3,7 @@ import {
   CleanupManager,
   createFixtureData,
 } from "./helpers";
+import { gotoFinaliseThemesList } from "./navigation";
 import { signOffConsultation } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
 
@@ -45,27 +46,22 @@ test.describe("Finalise Themes - Detail Page", () => {
     });
     cleanupManager.add(testData);
 
-    // Navigate to consultations to find a consultation
-    await page.goto("/consultations");
-    await page.waitForLoadState("networkidle");
- 
-    await page.evaluate(() => localStorage.setItem("onboardingComplete-finalising-themes-archive", "true"));
-    await page.evaluate(() => localStorage.setItem("onboardingComplete-finalising-themes", "true"));
+    // Navigate from the consultations list into the finalise themes list page.
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
-    // Get the test consultation at sign off stage
-    // Navigate to finalise themes page to find questions
-    const finaliseThemesLink = page.getByTestId(`Finalise Themes for ${signOffConsultation.title}`);
-    await finaliseThemesLink.first().click();
-    await page.waitForLoadState("networkidle");
+    // Only free-text questions have a detail page; target that card by its text
+    // rather than relying on fixture order.
+    const freeTextQuestion = signOffConsultation.questions!.find(
+      (question) => question.has_free_text,
+    )!;
+    const questionCard = page
+      .getByTestId("question-card")
+      .filter({ hasText: freeTextQuestion.text });
 
-    // Get the first question and navigate to finalise themes detail
-    await expect(page.getByTestId("question-card")).toHaveCount(3);
-    const firstQuestionButton = page.getByTestId("question-card").first();
-
-    await expect(firstQuestionButton).toBeVisible();
+    await expect(questionCard).toBeVisible();
 
     // Navigate to question page to find themes to finalise
-    await firstQuestionButton.click();
+    await questionCard.click();
     await page.waitForLoadState("networkidle");
 
     // Remove existing selected themes in case some are left

--- a/e2e_tests/tests/finalise-themes-list.e2e.ts
+++ b/e2e_tests/tests/finalise-themes-list.e2e.ts
@@ -1,8 +1,9 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import {
+  CleanupManager,
   createFixtureData,
-  deleteFixtureData,
 } from "./helpers";
+import { gotoFinaliseThemesList } from "./navigation";
 import { signOffConsultation } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
 
@@ -10,41 +11,14 @@ import type { FixtureReference } from "../fixtures";
 // fullyParallel from running tests across workers and racing over it
 test.describe.configure({ mode: "serial" });
 
-const ONBOARDING_KEY = "onboardingComplete-finalising-themes-archive";
+const cleanupManager = new CleanupManager();
 
-// Number of questions with free text responses in signOffConsultation
-// (hybrid Q1 + open Q4; the multiple choice Q3 has no free text).
-const FREE_TEXT_QUESTION_COUNT = 2;
-
-/**
- * Navigates from the consultations list to the finalise themes list page.
- * By default the onboarding tour is dismissed so it does not overlay the page.
- */
-async function gotoListPage(
-  page: Page,
-  { dismissOnboarding = true }: { dismissOnboarding?: boolean } = {},
-) {
-  await page.goto("/consultations");
-  await page.waitForLoadState("networkidle");
-
-  if (dismissOnboarding) {
-    await page.evaluate(
-      (key) => localStorage.setItem(key, "true"),
-      ONBOARDING_KEY,
-    );
-  }
-
-  const finaliseThemesLink = page.getByTestId(
-    `Finalise Themes for ${signOffConsultation.title}`,
-  );
-  await finaliseThemesLink.first().click();
-  await page.waitForLoadState("networkidle");
-
-  // The page is rendered with client:only, so questions are fetched after
-  // hydration. Wait for the cards to render before asserting on the
-  // client-rendered content (count, stage panel, tags, etc.).
-  await expect(page.getByTestId("question-card").first()).toBeVisible();
-}
+// Questions with free text are signed off in the finalise themes flow;
+// multiple-choice-only questions are not. Derived from the fixture so it
+// stays correct if the fixture's questions change.
+const FREE_TEXT_QUESTION_COUNT = (signOffConsultation.questions ?? []).filter(
+  (question) => question.has_free_text,
+).length;
 
 test.describe("Finalise Themes - List Page", () => {
   let testData: FixtureReference = {};
@@ -53,13 +27,14 @@ test.describe("Finalise Themes - List Page", () => {
     testData = await createFixtureData(request, {
       consultations: [signOffConsultation],
     });
+    cleanupManager.add(testData);
   });
 
   test("Get started help box displays and can be dismissed", async ({
     page,
   }) => {
     // Keep the onboarding tour visible (every other test dismisses it).
-    await gotoListPage(page, { dismissOnboarding: false });
+    await gotoFinaliseThemesList(page, signOffConsultation.title, { dismissOnboarding: false });
 
     await expect(
       page.getByRole("heading", { name: "Welcome to Finalise Themes" }),
@@ -75,7 +50,7 @@ test.describe("Finalise Themes - List Page", () => {
   });
 
   test("Process panel shows the correct stage", async ({ page }) => {
-    await gotoListPage(page);
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
     await expect(
       page.getByRole("heading", { name: "Finalising Themes" }).first(),
@@ -94,34 +69,39 @@ test.describe("Finalise Themes - List Page", () => {
   });
 
   test("Number of questions is correct", async ({ page }) => {
-    await gotoListPage(page);
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
     const questionCount = signOffConsultation.questions!.length;
-    await expect(page.getByText(`${questionCount} questions`)).toBeVisible();
+    await expect(
+      page.getByText(`${questionCount} questions`, { exact: true }),
+    ).toBeVisible();
   });
 
   test("Question list displays all questions", async ({ page }) => {
-    await gotoListPage(page);
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
-    const questionCount = signOffConsultation.questions!.length;
-    await expect(page.getByTestId("question-card")).toHaveCount(questionCount);
+    const questions = signOffConsultation.questions!;
+    await expect(page.getByTestId("question-card")).toHaveCount(questions.length);
 
-    const freeTextQuestion = signOffConsultation.questions![0];
-    await expect(
-      page.getByText(freeTextQuestion.text).first(),
-    ).toBeVisible();
+    for (const question of questions) {
+      await expect(page.getByText(question.text).first()).toBeVisible();
+    }
   });
 
   test("Searching filters the question list", async ({ page }) => {
-    await gotoListPage(page);
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
-    // "consumer needs" is unique to the open question (Q4).
-    await page.locator("#search-input").fill("consumer needs");
+    // The open question (free text, no multiple choice) is the only one whose
+    // opening words are unique, so search for those rather than a hardcoded
+    // string or a positional index into the fixture.
+    const openQuestion = signOffConsultation.questions!.find(
+      (question) => question.has_free_text && !question.has_multiple_choice,
+    )!;
+    const searchTerm = openQuestion.text.split(" ").slice(0, 4).join(" ");
+    await page.locator("#search-input").fill(searchTerm);
 
     await expect(page.getByTestId("question-card")).toHaveCount(1);
-    await expect(
-      page.getByText(signOffConsultation.questions![2].text).first(),
-    ).toBeVisible();
+    await expect(page.getByText(openQuestion.text).first()).toBeVisible();
 
     // A search with no matches shows the empty state.
     await page.locator("#search-input").fill("no question matches this");
@@ -131,7 +111,7 @@ test.describe("Finalise Themes - List Page", () => {
   });
 
   test("Question status tags are shown", async ({ page }) => {
-    await gotoListPage(page);
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
     // The multiple choice question is tagged accordingly. Use exact match:
     // the card subtext also mentions "Multiple choice data".
@@ -147,50 +127,44 @@ test.describe("Finalise Themes - List Page", () => {
   });
 
   test("Favouriting a question persists across reload", async ({ page }) => {
-    await gotoListPage(page);
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
-    const favButton = page
-      .locator('[data-testid^="favourite-button-"]')
-      .first();
+    const favButton = page.getByTestId(/^favourite-button-/).first();
     await expect(favButton).toBeVisible();
 
     const testId = await favButton.getAttribute("data-testid");
     expect(testId).toBeTruthy();
 
-    // The button's aria-label reflects favourite state.
-    await expect(favButton).toHaveAttribute(
-      "aria-label",
-      "Add question to favourites",
-    );
+    await expect(favButton).toHaveAttribute("aria-pressed", "false");
 
     await favButton.click();
-    await expect(favButton).toHaveAttribute(
-      "aria-label",
-      "Remove question from favourites",
-    );
+    await expect(favButton).toHaveAttribute("aria-pressed", "true");
 
     await page.reload();
     await page.waitForLoadState("networkidle");
     // Cards re-render client-side after reload; wait before checking state.
     await expect(page.getByTestId("question-card").first()).toBeVisible();
 
-    const favButtonAfterReload = page.locator(`[data-testid="${testId}"]`);
-    await expect(favButtonAfterReload).toHaveAttribute(
-      "aria-label",
-      "Remove question from favourites",
-    );
+    const favButtonAfterReload = page.getByTestId(testId!);
+    await expect(favButtonAfterReload).toHaveAttribute("aria-pressed", "true");
   });
 
   test("Clicking a question navigates to its detail page", async ({ page }) => {
-    await gotoListPage(page);
+    await gotoFinaliseThemesList(page, signOffConsultation.title);
 
     const consultationId = page
       .url()
       .match(/\/consultations\/([^/]+)\/finalising-themes/)?.[1];
     expect(consultationId).toBeTruthy();
 
-    // The first card is the free-text question, so it is clickable.
-    await page.getByTestId("question-card").first().click();
+    // Only free-text questions have a detail page to navigate to.
+    const freeTextQuestion = signOffConsultation.questions!.find(
+      (question) => question.has_free_text,
+    )!;
+    await page
+      .getByTestId("question-card")
+      .filter({ hasText: freeTextQuestion.text })
+      .click();
     await page.waitForLoadState("networkidle");
 
     await expect(page).toHaveURL(
@@ -199,6 +173,6 @@ test.describe("Finalise Themes - List Page", () => {
   });
 
   test.afterAll(async () => {
-    await deleteFixtureData(testData);
+    await cleanupManager.cleanup();
   });
 });

--- a/e2e_tests/tests/finalise-themes-list.e2e.ts
+++ b/e2e_tests/tests/finalise-themes-list.e2e.ts
@@ -1,0 +1,199 @@
+import { test, expect, Page } from "@playwright/test";
+import {
+  createFixtureData,
+  deleteFixtureData,
+} from "./helpers";
+import { signOffConsultation } from "../fixtures";
+import type { FixtureReference } from "../fixtures";
+
+// Shared fixture data is created once in beforeAll; serial mode prevents
+// fullyParallel from running tests across workers and racing over it
+// (matches finalise-themes-detail.e2e.ts).
+test.describe.configure({ mode: "serial" });
+
+const ONBOARDING_KEY = "onboardingComplete-finalising-themes-archive";
+
+// Number of questions with free text responses in signOffConsultation
+// (hybrid Q1 + open Q4; the multiple choice Q3 has no free text).
+const FREE_TEXT_QUESTION_COUNT = 2;
+
+/**
+ * Navigates from the consultations list to the finalise themes list page.
+ * By default the onboarding tour is dismissed so it does not overlay the page.
+ */
+async function gotoListPage(
+  page: Page,
+  { dismissOnboarding = true }: { dismissOnboarding?: boolean } = {},
+) {
+  await page.goto("/consultations");
+  await page.waitForLoadState("networkidle");
+
+  if (dismissOnboarding) {
+    await page.evaluate(
+      (key) => localStorage.setItem(key, "true"),
+      ONBOARDING_KEY,
+    );
+  }
+
+  const finaliseThemesLink = page.getByTestId(
+    `Finalise Themes for ${signOffConsultation.title}`,
+  );
+  await finaliseThemesLink.first().click();
+  await page.waitForLoadState("networkidle");
+
+  // The page is rendered with client:only, so questions are fetched after
+  // hydration. Wait for the cards to render before asserting on the
+  // client-rendered content (count, stage panel, tags, etc.).
+  await expect(page.getByTestId("question-card").first()).toBeVisible();
+}
+
+test.describe("Finalise Themes - List Page", () => {
+  let testData: FixtureReference = {};
+
+  test.beforeAll(async ({ request }) => {
+    testData = await createFixtureData(request, {
+      consultations: [signOffConsultation],
+    });
+  });
+
+  test("Get started help box displays and can be dismissed", async ({
+    page,
+  }) => {
+    // Keep the onboarding tour visible (every other test dismisses it).
+    await gotoListPage(page, { dismissOnboarding: false });
+
+    await expect(
+      page.getByRole("heading", { name: "Welcome to Finalise Themes" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("3-step process to finalise themes"),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Get Started" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Welcome to Finalise Themes" }),
+    ).not.toBeVisible();
+  });
+
+  test("Process panel shows the correct stage", async ({ page }) => {
+    await gotoListPage(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Finalising Themes" }).first(),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText(
+        `0 of ${FREE_TEXT_QUESTION_COUNT} questions signed off`,
+      ),
+    ).toBeVisible();
+
+    // Later steps in the 4-step progress bar render even at this stage.
+    await expect(
+      page.getByText("Assigning Themes (AI)"),
+    ).toBeVisible();
+  });
+
+  test("Number of questions is correct", async ({ page }) => {
+    await gotoListPage(page);
+
+    const questionCount = signOffConsultation.questions!.length;
+    await expect(page.getByText(`${questionCount} questions`)).toBeVisible();
+  });
+
+  test("Question list displays all questions", async ({ page }) => {
+    await gotoListPage(page);
+
+    const questionCount = signOffConsultation.questions!.length;
+    await expect(page.getByTestId("question-card")).toHaveCount(questionCount);
+
+    const freeTextQuestion = signOffConsultation.questions![0];
+    await expect(
+      page.getByText(freeTextQuestion.text).first(),
+    ).toBeVisible();
+  });
+
+  test("Searching filters the question list", async ({ page }) => {
+    await gotoListPage(page);
+
+    // "consumer needs" is unique to the open question (Q4).
+    await page.locator("#search-input").fill("consumer needs");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByTestId("question-card")).toHaveCount(1);
+    await expect(
+      page.getByText(signOffConsultation.questions![2].text).first(),
+    ).toBeVisible();
+
+    // A search with no matches shows the empty state.
+    await page.locator("#search-input").fill("no question matches this");
+    await expect(
+      page.getByText("No questions found matching your search."),
+    ).toBeVisible();
+  });
+
+  test("Question status tags are shown", async ({ page }) => {
+    await gotoListPage(page);
+
+    // The multiple choice question is tagged accordingly. Use exact match:
+    // the card subtext also mentions "Multiple choice data".
+    await expect(
+      page.getByText("Multiple choice", { exact: true }),
+    ).toBeVisible();
+
+    // No question has been signed off yet. Exact match targets the card tag,
+    // not the stage panel prose which also contains "sign off".
+    await expect(
+      page.getByText("Signed off", { exact: true }),
+    ).not.toBeVisible();
+  });
+
+  test("Favouriting a question persists across reload", async ({ page }) => {
+    await gotoListPage(page);
+
+    const favButton = page
+      .locator('[data-testid^="favourite-button-"]')
+      .first();
+    await expect(favButton).toBeVisible();
+
+    const testId = await favButton.getAttribute("data-testid");
+    expect(testId).toBeTruthy();
+
+    // The filled star (fill-yellow-500) is the favourited indicator.
+    await expect(favButton.locator("svg.fill-yellow-500")).toHaveCount(0);
+
+    await favButton.click();
+    await expect(favButton.locator("svg.fill-yellow-500")).toBeVisible();
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    // Cards re-render client-side after reload; wait before checking the star.
+    await expect(page.getByTestId("question-card").first()).toBeVisible();
+
+    const favButtonAfterReload = page.locator(`[data-testid="${testId}"]`);
+    await expect(
+      favButtonAfterReload.locator("svg.fill-yellow-500"),
+    ).toBeVisible();
+  });
+
+  test("Clicking a question navigates to its detail page", async ({ page }) => {
+    await gotoListPage(page);
+
+    const consultationId = page
+      .url()
+      .match(/\/consultations\/([^/]+)\/finalising-themes/)?.[1];
+    expect(consultationId).toBeTruthy();
+
+    // The first card is the free-text question, so it is clickable.
+    await page.getByTestId("question-card").first().click();
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(
+      new RegExp(`/consultations/${consultationId}/finalising-themes/[^/]+$`),
+    );
+  });
+
+  test.afterAll(async () => {
+    await deleteFixtureData(testData);
+  });
+});

--- a/e2e_tests/tests/finalise-themes-list.e2e.ts
+++ b/e2e_tests/tests/finalise-themes-list.e2e.ts
@@ -8,7 +8,6 @@ import type { FixtureReference } from "../fixtures";
 
 // Shared fixture data is created once in beforeAll; serial mode prevents
 // fullyParallel from running tests across workers and racing over it
-// (matches finalise-themes-detail.e2e.ts).
 test.describe.configure({ mode: "serial" });
 
 const ONBOARDING_KEY = "onboardingComplete-finalising-themes-archive";
@@ -118,7 +117,6 @@ test.describe("Finalise Themes - List Page", () => {
 
     // "consumer needs" is unique to the open question (Q4).
     await page.locator("#search-input").fill("consumer needs");
-    await page.waitForLoadState("networkidle");
 
     await expect(page.getByTestId("question-card")).toHaveCount(1);
     await expect(
@@ -159,21 +157,28 @@ test.describe("Finalise Themes - List Page", () => {
     const testId = await favButton.getAttribute("data-testid");
     expect(testId).toBeTruthy();
 
-    // The filled star (fill-yellow-500) is the favourited indicator.
-    await expect(favButton.locator("svg.fill-yellow-500")).toHaveCount(0);
+    // The button's aria-label reflects favourite state.
+    await expect(favButton).toHaveAttribute(
+      "aria-label",
+      "Add question to favourites",
+    );
 
     await favButton.click();
-    await expect(favButton.locator("svg.fill-yellow-500")).toBeVisible();
+    await expect(favButton).toHaveAttribute(
+      "aria-label",
+      "Remove question from favourites",
+    );
 
     await page.reload();
     await page.waitForLoadState("networkidle");
-    // Cards re-render client-side after reload; wait before checking the star.
+    // Cards re-render client-side after reload; wait before checking state.
     await expect(page.getByTestId("question-card").first()).toBeVisible();
 
     const favButtonAfterReload = page.locator(`[data-testid="${testId}"]`);
-    await expect(
-      favButtonAfterReload.locator("svg.fill-yellow-500"),
-    ).toBeVisible();
+    await expect(favButtonAfterReload).toHaveAttribute(
+      "aria-label",
+      "Remove question from favourites",
+    );
   });
 
   test("Clicking a question navigates to its detail page", async ({ page }) => {

--- a/e2e_tests/tests/navigation.ts
+++ b/e2e_tests/tests/navigation.ts
@@ -1,0 +1,44 @@
+import { expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+// Onboarding tours overlay the page until dismissed. The list page uses the
+// "-archive" key; the detail page additionally uses the "-finalising-themes"
+// key. Dismissing both is harmless on either page.
+const FINALISE_THEMES_ONBOARDING_KEYS = [
+  "onboardingComplete-finalising-themes-archive",
+  "onboardingComplete-finalising-themes",
+];
+
+/**
+ * Navigates from the consultations list to the finalise themes list page for
+ * the given consultation. By default the onboarding tours are dismissed so
+ * they do not overlay the page.
+ */
+export async function gotoFinaliseThemesList(
+  page: Page,
+  consultationTitle: string,
+  { dismissOnboarding = true }: { dismissOnboarding?: boolean } = {},
+) {
+  await page.goto("/consultations");
+  await page.waitForLoadState("networkidle");
+
+  if (dismissOnboarding) {
+    await page.evaluate(
+      (keys) => keys.forEach((key) => localStorage.setItem(key, "true")),
+      FINALISE_THEMES_ONBOARDING_KEYS,
+    );
+  }
+
+  const finaliseThemesLink = page.getByTestId(
+    `Finalise Themes for ${consultationTitle}`,
+  );
+  // Guard against a duplicate testId regression before clicking.
+  await expect(finaliseThemesLink).toHaveCount(1);
+  await finaliseThemesLink.click();
+  await page.waitForLoadState("networkidle");
+
+  // The page is rendered with client:only, so questions are fetched after
+  // hydration. Wait for the cards to render before asserting on the
+  // client-rendered content (count, stage panel, tags, etc.).
+  await expect(page.getByTestId("question-card").first()).toBeVisible();
+}

--- a/frontend/src/components/dashboard/QuestionCard/QuestionCard.svelte
+++ b/frontend/src/components/dashboard/QuestionCard/QuestionCard.svelte
@@ -45,6 +45,8 @@
     subtext = "",
     tag,
   }: Props = $props();
+
+  let favourited = $derived($favStore.includes(question.id));
 </script>
 
 <div
@@ -201,12 +203,14 @@
                   <Button
                     testId="favourite-button-{question.id}"
                     variant="ghost"
+                    ariaLabel={favourited
+                      ? "Remove question from favourites"
+                      : "Add question to favourites"}
                     handleClick={(e: MouseEvent) => {
                       e.stopPropagation();
                       favStore.toggleFav(question.id || "");
                     }}
                   >
-                    {@const favourited = $favStore.includes(question.id)}
                     <MaterialIcon
                       size="1.3rem"
                       color={favourited ? "fill-yellow-500" : "fill-gray-500"}

--- a/frontend/src/components/dashboard/QuestionCard/QuestionCard.svelte
+++ b/frontend/src/components/dashboard/QuestionCard/QuestionCard.svelte
@@ -200,9 +200,13 @@
                   onkeypress={(e) => e.stopPropagation()}
                   onclick={(e) => e.stopPropagation()}
                 >
+                  <!-- highlighted -> aria-pressed for the favourite toggle;
+                       "none" keeps that wiring from changing the star's look. -->
                   <Button
                     testId="favourite-button-{question.id}"
                     variant="ghost"
+                    highlighted={favourited}
+                    highlightVariant="none"
                     ariaLabel={favourited
                       ? "Remove question from favourites"
                       : "Add question to favourites"}

--- a/frontend/src/components/screens/ConsultationDetail/__snapshots__/ConsultationDetail.test.ts.snap
+++ b/frontend/src/components/screens/ConsultationDetail/__snapshots__/ConsultationDetail.test.ts.snap
@@ -699,6 +699,7 @@ exports[`ConsultationDetail > should match snapshot after loading 1`] = `
                         >
                           <!---->
                           <button
+                            aria-label="Add question to favourites"
                             aria-pressed="false"
                             class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
                             data-testid="favourite-button-5e8176da-fdcd-4f55-ab7b-b2ca8a12a467"
@@ -841,6 +842,7 @@ exports[`ConsultationDetail > should match snapshot after loading 1`] = `
                         >
                           <!---->
                           <button
+                            aria-label="Add question to favourites"
                             aria-pressed="false"
                             class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
                             data-testid="favourite-button-ef855675-af2b-4cfe-871d-ad108360e57a"
@@ -983,6 +985,7 @@ exports[`ConsultationDetail > should match snapshot after loading 1`] = `
                         >
                           <!---->
                           <button
+                            aria-label="Add question to favourites"
                             aria-pressed="false"
                             class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
                             data-testid="favourite-button-92848794-2072-41c4-b3bf-78248a6995da"
@@ -1124,6 +1127,7 @@ exports[`ConsultationDetail > should match snapshot after loading 1`] = `
                         >
                           <!---->
                           <button
+                            aria-label="Add question to favourites"
                             aria-pressed="false"
                             class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
                             data-testid="favourite-button-b20f35ee-411b-4746-9029-1e9b02610dea"

--- a/frontend/src/components/screens/FinalisingThemesArchive/__snapshots__/FinalisingThemesArchive.test.ts.snap
+++ b/frontend/src/components/screens/FinalisingThemesArchive/__snapshots__/FinalisingThemesArchive.test.ts.snap
@@ -482,6 +482,7 @@ exports[`FinalisingThemesArchive > should match snapshot after loading 1`] = `
                         >
                           <!---->
                           <button
+                            aria-label="Add question to favourites"
                             aria-pressed="false"
                             class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
                             data-testid="favourite-button-2d3bea3e-abd1-4231-80d9-41a974724731"
@@ -631,6 +632,7 @@ exports[`FinalisingThemesArchive > should match snapshot after loading 1`] = `
                         >
                           <!---->
                           <button
+                            aria-label="Add question to favourites"
                             aria-pressed="false"
                             class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
                             data-testid="favourite-button-7b809f89-a7a0-4c31-b788-008eef73f396"
@@ -780,6 +782,7 @@ exports[`FinalisingThemesArchive > should match snapshot after loading 1`] = `
                         >
                           <!---->
                           <button
+                            aria-label="Add question to favourites"
                             aria-pressed="false"
                             class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
                             data-testid="favourite-button-021b9599-35c3-42d5-afba-45aa691dfe53"


### PR DESCRIPTION
## Context
This PR adds e2e tests for the finalising themes list page that tests for
- Get started help box
- Process stage panel
- Question count
- Question list and search
- Question status tags
- Favourite a question (persists across reload)
- Navigating to a question's detail page

[Linear Ticket](https://linear.app/iai-consult/issue/PRO-359/e2e-finalising-themes-list-page)
