### PR TITLE
Remove local e2e test parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ _run-e2e-tests:
 	@echo "Running tests..."
 	@cd e2e_tests && npm install
 	@if [ -z "$$CI" ]; then cd e2e_tests && npx playwright install --with-deps; fi
-	@cd e2e_tests && npm run e2e
+	@cd e2e_tests && npm run e2e-chrome
 
 .PHONY: _clean-e2e
 _clean-e2e: ## Internal: always-run cleanup for test-end-to-end (drop test DB, remove generated override)

--- a/e2e_tests/playwright.config.ts
+++ b/e2e_tests/playwright.config.ts
@@ -22,8 +22,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Opt out of parallel tests. */
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["list"], ["html", { open: "never" }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -42,7 +42,7 @@ export default defineConfig({
 
   /* Global expect timeout */
   expect: {
-    timeout: 15000,
+    timeout: 30000,
   },
 
   /* Configure projects for major browsers */

--- a/e2e_tests/tests/frontend-dashboard.e2e.ts
+++ b/e2e_tests/tests/frontend-dashboard.e2e.ts
@@ -27,7 +27,7 @@ test.describe("Dashboard Page", () => {
   test("all question cards should show as links", async ({ page }) => {
     for (let questionId of questionIds) {
       const questionCard = page.getByTestId(`question-link-${questionId}`);
-      await expect(questionCard.first()).toBeVisible({ timeout: 10000 });
+      await expect(questionCard.first()).toBeVisible();
 
       const questionCardCount = await questionCard.count();
       
@@ -40,16 +40,16 @@ test.describe("Dashboard Page", () => {
     const numberOfResponses = analysisConsultation.questions!.reduce((sum, question) => sum + (question.responses ? question.responses.length : 0), 0).toString();
 
     const questionOnPage = page.getByTestId("metric-count-questions");
-    await expect (questionOnPage).toBeVisible({ timeout: 10000 });
+    await expect (questionOnPage).toBeVisible();
     await expect (questionOnPage).toHaveText(numberOfQuestions);
 
     const responsesOnPage = page.getByTestId("metric-count-responses");
-    await expect (responsesOnPage).toBeVisible({ timeout: 10000 });
+    await expect (responsesOnPage).toBeVisible();
     await expect (responsesOnPage).toHaveText(numberOfResponses);
 
     // demographic info is more complicated to work out, and is fixed to a size of 2 in fixture setup
     const demographicsOnPage = page.getByTestId("metric-count-demographics");
-    await expect (demographicsOnPage).toBeVisible({ timeout: 10000 });
+    await expect (demographicsOnPage).toBeVisible();
     await expect (demographicsOnPage).toHaveText("2");
 
     const demographicSummaries = page.getByTestId("demographics-metrics-summary");
@@ -67,7 +67,7 @@ test.describe("Dashboard Page", () => {
   test("favourited questions should appear in favourites section", async ({ page }) => {
     for (let questionId of questionIds) {
       const questionFavouriteButton = page.getByTestId(`favourite-button-${questionId}`);
-      await expect(questionFavouriteButton.first()).toBeVisible({ timeout: 10000 });
+      await expect(questionFavouriteButton.first()).toBeVisible();
       const favouriteButtonCount = await questionFavouriteButton.count();
       expect(favouriteButtonCount).toBe(1);
 

--- a/e2e_tests/tests/question-summary.e2e.ts
+++ b/e2e_tests/tests/question-summary.e2e.ts
@@ -59,7 +59,7 @@ test.describe("Question Summary Page", () => {
     // generous timeout to absorb load spikes when the suite runs in parallel.
     await expect(
       page.getByText(`Q${hybridQuestionWithThemes.number}:`, { exact: false }),
-    ).toBeVisible({ timeout: 30000 });
+    ).toBeVisible();
   });
 
   test("displays the question text in the summary header", async ({ page }) => {
@@ -69,18 +69,14 @@ test.describe("Question Summary Page", () => {
   });
 
   test("filter sidebar shows expected demographics", async ({ page }) => {
-    await expect(page.getByRole("heading", { name: /filters/i })).toBeVisible({
-      
-    });
+    await expect(page.getByRole("heading", { name: /filters/i })).toBeVisible();
 
     const sidebar = page.getByTestId("filters-sidebar");
 
     // Demographic categories from the fixture: "age_group" and "nation".
     // The sidebar shows skeletons until the demographics request resolves, so
     // give this first assertion the longer timeout to wait for the real data.
-    await expect(sidebar.getByText("age_group", { exact: true })).toBeVisible({
-      
-    });
+    await expect(sidebar.getByText("age_group", { exact: true })).toBeVisible();
     await expect(sidebar.getByText("nation", { exact: true })).toBeVisible();
 
     // Demographic values from the fixture should be listed.
@@ -161,9 +157,7 @@ test.describe("Question Summary Page", () => {
     ).toBeVisible();
 
     // All free-text responses fit on one page, so every card renders.
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
     await expect(
       page.getByText(new RegExp(`showing all ${TOTAL_RESPONSES} responses`, "i")),
     ).toBeVisible();
@@ -177,9 +171,7 @@ test.describe("Question Summary Page", () => {
   test("filtering by a theme narrows the responses and can be cleared", async ({
     page,
   }) => {
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
 
     // Filter by the top theme; the fixture assigns it to a known subset.
     const topTheme = hybridQuestionWithThemes.themes![0];
@@ -197,17 +189,13 @@ test.describe("Question Summary Page", () => {
     // Clearing the filter restores the full list.
     await clearButton(page).click();
     await expect(filteredBadge(page)).toBeHidden();
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
   });
 
   test("filtering by a demographic narrows the responses and can be cleared", async ({
     page,
   }) => {
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
 
     // Filter by a nation present in the fixture's respondent demographics.
     const nation = "England";
@@ -215,23 +203,17 @@ test.describe("Question Summary Page", () => {
     await sidebar.getByText(nation, { exact: true }).first().click();
 
     await expect(filteredBadge(page)).toBeVisible();
-    await expect(responseCards(page)).toHaveCount(responsesWithNation(nation), {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(responsesWithNation(nation));
 
     await clearButton(page).click();
     await expect(filteredBadge(page)).toBeHidden();
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
   });
 
   test("filtering by a multiple choice answer narrows the responses and can be cleared", async ({
     page,
   }) => {
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
 
     // Each multiple choice option label is rendered as a heading, which is
     // unique on the page (response card answer tags are plain spans).
@@ -239,38 +221,28 @@ test.describe("Question Summary Page", () => {
     await page.getByRole("heading", { name: choice, exact: true }).click();
 
     await expect(filteredBadge(page)).toBeVisible();
-    await expect(responseCards(page)).toHaveCount(responsesWithChoice(choice), {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(responsesWithChoice(choice));
 
     await clearButton(page).click();
     await expect(filteredBadge(page)).toBeHidden();
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
   });
 
   test("searching responses narrows the list and can be cleared", async ({
     page,
   }) => {
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
 
     // "disagree" appears in exactly one response's free text.
     const searchTerm = "disagree";
     await page.getByTestId("responses-search-input").fill(searchTerm);
 
     await expect(filteredBadge(page)).toBeVisible();
-    await expect(responseCards(page)).toHaveCount(
-      responsesMatchingText(searchTerm),
-    );
+    await expect(responseCards(page)).toHaveCount(responsesMatchingText(searchTerm));
 
     await clearButton(page).click();
     await expect(filteredBadge(page)).toBeHidden();
-    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES, {
-      
-    });
+    await expect(responseCards(page)).toHaveCount(TOTAL_RESPONSES);
   });
 
   test("back button returns to the consultation detail page", async ({

--- a/e2e_tests/tests/respondent-detail.e2e.ts
+++ b/e2e_tests/tests/respondent-detail.e2e.ts
@@ -29,7 +29,7 @@ test.describe("Respondent Detail Page", () => {
     await page.waitForLoadState("networkidle");
 
     const questionCard = page.getByTestId(`question-link-${questionId}`);
-    await expect(questionCard.first()).toBeVisible({ timeout: 10000 });
+    await expect(questionCard.first()).toBeVisible();
 
     const questionCardCount = await questionCard.count();
     
@@ -42,7 +42,7 @@ test.describe("Respondent Detail Page", () => {
 
     const allRespondentButtons = page.getByTestId('respondent-button-1');
 
-    await expect(allRespondentButtons.first()).toBeVisible({ timeout: 10000 });
+    await expect(allRespondentButtons.first()).toBeVisible();
 
     const respondentCount = await allRespondentButtons.count();
     
@@ -55,12 +55,12 @@ test.describe("Respondent Detail Page", () => {
 
     await expect(page).toHaveURL(/\/consultations\/.*\/respondent\/.*/);
     
-    await expect(page.getByRole("heading", { name: /responses to consultation questions/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("heading", { name: /responses to consultation questions/i })).toBeVisible();
     
     const loadingMessage = page.getByText("Loading Responses...");
-    await expect(loadingMessage).toBeHidden({ timeout: 30000 });
+    await expect(loadingMessage).toBeHidden();
 
-    await expect(page.getByTestId('question-number').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('question-number').first()).toBeVisible();
   });
 
   test("page navigation and title should display correctly", async ({ page }) => {


### PR DESCRIPTION
## Context
The e2e tests were very flaky locally for a number of engineers. I've spent about a week exploring different causes for this, but ultimately, parallelism appeared to be overtaxing the local database. After discussion with the team, we've decided to remove parallelism for local tests and to focus on chromium for now (this decision should be revisited if we start to see regressions in other browsers).

## Changes proposed in this pull request
* change the make command to use a chromium-only playwright command
* remove parallelism from local testing
* standardise the timeouts across the testing database

## Guidance to review
Does this run locally without flakiness?

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
