### PR TITLE
refactor: Align e2e helpers methods - PRO-359

### DIFF
--- a/e2e_tests/tests/consultations.e2e.ts
+++ b/e2e_tests/tests/consultations.e2e.ts
@@ -1,10 +1,6 @@
 import { test, expect } from "@playwright/test";
-import {
-  CleanupManager,
-  createFixtureData,
-  deleteFixtureData,
-  getFirstConsultationLink,
-} from "./helpers";
+import { CleanupManager, createFixtureData } from "./helpers";
+import { getFirstConsultationLink } from "./navigation";
 import {
   openQuestion,
   setupConsultation,

--- a/e2e_tests/tests/consultations.e2e.ts
+++ b/e2e_tests/tests/consultations.e2e.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { CleanupManager, createFixtureData } from "./helpers";
-import { getFirstConsultationLink } from "./navigation";
+import { getConsultationId, getFirstConsultationLink } from "./navigation";
 import {
   openQuestion,
   setupConsultation,
@@ -88,7 +88,7 @@ test.describe("Consultations - Detail/Dashboard Page", () => {
     const result = await getFirstConsultationLink(page);
     expect(result).toBeTruthy();
 
-    consultationId = result!.href.match(/\/consultations\/([^/]+)/)?.[1]!;
+    consultationId = getConsultationId(result!.href)!;
     await result!.link.click();
     await page.waitForLoadState("networkidle");
   });
@@ -165,7 +165,7 @@ test.describe("Consultations - Evaluation Page", () => {
     // Get first consultation
     const result = await getFirstConsultationLink(page);
     expect(result).toBeTruthy();
-    consultationId = result!.href.match(/\/consultations\/([^/]+)/)?.[1]!;
+    consultationId = getConsultationId(result!.href)!;
 
     // Navigate directly to evaluation page
     await page.goto(`/evaluations/${consultationId}/questions`);

--- a/e2e_tests/tests/finalise-themes-list.e2e.ts
+++ b/e2e_tests/tests/finalise-themes-list.e2e.ts
@@ -3,7 +3,7 @@ import {
   CleanupManager,
   createFixtureData,
 } from "./helpers";
-import { gotoFinaliseThemesList } from "./navigation";
+import { getConsultationId, gotoFinaliseThemesList } from "./navigation";
 import { signOffConsultation } from "../fixtures";
 import type { FixtureReference } from "../fixtures";
 
@@ -152,9 +152,7 @@ test.describe("Finalise Themes - List Page", () => {
   test("Clicking a question navigates to its detail page", async ({ page }) => {
     await gotoFinaliseThemesList(page, signOffConsultation.title);
 
-    const consultationId = page
-      .url()
-      .match(/\/consultations\/([^/]+)\/finalising-themes/)?.[1];
+    const consultationId = getConsultationId(page.url());
     expect(consultationId).toBeTruthy();
 
     // Only free-text questions have a detail page to navigate to.

--- a/e2e_tests/tests/helpers.ts
+++ b/e2e_tests/tests/helpers.ts
@@ -1,5 +1,5 @@
 import { request as apirequest } from "@playwright/test";
-import type { Page, APIRequestContext } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
 
 import { testAccessToken } from "../constants";
 import type { Fixture, FixtureReference } from "../fixtures";
@@ -134,24 +134,6 @@ export async function deleteUser(email: string) {
   if (!fixture_response.ok())
     throw new Error(`User deletion failed: ${fixture_response.status()}
     ${await fixture_response.text()}`);
-}
-
-/**
- * Finds the first consultation link that points to an actual consultation detail page
- * (not the consultations list page itself)
- */
-export async function getFirstConsultationLink(page: Page) {
-  const allLinks = page.locator('a[href*="/consultations/"]');
-  const count = await allLinks.count();
-
-  for (let i = 0; i < count; i++) {
-    const link = allLinks.nth(i);
-    const href = await link.getAttribute("href");
-    if (href && href !== "/consultations" && !href.endsWith("/consultations")) {
-      return { link, href };
-    }
-  }
-  return null;
 }
 
 interface CleanupManagerOptions {

--- a/e2e_tests/tests/navigation.ts
+++ b/e2e_tests/tests/navigation.ts
@@ -19,6 +19,14 @@ export async function getFirstConsultationLink(page: Page) {
   return null;
 }
 
+/**
+ * Extracts the consultation ID from a consultation URL (either the current page
+ * URL or an href), e.g. "/consultations/abc-123/..." -> "abc-123".
+ */
+export function getConsultationId(url: string): string | undefined {
+  return url.match(/\/consultations\/([^/]+)/)?.[1];
+}
+
 // Onboarding tours overlay the page until dismissed. The list page uses the
 // "-archive" key; the detail page additionally uses the "-finalising-themes"
 // key. Dismissing both is harmless on either page.

--- a/e2e_tests/tests/navigation.ts
+++ b/e2e_tests/tests/navigation.ts
@@ -1,6 +1,24 @@
 import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
+/**
+ * Finds the first consultation link that points to an actual consultation detail
+ * page (not the consultations list page itself).
+ */
+export async function getFirstConsultationLink(page: Page) {
+  const allLinks = page.locator('a[href*="/consultations/"]');
+  const count = await allLinks.count();
+
+  for (let i = 0; i < count; i++) {
+    const link = allLinks.nth(i);
+    const href = await link.getAttribute("href");
+    if (href && href !== "/consultations" && !href.endsWith("/consultations")) {
+      return { link, href };
+    }
+  }
+  return null;
+}
+
 // Onboarding tours overlay the page until dismissed. The list page uses the
 // "-archive" key; the detail page additionally uses the "-finalising-themes"
 // key. Dismissing both is harmless on either page.

--- a/e2e_tests/tests/users.e2e.ts
+++ b/e2e_tests/tests/users.e2e.ts
@@ -5,8 +5,8 @@ import {
   deleteFixtureData,
   addUser,
   deleteUser,
-  getFirstConsultationLink
 } from './helpers';
+import { getFirstConsultationLink } from './navigation';
 import { defaultUser, setupConsultation } from '../fixtures';
 import type { FixtureReference } from "../fixtures";
 

--- a/e2e_tests/tests/users.e2e.ts
+++ b/e2e_tests/tests/users.e2e.ts
@@ -6,7 +6,7 @@ import {
   addUser,
   deleteUser,
 } from './helpers';
-import { getFirstConsultationLink } from './navigation';
+import { getConsultationId, getFirstConsultationLink } from './navigation';
 import { defaultUser, setupConsultation } from '../fixtures';
 import type { FixtureReference } from "../fixtures";
 
@@ -103,7 +103,7 @@ test.describe('Consultation Details - Adding Users', () => {
     // Navigate to the consultation details page
     const result = await getFirstConsultationLink(page);
     expect(result).toBeTruthy();
-    const consultationId = result!.href.match(/\/consultations\/([^/]+)/)?.[1];
+    const consultationId = getConsultationId(result!.href);
     await page.goto(`/support/consultations/${consultationId}/users/new`);
     await page.waitForLoadState('networkidle');
     // Fill in the form with valid details
@@ -121,7 +121,7 @@ test.describe('Consultation Details - Adding Users', () => {
   test('Ensure that deleted user is removed from consultation details', async ({ page }) => {
     const result = await getFirstConsultationLink(page);
     expect(result).toBeTruthy();
-    const consultationId = result!.href.match(/\/consultations\/([^/]+)/)?.[1];
+    const consultationId = getConsultationId(result!.href);
     // First create a user and add to the consultation
     uniqueEmail = `testuser${Date.now()}@example.com`;
     await addUser(uniqueEmail, consultationId!);


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

A follow-up to #1408 as `helpers.ts` is mixed unrelated concerns (API/auth plumbing vs. page navigation), and the consultation-id extraction regex had been copy-pasted across several spec files. This PR tidies that up so the e2e helpers are easier to find and reuse, with no change to test behaviour.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
  This PR introduces a change that refactors the helper methods:

  - Move `getFirstConsultationLink` into `navigation.ts` — it's a page/DOM navigation helper, so it now lives alongside `gotoFinaliseThemesList` rather than in the API-focused `helpers.ts`.
  - Extract a shared `getConsultationId(url)` helper — replaces the `/\/consultations\/([^/]+)/` regex that was duplicated across 6 call sites in 4 spec files
