### PR TITLE
refactor(themefinder): migrate LLM layer to Pydantic AI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,19 @@ frontend/govuk-assets
 frontend/admin
 frontend/django_extensions
 
+# themefinder: development-only directories not needed in production images
+themefinder/evals
+themefinder/docs
+themefinder/tests
+themefinder/examples
+themefinder/architecture
+themefinder/.venv
+themefinder/.pytest_cache
+themefinder/.mypy_cache
+themefinder/.ruff_cache
+themefinder/**/__pycache__
+themefinder/*.egg-info
+
 # Local virtualenvs, dependencies and build output
 **/.venv
 **/venv
@@ -31,8 +44,11 @@ frontend/.astro
 # Python caches
 **/__pycache__
 **/.pytest_cache
+**/.mypy_cache
 **/.ruff_cache
-.mypy_cache
+
+# Local dev artifacts (sql.log may contain sensitive query data)
+**/sql.log
 
 # Local env files
 .env

--- a/.github/workflows/themefinder-eval.yml
+++ b/.github/workflows/themefinder-eval.yml
@@ -22,6 +22,10 @@ on:
           - refinement
           - all
         default: 'generation'
+      runs:
+        description: 'Number of repeats per model'
+        type: string
+        default: '1'
 
 jobs:
   themefinder-eval-start-runner:
@@ -40,7 +44,7 @@ jobs:
   themefinder-eval:
     needs: themefinder-eval-start-runner
     runs-on: ${{ needs.themefinder-eval-start-runner.outputs.label }}
-    timeout-minutes: 60
+    timeout-minutes: 180
 
     steps:
       - uses: actions/checkout@v7
@@ -79,16 +83,17 @@ jobs:
           ENVIRONMENT: production
           DATASET: ${{ github.event.inputs.dataset || 'gambling_XS' }}
           EVAL_TYPE: ${{ github.event.inputs.eval_type || 'generation' }}
+          RUNS: ${{ github.event.inputs.runs || '1' }}
         run: |
           set -o pipefail
           cd themefinder/evals
 
           if [ "$EVAL_TYPE" = "all" ]; then
-            echo "Running all evals for $DATASET..."
-            uv run python benchmark.py --quick 2>&1 | tee results.txt
+            echo "Running all evals for $DATASET ($RUNS repeats)..."
+            uv run python benchmark.py --dataset "$DATASET" --provider azure --models gpt-4.1 --runs "$RUNS" 2>&1 | tee results.txt
           else
-            echo "Running $EVAL_TYPE eval for $DATASET..."
-            uv run python benchmark.py --quick --evals "$EVAL_TYPE" 2>&1 | tee results.txt
+            echo "Running $EVAL_TYPE eval for $DATASET ($RUNS repeats)..."
+            uv run python benchmark.py --dataset "$DATASET" --provider azure --models gpt-4.1 --runs "$RUNS" --evals "$EVAL_TYPE" 2>&1 | tee results.txt
           fi
 
           if grep -q "Eval Results\|experiment\|accuracy\|f1" results.txt; then

--- a/pipeline-mapping/assign_themes_script.py
+++ b/pipeline-mapping/assign_themes_script.py
@@ -10,8 +10,8 @@ import boto3
 import pandas as pd
 import sentry_sdk
 import urllib3
-from themefinder.llm import OpenAILLM
 from themefinder import (
+    LLM,
     detail_detection,
     rule_2_themes_must_have_a_non_negligible_number_of_responses_slack,
     rule_4_themes_should_not_overlap_slack,
@@ -153,11 +153,11 @@ async def process_consultation(consultation_dir: str, model_name: str) -> str:
     Returns:
         str: Path to the output directory
     """
-    llm = OpenAILLM(
-        model=model_name,
-        request_kwargs={"temperature": 0},
+    llm = LLM(
+        model_name,
         base_url=os.environ["LLM_GATEWAY_URL"],
         api_key=os.environ["LITELLM_CONSULT_OPENAI_API_KEY"],
+        temperature=0,
     )
 
     date = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")

--- a/pipeline-sign-off/find_themes_script.py
+++ b/pipeline-sign-off/find_themes_script.py
@@ -12,8 +12,8 @@ import sentry_sdk
 import urllib3
 from openai import OpenAI
 from pydantic import BaseModel
-from themefinder.llm import OpenAILLM
 from themefinder import (
+    LLM,
     theme_condensation,
     theme_generation,
     theme_refinement,
@@ -254,11 +254,11 @@ async def process_consultation(consultation_dir: str, model_name: str) -> str:
         consultation_dir: Directory containing question subdirectories
         model_name: Language model instance for processing
     """
-    llm = OpenAILLM(
-        model=model_name,
-        request_kwargs={"temperature": 0},
+    llm = LLM(
+        model_name,
         base_url=os.environ["LLM_GATEWAY_URL"],
         api_key=os.environ["LITELLM_CONSULT_OPENAI_API_KEY"],
+        temperature=0,
     )
 
     date = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")

--- a/themefinder/.gitignore
+++ b/themefinder/.gitignore
@@ -91,6 +91,10 @@ evals/data/*
 !evals/data/gambling_XS/
 !evals/data/generation/
 !evals/data/condensation/
+# The blanket *.json rule above (for GCP creds) also hides the reference
+# dataset's .json files (question.json inputs, themes.json outputs), which the
+# local eval fallback needs in CI. Re-include them explicitly.
+!evals/data/gambling_XS/**/*.json
 
 # Benchmark outputs (generated locally)
 evals/benchmark_*.log

--- a/themefinder/evals/benchmark.py
+++ b/themefinder/evals/benchmark.py
@@ -43,15 +43,16 @@ from typing import Any
 import dotenv
 import nest_asyncio
 import pandas as pd
+from pydantic_ai.settings import ModelSettings
 from rich.console import Console
 from rich.table import Table
-from themefinder.llm import OpenAILLM
+from themefinder.llm import LLM
 
 # Allow nested asyncio.run() calls (needed by eval modules)
 nest_asyncio.apply()
 
 # Monkey-patch openai with langfuse-openai for automatic LLM call tracing.
-# Must happen before any OpenAILLM instances are created.
+# Must happen before any LLM instances are created.
 try:
     from langfuse.openai import openai as _langfuse_openai
 
@@ -185,21 +186,20 @@ class ModelConfig:
     temperature: float = 0.0
     timeout: int = 600  # 10 min default
 
-    def create_llm(self) -> OpenAILLM:
-        """Create an OpenAILLM instance via the LLM gateway."""
+    def create_llm(self) -> LLM:
+        """Create an LLM instance via the LLM gateway."""
         if self.provider in (LLMProvider.VERTEX_GEMINI, LLMProvider.VERTEX_CLAUDE):
             raise NotImplementedError(
-                f"TODO: implement OpenAILLM adapter for {self.provider.value}"
+                f"TODO: implement LLM adapter for {self.provider.value}"
             )
-        request_kwargs: dict[str, Any] = {}
+        model_settings = ModelSettings(timeout=self.timeout)
         if not self.reasoning_effort:
-            request_kwargs["temperature"] = self.temperature
-        return OpenAILLM(
-            model=self.deployment,
-            request_kwargs=request_kwargs,
+            model_settings["temperature"] = self.temperature
+        return LLM(
+            self.deployment,
             base_url=os.getenv("LLM_GATEWAY_URL"),
             api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
-            timeout=self.timeout,
+            model_settings=model_settings,
         )
 
     @property
@@ -213,10 +213,13 @@ class ModelConfig:
 
 
 # All available model configurations by provider
-# Azure OpenAI models - use dated versions that support structured outputs
+# Azure OpenAI models. Deployment strings must match the names the LLM gateway
+# exposes via /v1/models (see backend Consultation.ModelName for the canonical
+# gpt-4o/gpt-4.1 identifiers); the older dated deployment names are no longer
+# registered and return 400 "Invalid model name".
 AZURE_MODELS = [
-    ModelConfig(name="gpt-4o", deployment="gpt-4o-2024-08-06-sweden"),
-    ModelConfig(name="gpt-4.1", deployment="gpt-4.1-sweden-2025-03"),
+    ModelConfig(name="gpt-4o", deployment="gpt-4o-sweden"),
+    ModelConfig(name="gpt-4.1", deployment="gpt-4.1"),
     ModelConfig(name="gpt-4.1-mini", deployment="gpt-4.1-mini"),
     ModelConfig(name="gpt-5-nano", deployment="gpt-5-nano", reasoning_effort="low"),
     ModelConfig(name="gpt-5-mini", deployment="gpt-5-mini", reasoning_effort="low"),
@@ -583,12 +586,11 @@ class BenchmarkRunner:
         # Create dedicated judge LLM if configured (separates judge from task model)
         judge_llm = None
         if self.config.judge_model:
-            judge_llm = OpenAILLM(
-                model=self.config.judge_model,
-                request_kwargs={"temperature": 0},
+            judge_llm = LLM(
+                self.config.judge_model,
                 base_url=os.getenv("LLM_GATEWAY_URL"),
                 api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
-                timeout=600,
+                model_settings=ModelSettings(temperature=0, timeout=600),
             )
 
         # Run the evaluation with timing, wrapped in trace_context for v3 API

--- a/themefinder/evals/data/gambling_XS/inputs/question_part_1/question.json
+++ b/themefinder/evals/data/gambling_XS/inputs/question_part_1/question.json
@@ -1,0 +1,4 @@
+{
+    "question_number": 1,
+    "question_text": "Should gambling advertisements be completely banned during televised sporting events, and what impact do you think this would have on sports viewing and gambling behavior?"
+}

--- a/themefinder/evals/data/gambling_XS/inputs/question_part_2/question.json
+++ b/themefinder/evals/data/gambling_XS/inputs/question_part_2/question.json
@@ -1,0 +1,4 @@
+{
+    "question_number": 2,
+    "question_text": "If gambling adverts during sports broadcasts were restricted, what alternative approaches could be used to promote responsible gambling awareness while protecting vulnerable viewers?"
+}

--- a/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_1/themes.json
+++ b/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_1/themes.json
@@ -1,0 +1,80 @@
+[
+    {
+        "topic_id": "A",
+        "topic_label": "Complete Ban Support",
+        "topic_description": "Strong support for completely banning gambling advertisements during sports broadcasts to protect vulnerable individuals and families.",
+        "topic": "Complete Ban Support: Strong support for completely banning gambling advertisements during sports broadcasts to protect vulnerable individuals and families."
+    },
+    {
+        "topic_id": "B",
+        "topic_label": "Economic Impact Concerns",
+        "topic_description": "Concerns about negative economic impacts on sports funding, broadcasting, employment, and grassroots sports if gambling advertising is banned.",
+        "topic": "Economic Impact Concerns: Concerns about negative economic impacts on sports funding, broadcasting, employment, and grassroots sports if gambling advertising is banned."
+    },
+    {
+        "topic_id": "C",
+        "topic_label": "Personal Freedom Arguments",
+        "topic_description": "Arguments emphasizing personal responsibility and freedom of choice, opposing government intervention in legal advertising.",
+        "topic": "Personal Freedom Arguments: Arguments emphasizing personal responsibility and freedom of choice, opposing government intervention in legal advertising."
+    },
+    {
+        "topic_id": "D",
+        "topic_label": "Addiction and Harm Testimonies",
+        "topic_description": "Personal stories and testimonies about gambling addiction, financial ruin, and family destruction caused by gambling.",
+        "topic": "Addiction and Harm Testimonies: Personal stories and testimonies about gambling addiction, financial ruin, and family destruction caused by gambling."
+    },
+    {
+        "topic_id": "E",
+        "topic_label": "Child Protection Focus",
+        "topic_description": "Emphasis on protecting children and young people from gambling exposure and normalization through sports viewing.",
+        "topic": "Child Protection Focus: Emphasis on protecting children and young people from gambling exposure and normalization through sports viewing."
+    },
+    {
+        "topic_id": "F",
+        "topic_label": "Partial Restriction Proposals",
+        "topic_description": "Suggestions for compromise solutions like watershed restrictions, frequency limits, or content restrictions rather than complete bans.",
+        "topic": "Partial Restriction Proposals: Suggestions for compromise solutions like watershed restrictions, frequency limits, or content restrictions rather than complete bans."
+    },
+    {
+        "topic_id": "G",
+        "topic_label": "Industry Regulation Criticism",
+        "topic_description": "Criticism of current self-regulation, calling for stronger government oversight and enforcement of gambling advertising.",
+        "topic": "Industry Regulation Criticism: Criticism of current self-regulation, calling for stronger government oversight and enforcement of gambling advertising."
+    },
+    {
+        "topic_id": "H",
+        "topic_label": "Cultural Normalization Concerns",
+        "topic_description": "Worries about how gambling has become normalized and integrated into sports culture and commentary.",
+        "topic": "Cultural Normalization Concerns: Worries about how gambling has become normalized and integrated into sports culture and commentary."
+    },
+    {
+        "topic_id": "I",
+        "topic_label": "Alternative Funding Models",
+        "topic_description": "Discussion of how sports could find alternative funding sources to replace gambling sponsorship revenue.",
+        "topic": "Alternative Funding Models: Discussion of how sports could find alternative funding sources to replace gambling sponsorship revenue."
+    },
+    {
+        "topic_id": "J",
+        "topic_label": "Comparison to Other Restrictions",
+        "topic_description": "Comparisons to tobacco advertising bans or arguments about consistency with other harmful product advertising.",
+        "topic": "Comparison to Other Restrictions: Comparisons to tobacco advertising bans or arguments about consistency with other harmful product advertising."
+    },
+    {
+        "topic_id": "K",
+        "topic_label": "Gender and Demographic Targeting",
+        "topic_description": "Concerns about gambling companies specifically targeting vulnerable demographics, particularly young men.",
+        "topic": "Gender and Demographic Targeting: Concerns about gambling companies specifically targeting vulnerable demographics, particularly young men."
+    },
+    {
+        "topic_id": "X",
+        "topic_label": "None of the Above",
+        "topic_description": "The response discusses a topic not covered by the listed themes (only use this if no other theme applies).",
+        "topic": "None of the Above: The response discusses a topic not covered by the listed themes (only use this if no other theme applies)."
+    },
+    {
+        "topic_id": "Y",
+        "topic_label": "No Reason Given",
+        "topic_description": "The response does not provide a substantive answer to the question.",
+        "topic": "No Reason Given: The response does not provide a substantive answer to the question."
+    }
+]

--- a/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_2/themes.json
+++ b/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_2/themes.json
@@ -1,0 +1,80 @@
+[
+    {
+        "topic_id": "A",
+        "topic_label": "Education and Awareness Programs",
+        "topic_description": "Proposals for educational initiatives in schools, communities, and public health campaigns about gambling risks and probability.",
+        "topic": "Education and Awareness Programs: Proposals for educational initiatives in schools, communities, and public health campaigns about gambling risks and probability."
+    },
+    {
+        "topic_id": "B",
+        "topic_label": "Technology-Based Solutions",
+        "topic_description": "Suggestions for using technology like AI monitoring, app restrictions, smart delays, and digital interventions to prevent problem gambling.",
+        "topic": "Technology-Based Solutions: Suggestions for using technology like AI monitoring, app restrictions, smart delays, and digital interventions to prevent problem gambling."
+    },
+    {
+        "topic_id": "C",
+        "topic_label": "Financial Controls and Limits",
+        "topic_description": "Proposals for deposit limits, loss limits, income verification, credit restrictions, and other financial safeguards.",
+        "topic": "Financial Controls and Limits: Proposals for deposit limits, loss limits, income verification, credit restrictions, and other financial safeguards."
+    },
+    {
+        "topic_id": "D",
+        "topic_label": "Treatment and Support Services",
+        "topic_description": "Emphasis on improving access to counseling, support groups, helplines, and addiction treatment services.",
+        "topic": "Treatment and Support Services: Emphasis on improving access to counseling, support groups, helplines, and addiction treatment services."
+    },
+    {
+        "topic_id": "E",
+        "topic_label": "Industry Accountability Measures",
+        "topic_description": "Requirements for gambling companies to fund treatment, report on harm, train staff, and take responsibility for addiction.",
+        "topic": "Industry Accountability Measures: Requirements for gambling companies to fund treatment, report on harm, train staff, and take responsibility for addiction."
+    },
+    {
+        "topic_id": "F",
+        "topic_label": "Regulatory and Legal Changes",
+        "topic_description": "Proposals for new laws, licensing requirements, enforcement mechanisms, and regulatory frameworks.",
+        "topic": "Regulatory and Legal Changes: Proposals for new laws, licensing requirements, enforcement mechanisms, and regulatory frameworks."
+    },
+    {
+        "topic_id": "G",
+        "topic_label": "Warning and Information Requirements",
+        "topic_description": "Suggestions for mandatory warnings, transparent odds display, reality checks, and clear information about risks.",
+        "topic": "Warning and Information Requirements: Suggestions for mandatory warnings, transparent odds display, reality checks, and clear information about risks."
+    },
+    {
+        "topic_id": "H",
+        "topic_label": "Community and Social Interventions",
+        "topic_description": "Focus on peer support, workplace programs, community activities, and social alternatives to gambling.",
+        "topic": "Community and Social Interventions: Focus on peer support, workplace programs, community activities, and social alternatives to gambling."
+    },
+    {
+        "topic_id": "I",
+        "topic_label": "Self-Exclusion and Control Tools",
+        "topic_description": "Improvements to self-exclusion systems, personal limit setting, and tools for individuals to control their gambling.",
+        "topic": "Self-Exclusion and Control Tools: Improvements to self-exclusion systems, personal limit setting, and tools for individuals to control their gambling."
+    },
+    {
+        "topic_id": "J",
+        "topic_label": "Marketing and Sponsorship Alternatives",
+        "topic_description": "Ideas for replacing gambling sponsorship with ethical alternatives and changing how gambling is marketed.",
+        "topic": "Marketing and Sponsorship Alternatives: Ideas for replacing gambling sponsorship with ethical alternatives and changing how gambling is marketed."
+    },
+    {
+        "topic_id": "K",
+        "topic_label": "Early Intervention Strategies",
+        "topic_description": "Approaches to identify and help at-risk individuals before addiction develops, including screening and assessment.",
+        "topic": "Early Intervention Strategies: Approaches to identify and help at-risk individuals before addiction develops, including screening and assessment."
+    },
+    {
+        "topic_id": "XX",
+        "topic_label": "None of the Above",
+        "topic_description": "The response discusses a topic not covered by the listed themes (only use this if no other theme applies).",
+        "topic": "None of the Above: The response discusses a topic not covered by the listed themes (only use this if no other theme applies)."
+    },
+    {
+        "topic_id": "XY",
+        "topic_label": "No Reason Given",
+        "topic_description": "The response does not provide a substantive answer to the question.",
+        "topic": "No Reason Given: The response does not provide a substantive answer to the question."
+    }
+]

--- a/themefinder/evals/eval_condensation.py
+++ b/themefinder/evals/eval_condensation.py
@@ -15,14 +15,14 @@ import pandas as pd
 from datasets import DatasetConfig, load_local_data
 from evaluators import calculate_redundancy_score, create_condensation_quality_evaluator
 from themefinder import theme_condensation
-from themefinder.llm import OpenAILLM
+from themefinder.llm import LLM
 
 
 async def evaluate_condensation(
     dataset: str = "gambling_XS",
-    llm: OpenAILLM | None = None,
+    llm: LLM | None = None,
     langfuse_ctx: langfuse_utils.LangfuseContext | None = None,
-    judge_llm: OpenAILLM | None = None,
+    judge_llm: LLM | None = None,
 ) -> dict:
     """Run condensation evaluation.
 
@@ -51,11 +51,11 @@ async def evaluate_condensation(
 
     # Use provided LLM or create new one
     if llm is None:
-        llm = OpenAILLM(
-            model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
-            request_kwargs={"temperature": 0},
+        llm = LLM(
+            os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             base_url=os.getenv("LLM_GATEWAY_URL"),
             api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            temperature=0,
         )
 
     # Select judge LLM (falls back to task LLM if not provided)

--- a/themefinder/evals/eval_generation.py
+++ b/themefinder/evals/eval_generation.py
@@ -23,7 +23,7 @@ from evaluators import (
     create_title_specificity_evaluator,
 )
 from metrics import calculate_generation_metrics
-from themefinder.llm import OpenAILLM
+from themefinder.llm import LLM
 
 from themefinder import theme_condensation, theme_generation, theme_refinement
 
@@ -32,9 +32,9 @@ logger = logging.getLogger("themefinder.evals.generation")
 
 async def evaluate_generation(
     dataset: str = "gambling_XS",
-    llm: OpenAILLM | None = None,
+    llm: LLM | None = None,
     langfuse_ctx: langfuse_utils.LangfuseContext | None = None,
-    judge_llm: OpenAILLM | None = None,
+    judge_llm: LLM | None = None,
 ) -> dict:
     """Run generation evaluation.
 
@@ -63,11 +63,11 @@ async def evaluate_generation(
 
     # Use provided LLM or create new one
     if llm is None:
-        llm = OpenAILLM(
-            model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
-            request_kwargs={"temperature": 0},
+        llm = LLM(
+            os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             base_url=os.getenv("LLM_GATEWAY_URL"),
             api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            temperature=0,
         )
 
     # Branch: Langfuse dataset vs local fallback
@@ -272,7 +272,7 @@ async def _run_local_fallback(config: DatasetConfig, llm) -> dict:
             question=question,
         )
 
-        eval_scores = calculate_generation_metrics(refined_df, theme_framework)
+        eval_scores = calculate_generation_metrics(refined_df, theme_framework, llm=llm)
         print(f"Theme Generation ({question_part}): \n {eval_scores}")
 
         # Collect scores with question prefix

--- a/themefinder/evals/eval_mapping.py
+++ b/themefinder/evals/eval_mapping.py
@@ -14,7 +14,7 @@ import pandas as pd
 from datasets import DatasetConfig, load_local_data
 from evaluators import mapping_f1_evaluator
 from metrics import calculate_mapping_metrics
-from themefinder.llm import OpenAILLM
+from themefinder.llm import LLM
 
 from themefinder import theme_mapping
 
@@ -22,7 +22,7 @@ from themefinder import theme_mapping
 async def evaluate_mapping(
     dataset: str = "gambling_XS",
     question_num: int | None = None,
-    llm: OpenAILLM | None = None,
+    llm: LLM | None = None,
     langfuse_ctx: langfuse_utils.LangfuseContext | None = None,
 ) -> dict:
     """Run mapping evaluation.
@@ -53,11 +53,11 @@ async def evaluate_mapping(
 
     # Use provided LLM or create new one
     if llm is None:
-        llm = OpenAILLM(
-            model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
-            request_kwargs={"temperature": 0},
+        llm = LLM(
+            os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             base_url=os.getenv("LLM_GATEWAY_URL"),
             api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            temperature=0,
         )
 
     # Branch: Langfuse dataset vs local fallback

--- a/themefinder/evals/eval_refinement.py
+++ b/themefinder/evals/eval_refinement.py
@@ -14,14 +14,14 @@ import pandas as pd
 from datasets import DatasetConfig, load_local_data
 from evaluators import create_refinement_quality_evaluator
 from themefinder import theme_refinement
-from themefinder.llm import OpenAILLM
+from themefinder.llm import LLM
 
 
 async def evaluate_refinement(
     dataset: str = "gambling_XS",
-    llm: OpenAILLM | None = None,
+    llm: LLM | None = None,
     langfuse_ctx: langfuse_utils.LangfuseContext | None = None,
-    judge_llm: OpenAILLM | None = None,
+    judge_llm: LLM | None = None,
 ) -> dict:
     """Run refinement evaluation.
 
@@ -50,11 +50,11 @@ async def evaluate_refinement(
 
     # Use provided LLM or create new one
     if llm is None:
-        llm = OpenAILLM(
-            model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
-            request_kwargs={"temperature": 0},
+        llm = LLM(
+            os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             base_url=os.getenv("LLM_GATEWAY_URL"),
             api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            temperature=0,
         )
 
     # Select judge LLM (falls back to task LLM if not provided)

--- a/themefinder/evals/metrics.py
+++ b/themefinder/evals/metrics.py
@@ -1,16 +1,13 @@
-import json
 import os
 
 import numpy as np
 import pandas as pd
 from sklearn import metrics, utils
 from sklearn.preprocessing import MultiLabelBinarizer
-from themefinder.llm import OpenAILLM
+from themefinder.llm import LLM
 
+from evaluators import _parse_evaluation_response
 from prompts import generation_eval_prompt
-
-# Minimum score (0-5) to consider a topic well-grounded or captured
-GROUNDEDNESS_THRESHOLD = 3
 
 
 def calculate_generation_metrics(
@@ -34,11 +31,11 @@ def calculate_generation_metrics(
             - Recall Average topic Representation: Mean representation score
     """
     if llm is None:
-        llm = OpenAILLM(
-            model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
-            request_kwargs={"temperature": 0},
+        llm = LLM(
+            os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
             base_url=os.getenv("LLM_GATEWAY_URL"),
             api_key=os.getenv("CONSULT_EVAL_LITELLM_API_KEY"),
+            temperature=0,
         )
     precision_response = llm.invoke(
         generation_eval_prompt(
@@ -46,24 +43,20 @@ def calculate_generation_metrics(
             topic_list_2=topic_framework,
         )
     )
-    precision_scores = list(json.loads(precision_response.parsed).values())
+    precision = _parse_evaluation_response(precision_response.parsed)
     recall_response = llm.invoke(
         generation_eval_prompt(
             topic_list_1=topic_framework,
             topic_list_2=generated_topics,
         )
     )
-    recall_scores = list(json.loads(recall_response.parsed).values())
+    recall = _parse_evaluation_response(recall_response.parsed)
     return {
         "Precision N topics": len(generated_topics),
-        "Precision N not well grounded": sum(
-            score < GROUNDEDNESS_THRESHOLD for score in precision_scores
-        ),
-        "Precision Average Groundedness": np.mean(precision_scores).round(2),
-        "Recall N not Captured": sum(
-            score < GROUNDEDNESS_THRESHOLD for score in recall_scores
-        ),
-        "Recall Average topic Representation": np.mean(recall_scores).round(2),
+        "Precision N not well grounded": precision["n_below_threshold"],
+        "Precision Average Groundedness": round(precision["average"], 2),
+        "Recall N not Captured": recall["n_below_threshold"],
+        "Recall Average topic Representation": round(recall["average"], 2),
     }
 
 

--- a/themefinder/pyproject.toml
+++ b/themefinder/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "cryptography>=46.0.7",
     "tenacity>=8.0.0",
     "tiktoken>=0.5.0",
+    "pydantic-ai-slim[openai,anthropic,google]>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -58,6 +59,13 @@ where = ["src"]
 pythonpath = "."
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.coverage.run]
+# Live-inference tests only execute when LLM gateway credentials are present
+# (skipif-gated). In CI they are skipped, so counting them would make the
+# coverage total depend on whether creds are available. Omit them so the gate
+# measures the same code in every environment.
+omit = ["tests/test_live_inference.py"]
 
 
 [build-system]

--- a/themefinder/src/themefinder/__init__.py
+++ b/themefinder/src/themefinder/__init__.py
@@ -1,4 +1,4 @@
-from .llm import LLM, LLMResponse, OpenAILLM
+from .llm import LLM, LLMResponse
 from .tasks import (
     detail_detection,
     find_themes,
@@ -18,7 +18,6 @@ from .themeset_rules import (
 __all__ = [
     "LLM",
     "LLMResponse",
-    "OpenAILLM",
     "find_themes",
     "theme_clustering",
     "theme_condensation",

--- a/themefinder/src/themefinder/llm.py
+++ b/themefinder/src/themefinder/llm.py
@@ -1,16 +1,20 @@
 """LLM abstraction layer for themefinder.
 
-Provides a Protocol-based interface for LLM calls with structured output support,
-and an OpenAI implementation. Designed for easy extension to other providers.
+A single Pydantic AI-backed ``LLM`` class drives all chat/structured calls.
+The model/provider is a single configurable value: pass a provider-prefixed
+string (``"openai:gpt-4o"``, ``"anthropic:claude-..."``, ``"google:gemini-..."``)
+for direct-to-provider routing, or a ``base_url``/``api_key`` pair to route through
+an OpenAI-compatible gateway (the Consult LiteLLM proxy).
 """
 
-import asyncio
-import concurrent.futures
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
 
-import openai
 from pydantic import BaseModel
+from pydantic_ai import Agent, NativeOutput
+from pydantic_ai.models import Model
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.settings import ModelSettings
 
 
 @dataclass
@@ -20,59 +24,71 @@ class LLMResponse:
     parsed: BaseModel | str
 
 
-@runtime_checkable
-class LLM(Protocol):
-    """Protocol defining the LLM interface for themefinder."""
+def _resolve_model(
+    model: str | Model,
+    base_url: str | None,
+    api_key: str | None,
+) -> str | Model:
+    """Resolve the ``model`` argument into something an ``Agent`` accepts.
 
-    async def ainvoke(
-        self, prompt: str, output_model: type[BaseModel] | None = None
-    ) -> LLMResponse: ...
+    - ``model`` is already a ``Model`` instance -> use as-is (also the test seam),
+      regardless of ``base_url``/``api_key``: a ready-made model carries its own
+      provider, so there is nothing for the gateway args to configure.
+    - ``base_url``/``api_key`` given (with a string ``model``) -> gateway mode:
+      build an ``OpenAIChatModel`` over an ``OpenAIProvider`` pointed at the
+      gateway. Here ``model`` is the gateway's model name (no ``provider:``
+      prefix); the proxy does the routing.
+    - otherwise -> pass the provider-prefixed string straight through to the
+      ``Agent``, which resolves the provider from env API keys.
+    """
+    if not isinstance(model, str):
+        return model
+    if base_url is not None or api_key is not None:
+        return OpenAIChatModel(
+            model,
+            provider=OpenAIProvider(base_url=base_url, api_key=api_key),
+        )
+    return model
 
-    def invoke(
-        self, prompt: str, output_model: type[BaseModel] | None = None
-    ) -> LLMResponse: ...
 
-
-class OpenAILLM:
-    """OpenAI SDK implementation of the LLM protocol."""
+class LLM:
+    """Pydantic AI-backed implementation of the themefinder LLM interface."""
 
     def __init__(
         self,
-        model,
-        request_kwargs: dict | None = None,
-        **client_kwargs,
+        model: str | Model,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        temperature: float | None = None,
+        model_settings: ModelSettings | None = None,
     ):
-        self.model = model
-        self.request_kwargs = request_kwargs or {}
-        self.client = openai.AsyncOpenAI(**client_kwargs)
+        self._model = _resolve_model(model, base_url, api_key)
+        self._settings = model_settings or (
+            ModelSettings(temperature=temperature) if temperature is not None else None
+        )
+        self._agent = Agent(self._model)
+
+    @staticmethod
+    def _output_type(output_model: type[BaseModel] | None):
+        return NativeOutput(output_model) if output_model is not None else str
 
     async def ainvoke(
         self, prompt: str, output_model: type[BaseModel] | None = None
     ) -> LLMResponse:
-        kwargs = {
-            "model": self.model,
-            "messages": [{"role": "user", "content": prompt}],
-            **self.request_kwargs,
-        }
-        if output_model:
-            kwargs["response_format"] = output_model
-            response = await self.client.chat.completions.parse(**kwargs)
-            return LLMResponse(parsed=response.choices[0].message.parsed)
-        else:
-            response = await self.client.chat.completions.create(**kwargs)
-            return LLMResponse(parsed=response.choices[0].message.content)
+        result = await self._agent.run(
+            prompt,
+            output_type=self._output_type(output_model),
+            model_settings=self._settings,
+        )
+        return LLMResponse(parsed=result.output)
 
     def invoke(
         self, prompt: str, output_model: type[BaseModel] | None = None
     ) -> LLMResponse:
-        """Synchronous wrapper around ainvoke."""
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-        if loop and loop.is_running():
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                return pool.submit(
-                    asyncio.run, self.ainvoke(prompt, output_model)
-                ).result()
-        return asyncio.run(self.ainvoke(prompt, output_model))
+        result = self._agent.run_sync(
+            prompt,
+            output_type=self._output_type(output_model),
+            model_settings=self._settings,
+        )
+        return LLMResponse(parsed=result.output)

--- a/themefinder/src/themefinder/llm_batch_processor.py
+++ b/themefinder/src/themefinder/llm_batch_processor.py
@@ -2,12 +2,12 @@ import asyncio
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
-import openai
 import pandas as pd
 import tiktoken
 from pydantic import BaseModel, ValidationError
+from pydantic_ai.exceptions import ModelHTTPError, UnexpectedModelBehavior
 from tenacity import (
     before,
     before_sleep_log,
@@ -95,7 +95,7 @@ async def batch_and_run(
 
 
 def partition_dataframe(
-    df: pd.DataFrame, partition_key: Optional[str]
+    df: pd.DataFrame, partition_key: str | None
 ) -> list[pd.DataFrame]:
     """Splits the DataFrame into partitions based on the partition_key if provided."""
     if partition_key:
@@ -153,7 +153,7 @@ def batch_task_input_df(
     df: pd.DataFrame,
     allowed_tokens: int,
     batch_size: int,
-    partition_key: Optional[str] = None,
+    partition_key: str | None = None,
 ) -> list[pd.DataFrame]:
     """
     Partitions and batches a DataFrame according to a token limit and batch size,
@@ -255,10 +255,12 @@ async def call_llm(
                     if isinstance(all_results, dict)
                     else all_results.responses
                 )
-            except (openai.BadRequestError, ValueError) as e:
-                logger.warning(e)
-                return [], batch_prompt.response_ids
-            except ValidationError as e:
+            except (
+                ModelHTTPError,
+                UnexpectedModelBehavior,
+                ValueError,
+                ValidationError,
+            ) as e:
                 logger.warning(e)
                 return [], batch_prompt.response_ids
 
@@ -329,7 +331,7 @@ def process_llm_responses(
     return task_responses
 
 
-def calculate_string_token_length(input_text: str, model: str = None) -> int:
+def calculate_string_token_length(input_text: str, model: str | None = None) -> int:
     """
     Calculates the number of tokens in a given string using the specified model's tokenizer.
 
@@ -342,7 +344,12 @@ def calculate_string_token_length(input_text: str, model: str = None) -> int:
     """
     # Use the MODEL_NAME env var if no model is provided; otherwise default to "gpt-4o"
     model = model or os.environ.get("MODEL_NAME", "gpt-4o")
-    tokenizer_encoding = tiktoken.encoding_for_model(model)
+    try:
+        tokenizer_encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        # Non-OpenAI model names are unknown to tiktoken. Token counting here is
+        # only an approximate batching heuristic, so a default encoding is fine.
+        tokenizer_encoding = tiktoken.get_encoding("o200k_base")
     number_of_tokens = len(tokenizer_encoding.encode(input_text))
     return number_of_tokens
 

--- a/themefinder/src/themefinder/tasks.py
+++ b/themefinder/src/themefinder/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Mapping
 
 import pandas as pd
 
@@ -23,11 +24,21 @@ from themefinder.prompts import (
 )
 from themefinder.themefinder_logging import logger
 
+STAGES = (
+    "theme_generation",
+    "theme_condensation",
+    "theme_refinement",
+    "theme_mapping",
+    "detail_detection",
+)
+
 
 async def find_themes(
     responses_df: pd.DataFrame,
     llm: LLM,
     question: str,
+    *,
+    stage_llms: Mapping[str, LLM] | None = None,
     system_prompt: str = CONSULTATION_SYSTEM_PROMPT,
     verbose: bool = True,
     concurrency: int = 10,
@@ -45,6 +56,9 @@ async def find_themes(
         responses_df: DataFrame containing survey responses
         llm: LLM instance for text analysis
         question: The survey question
+        stage_llms: Optional mapping of stage name to LLM, overriding ``llm`` for
+            specific stages. Keys must be a subset of ``STAGES``; any stage not
+            present uses ``llm``.
         system_prompt: System prompt to guide the LLM's behaviour.
         verbose: Whether to show information messages during processing.
         concurrency: Number of concurrent API calls to make.
@@ -59,23 +73,31 @@ async def find_themes(
     """
     logger.setLevel(logging.INFO if verbose else logging.CRITICAL)
 
+    overrides = stage_llms or {}
+    unknown = set(overrides) - set(STAGES)
+    if unknown:
+        raise ValueError(f"Unknown stage_llms keys: {sorted(unknown)}")
+
+    def pick(stage: str) -> LLM:
+        return overrides.get(stage, llm)
+
     theme_df, _ = await theme_generation(
         responses_df,
-        llm,
+        pick("theme_generation"),
         question=question,
         system_prompt=system_prompt,
         concurrency=concurrency,
     )
     condensed_theme_df, _ = await theme_condensation(
         theme_df,
-        llm,
+        pick("theme_condensation"),
         question=question,
         system_prompt=system_prompt,
         concurrency=concurrency,
     )
     refined_theme_df, _ = await theme_refinement(
         condensed_theme_df,
-        llm,
+        pick("theme_refinement"),
         question=question,
         system_prompt=system_prompt,
         concurrency=concurrency,
@@ -83,7 +105,7 @@ async def find_themes(
 
     mapping_df, mapping_unprocessables = await theme_mapping(
         responses_df[["response_id", "response"]],
-        llm,
+        pick("theme_mapping"),
         question=question,
         refined_themes_df=refined_theme_df,
         system_prompt=system_prompt,
@@ -91,7 +113,7 @@ async def find_themes(
     )
     detailed_df, _ = await detail_detection(
         responses_df[["response_id", "response"]],
-        llm,
+        pick("detail_detection"),
         question=question,
         system_prompt=system_prompt,
         concurrency=concurrency,

--- a/themefinder/tests/test_live_inference.py
+++ b/themefinder/tests/test_live_inference.py
@@ -1,0 +1,210 @@
+"""Live inference tests that make real LLM calls through the Consult LiteLLM gateway.
+
+They run as part of the normal suite. They skip (rather than fail) only when
+gateway credentials are absent, so CI without secrets stays green while a
+developer with a configured ``.env`` runs them automatically.
+
+Credentials are read from the repo-root ``.env`` (``LLM_GATEWAY_URL`` and
+``LITELLM_CONSULT_OPENAI_API_KEY`` — the same vars the production pipeline uses).
+The model defaults to ``gpt-4.1`` (the Consult default) and can be overridden with
+``LIVE_TEST_MODEL``. Real data comes from the tracked synthetic ``gambling_XS``
+evaluation dataset.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from dotenv import load_dotenv
+from pydantic_ai import Agent, NativeOutput, ToolOutput
+
+from themefinder import (
+    detail_detection,
+    find_themes,
+    theme_generation,
+    theme_mapping,
+)
+from themefinder.llm import LLM
+from themefinder.models import (
+    EvidenceRich,
+    ThemeGenerationResponses,
+)
+
+# Load env from the repo root (.../consult/.env) and the package dir if present.
+_PACKAGE_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _PACKAGE_DIR.parent
+load_dotenv(_REPO_ROOT / ".env")
+load_dotenv(_PACKAGE_DIR / ".env")
+
+GATEWAY_URL = os.environ.get("LLM_GATEWAY_URL")
+API_KEY = os.environ.get("LITELLM_CONSULT_OPENAI_API_KEY")
+MODEL = os.environ.get("LIVE_TEST_MODEL", "gpt-4.1")
+
+DATA_DIR = _PACKAGE_DIR / "evals" / "data" / "gambling_XS"
+QUESTION = "Should gambling advertising during live sporting events be banned?"
+
+pytestmark = pytest.mark.skipif(
+    not (GATEWAY_URL and API_KEY),
+    reason="LLM_GATEWAY_URL / LITELLM_CONSULT_OPENAI_API_KEY not set",
+)
+
+# A tiny self-contained structured-output prompt (no template machinery needed).
+STRUCTURED_PROMPT = (
+    "You are analysing public consultation responses about banning gambling "
+    "advertising. Extract up to three distinct themes from these responses, each "
+    "with a short topic_label, a one-sentence topic_description, and a position of "
+    "AGREEMENT, DISAGREEMENT or UNCLEAR.\n"
+    "Responses:\n"
+    "1. Ban all gambling adverts, they normalise betting for children.\n"
+    "2. A ban is overkill — sports clubs rely on this sponsorship money.\n"
+    "3. Only restrict adverts during live sport when families are watching.\n"
+)
+
+
+@pytest.fixture(scope="module")
+def llm() -> LLM:
+    """Gateway-backed LLM at temperature 0 for repeatable output."""
+    return LLM(MODEL, base_url=GATEWAY_URL, api_key=API_KEY, temperature=0)
+
+
+@pytest.fixture(scope="module")
+def responses_df() -> pd.DataFrame:
+    """A small slice of the tracked synthetic gambling_XS responses."""
+    path = DATA_DIR / "inputs" / "question_part_1" / "responses.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    df = pd.DataFrame(rows).head(12)
+    return df[["response_id", "response"]]
+
+
+# --- basic connectivity ------------------------------------------------------
+
+
+async def test_gateway_returns_text_response(llm):
+    """A plain (unstructured) call returns a non-empty text response."""
+    result = await llm.ainvoke("Reply with exactly the single word: pong")
+    assert isinstance(result.parsed, str)
+    assert result.parsed.strip() != ""
+
+
+# --- structured output: native vs tool (pydantic) mode -----------------------
+
+
+async def test_wrapper_native_structured_output(llm):
+    """The LLM wrapper's own path (NativeOutput) returns a validated model."""
+    result = await llm.ainvoke(STRUCTURED_PROMPT, output_model=ThemeGenerationResponses)
+    assert isinstance(result.parsed, ThemeGenerationResponses)
+    assert len(result.parsed.responses) >= 1
+
+
+@pytest.mark.parametrize(
+    "output_type_factory",
+    [
+        pytest.param(NativeOutput, id="native"),
+        pytest.param(ToolOutput, id="tool"),
+    ],
+)
+async def test_structured_output_modes_through_gateway(llm, output_type_factory):
+    """OpenAI structured output works through the gateway in BOTH modes:
+    native JSON-schema (NativeOutput, the wrapper's choice) and tool-calling
+    (ToolOutput, Pydantic AI's default). Exercises the same validator-bearing
+    *Responses model both ways to surface provider variability."""
+    agent = Agent(llm._model)
+    result = await agent.run(
+        STRUCTURED_PROMPT,
+        output_type=output_type_factory(ThemeGenerationResponses),
+        model_settings=llm._settings,
+    )
+    assert isinstance(result.output, ThemeGenerationResponses)
+    assert len(result.output.responses) >= 1
+    for theme in result.output.responses:
+        assert theme.topic_label.strip()
+        assert theme.topic_description.strip()
+
+
+# --- individual tasks on real gambling_XS data -------------------------------
+
+
+async def test_theme_generation_live(llm, responses_df):
+    themes_df, unprocessable = await theme_generation(
+        responses_df, llm, question=QUESTION, concurrency=5
+    )
+    assert not themes_df.empty
+    assert {"topic_label", "topic_description", "position"}.issubset(themes_df.columns)
+    assert unprocessable.empty
+
+
+async def test_theme_mapping_live(llm, responses_df):
+    refined_themes_df = pd.DataFrame(
+        {
+            "topic_id": ["A", "B", "C"],
+            "topic": [
+                "Support ban: The respondent supports banning gambling advertising.",
+                "Oppose ban: The respondent opposes banning gambling advertising.",
+                "Partial restriction: The respondent wants limits rather than a full ban.",
+            ],
+        }
+    )
+    mapped_df, unprocessable = await theme_mapping(
+        responses_df,
+        llm,
+        question=QUESTION,
+        refined_themes_df=refined_themes_df,
+        concurrency=5,
+    )
+    assert not mapped_df.empty
+    assert {"response_id", "labels"}.issubset(mapped_df.columns)
+    # Integrity check is on: every input response should be mapped.
+    assert unprocessable.empty
+    assert set(mapped_df["response_id"]) == set(responses_df["response_id"])
+    # Every assigned label is a known theme id or one of the prompt's documented
+    # fallbacks ("Other" / "No Reason Given") used when no theme fits.
+    allowed = set(refined_themes_df["topic_id"]) | {"Other", "No Reason Given"}
+    for labels in mapped_df["labels"]:
+        assert set(labels).issubset(allowed)
+
+
+async def test_detail_detection_live(llm, responses_df):
+    detail_df, unprocessable = await detail_detection(
+        responses_df, llm, question=QUESTION, concurrency=5
+    )
+    assert not detail_df.empty
+    assert "evidence_rich" in detail_df.columns
+    assert unprocessable.empty
+    valid = {EvidenceRich.YES, EvidenceRich.NO, "YES", "NO"}
+    assert all(value in valid for value in detail_df["evidence_rich"])
+
+
+# --- end-to-end pipeline -----------------------------------------------------
+
+
+async def test_find_themes_end_to_end_live(llm, responses_df):
+    result = await find_themes(
+        responses_df, llm, question=QUESTION, concurrency=5, verbose=False
+    )
+    assert {
+        "question",
+        "themes",
+        "mapping",
+        "detailed_responses",
+        "unprocessables",
+    }.issubset(result)
+    assert result["question"] == QUESTION
+    assert not result["themes"].empty
+    assert not result["mapping"].empty
+
+
+# --- direct-provider sanity (only if a provider key is present) --------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set (direct-provider mode)",
+)
+async def test_direct_anthropic_structured_output():
+    """Direct-to-provider routing (no gateway) via a provider-prefixed string."""
+    llm = LLM("anthropic:claude-haiku-4-5", temperature=0)
+    result = await llm.ainvoke(STRUCTURED_PROMPT, output_model=ThemeGenerationResponses)
+    assert isinstance(result.parsed, ThemeGenerationResponses)
+    assert len(result.parsed.responses) >= 1

--- a/themefinder/tests/test_llm.py
+++ b/themefinder/tests/test_llm.py
@@ -1,0 +1,143 @@
+"""Tests for the Pydantic AI-backed LLM wrapper.
+
+Models are injected directly as the ``model`` argument (the wrapper hides its
+``Agent``), exercising the ``_resolve_model`` "already a Model" branch. We use
+``FunctionModel`` with a profile that advertises native JSON-schema output so the
+``NativeOutput`` wrapping the wrapper applies is accepted.
+"""
+
+import pytest
+from pydantic_ai.models.function import FunctionModel
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.profiles import ModelProfile
+
+from themefinder.llm import LLM, LLMResponse, _resolve_model
+from themefinder.models import Position, ThemeGenerationResponses
+
+
+def _theme_json(label: str) -> str:
+    return (
+        '{"responses":[{"topic_label":"%s",'
+        '"topic_description":"a description","position":"AGREEMENT"}]}' % label
+    )
+
+
+def native_model(label: str = "alpha") -> FunctionModel:
+    """A FunctionModel that returns a fixed ThemeGenerationResponses tagged by label."""
+
+    def fn(messages, info):
+        return ModelResponse(parts=[TextPart(_theme_json(label))])
+
+    return FunctionModel(fn, profile=ModelProfile(supports_json_schema_output=True))
+
+
+def text_model(text: str = "hello") -> FunctionModel:
+    def fn(messages, info):
+        return ModelResponse(parts=[TextPart(text)])
+
+    return FunctionModel(fn)
+
+
+# --- _resolve_model / construction -------------------------------------------
+
+
+@pytest.fixture()
+def fake_openai_key(monkeypatch):
+    """A dummy key so building an Agent over a bare "openai:" string succeeds."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+
+def test_direct_string_model_passed_through(fake_openai_key):
+    """(a) A provider-prefixed string is passed straight to the Agent (direct mode)."""
+    assert _resolve_model("openai:gpt-4o", None, None) == "openai:gpt-4o"
+    llm = LLM("openai:gpt-4o")
+    assert llm._model == "openai:gpt-4o"
+
+
+def test_gateway_mode_builds_openai_chat_model():
+    """(b) base_url+api_key builds an OpenAIChatModel over an OpenAIProvider, and
+    needs no provider: prefix on the model name (LiteLLM-proxy mode)."""
+    llm = LLM("gpt-4o", base_url="http://gateway.local/v1", api_key="secret")
+    assert isinstance(llm._model, OpenAIChatModel)
+    # The gateway model name carries no provider prefix.
+    assert llm._model.model_name == "gpt-4o"
+
+
+def test_api_key_only_also_uses_gateway_branch():
+    llm = LLM("gpt-4o", api_key="secret")
+    assert isinstance(llm._model, OpenAIChatModel)
+
+
+def test_model_instance_passed_verbatim():
+    """(c) A Model instance is used as-is (the test-injection seam)."""
+    model = native_model()
+    assert _resolve_model(model, None, None) is model
+    assert LLM(model)._model is model
+
+
+def test_model_instance_ignores_gateway_args():
+    """A ready-made Model instance is used as-is even when base_url/api_key are
+    passed: it carries its own provider, so it must not be re-wrapped (which
+    would TypeError inside OpenAIChatModel)."""
+    model = native_model()
+    assert _resolve_model(model, "http://gateway.local/v1", "secret") is model
+    llm = LLM(model, base_url="http://gateway.local/v1", api_key="secret")
+    assert llm._model is model
+
+
+def test_temperature_builds_model_settings(fake_openai_key):
+    llm = LLM("openai:gpt-4o", temperature=0)
+    assert llm._settings is not None
+    assert llm._settings["temperature"] == 0
+
+
+def test_no_temperature_no_settings(fake_openai_key):
+    assert LLM("openai:gpt-4o")._settings is None
+
+
+# --- invoke / ainvoke --------------------------------------------------------
+
+
+async def test_ainvoke_returns_llmresponse_with_parsed_model():
+    """(d/e) ainvoke returns LLMResponse wrapping a parsed *Responses instance."""
+    llm = LLM(native_model("transport"))
+    result = await llm.ainvoke("prompt", output_model=ThemeGenerationResponses)
+    assert isinstance(result, LLMResponse)
+    assert isinstance(result.parsed, ThemeGenerationResponses)
+    assert result.parsed.responses[0].topic_label == "transport"
+    assert result.parsed.responses[0].position == Position.AGREEMENT
+
+
+def test_invoke_sync_returns_llmresponse_with_parsed_model():
+    llm = LLM(native_model("housing"))
+    result = llm.invoke("prompt", output_model=ThemeGenerationResponses)
+    assert isinstance(result.parsed, ThemeGenerationResponses)
+    assert result.parsed.responses[0].topic_label == "housing"
+
+
+async def test_ainvoke_without_output_model_returns_text():
+    llm = LLM(text_model("plain text answer"))
+    result = await llm.ainvoke("prompt")
+    assert result.parsed == "plain text answer"
+
+
+# --- multi-model path --------------------------------------------------------
+
+
+async def test_same_input_through_two_models_yields_one_result_each():
+    """(f) Running the same input through two different models yields one result
+    per model — provider comparison needs no helper."""
+    prompt = "same prompt"
+    results = [
+        await LLM(native_model(tag)).ainvoke(
+            prompt, output_model=ThemeGenerationResponses
+        )
+        for tag in ("model_a", "model_b")
+    ]
+    labels = [r.parsed.responses[0].topic_label for r in results]
+    assert labels == ["model_a", "model_b"]
+
+
+def test_unknown_output_model_none_is_string_type():
+    assert LLM._output_type(None) is str

--- a/themefinder/tests/test_llm_batch_processor.py
+++ b/themefinder/tests/test_llm_batch_processor.py
@@ -1,10 +1,9 @@
 from unittest.mock import MagicMock, patch
 
-import httpx
-import openai
 import pandas as pd
 import pytest
 import tiktoken
+from pydantic_ai.exceptions import ModelHTTPError
 
 from themefinder import detail_detection
 from themefinder.models import (
@@ -524,20 +523,9 @@ def test_generate_prompts_with_partition(monkeypatch):
 async def test_call_llm_bad_request(monkeypatch, mock_llm):
     batch_prompts = [BatchPrompt(prompt_string="dummy prompt", response_ids=[1, 2])]
 
-    class DummyBadRequestError(openai.BadRequestError):
-        def __init__(self, *args, **kwargs):
-            dummy_request = httpx.Request("GET", "http://dummy.url")
-            dummy_response = httpx.Response(
-                status_code=400,
-                content=b'{"error": "dummy"}',
-                headers={"Content-Type": "application/json"},
-                request=dummy_request,
-            )
-            super().__init__(
-                "dummy message", response=dummy_response, body="dummy body"
-            )
-
-    mock_llm.ainvoke.side_effect = DummyBadRequestError()
+    mock_llm.ainvoke.side_effect = ModelHTTPError(
+        status_code=400, model_name="test-model", body={"error": "dummy"}
+    )
     results, failed_ids = await call_llm(
         batch_prompts, mock_llm, output_model=DetailDetectionResponses
     )

--- a/themefinder/tests/test_tasks.py
+++ b/themefinder/tests/test_tasks.py
@@ -420,6 +420,83 @@ async def test_find_themes(mock_llm, sample_df):
         assert mock_call_llm.await_count == 5
 
 
+def _patch_stage_functions():
+    """Patch all five find_themes stage functions with AsyncMocks returning
+    empty (results, unprocessables) tuples, so we can inspect routing."""
+    empty = (pd.DataFrame({"response_id": []}), pd.DataFrame())
+    patchers = {
+        stage: patch(
+            f"themefinder.tasks.{stage}",
+            new=AsyncMock(return_value=empty),
+        )
+        for stage in (
+            "theme_generation",
+            "theme_condensation",
+            "theme_refinement",
+            "theme_mapping",
+            "detail_detection",
+        )
+    }
+    return patchers
+
+
+@pytest.mark.asyncio
+async def test_find_themes_stage_llms_routes_per_stage(sample_df):
+    """stage_llms overrides route the named stages to their own LLM; the rest
+    fall back to the base llm."""
+    base_llm = Mock(name="base")
+    mapping_llm = Mock(name="mapping")
+    detail_llm = Mock(name="detail")
+
+    patchers = _patch_stage_functions()
+    mocks = {stage: p.start() for stage, p in patchers.items()}
+    try:
+        await find_themes(
+            sample_df.copy(),
+            base_llm,
+            question="q",
+            stage_llms={"theme_mapping": mapping_llm, "detail_detection": detail_llm},
+            verbose=False,
+        )
+    finally:
+        for p in patchers.values():
+            p.stop()
+
+    # The llm is the second positional arg of each stage function.
+    assert mocks["theme_generation"].call_args.args[1] is base_llm
+    assert mocks["theme_condensation"].call_args.args[1] is base_llm
+    assert mocks["theme_refinement"].call_args.args[1] is base_llm
+    assert mocks["theme_mapping"].call_args.args[1] is mapping_llm
+    assert mocks["detail_detection"].call_args.args[1] is detail_llm
+
+
+@pytest.mark.asyncio
+async def test_find_themes_without_stage_llms_uses_base_for_all(sample_df):
+    base_llm = Mock(name="base")
+    patchers = _patch_stage_functions()
+    mocks = {stage: p.start() for stage, p in patchers.items()}
+    try:
+        await find_themes(sample_df.copy(), base_llm, question="q", verbose=False)
+    finally:
+        for p in patchers.values():
+            p.stop()
+
+    for mock in mocks.values():
+        assert mock.call_args.args[1] is base_llm
+
+
+@pytest.mark.asyncio
+async def test_find_themes_unknown_stage_key_raises(sample_df):
+    with pytest.raises(ValueError, match="Unknown stage_llms keys"):
+        await find_themes(
+            sample_df.copy(),
+            Mock(),
+            question="q",
+            stage_llms={"not_a_stage": Mock()},
+            verbose=False,
+        )
+
+
 @pytest.mark.asyncio
 async def test_theme_clustering():
     """Test theme_clustering function"""

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-29T10:37:21.365542Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -46,6 +46,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.113.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/2a/f856135e5b055bf8b6f34133b313810dfe1cb848e5ac5ea843e196daefdd/anthropic-0.113.0.tar.gz", hash = "sha256:1830e866430ebd351c4f277d20e4c9b0aa9ad71f6569a23772ae88b33e0abaf8", size = 939444, upload-time = "2026-06-29T14:57:22.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/4d/ea001c0993b8f48153c5eb74eecf5a3ed120df07fe894757351e8308bbe6/anthropic-0.113.0-py3-none-any.whl", hash = "sha256:9a52ed7a4982e916fa878d1ed3eaec2dcdf98699a39d8fc45b54b3c50f1e7426", size = 937995, upload-time = "2026-06-29T14:57:23.721Z" },
 ]
 
 [[package]]
@@ -671,6 +690,15 @@ crypto = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "drf-nested-routers"
 version = "0.95.0"
 source = { registry = "https://pypi.org/simple" }
@@ -778,6 +806,19 @@ wheels = [
 ]
 
 [[package]]
+name = "genai-prices"
+version = "0.0.67"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/9e/f96ad08d62f7bd33a5b24e65d4eb220569714b9a2a8813ada2e1fa47b4dd/genai_prices-0.0.67.tar.gz", hash = "sha256:54e07eb6541fda377187a471c5dba21a81b439c57f8dc44d89db3103c29ca343", size = 80015, upload-time = "2026-06-24T20:16:23.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/05/d1ca6b960a3305f86d1c5f4274f2ddf8c94611ec7edc436a01cd38a01742/genai_prices-0.0.67-py3-none-any.whl", hash = "sha256:08977f1e83b4132abcfc60dabf21ff13c2d25958afb9199e59c4407bf5c9ed3f", size = 82495, upload-time = "2026-06-24T20:16:22.4Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -787,6 +828,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/fe/b796087493c3c55371aa58b9f264841ace5bfdf8c668cafa7afa33c44bec/google_genai-2.10.0.tar.gz", hash = "sha256:77912cd558cd7dfd5b75c25fd1c609e78d7954dde583331104022a46ea90f9ee", size = 600039, upload-time = "2026-06-24T01:33:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/39/00bcfd94de255d24249401efff4f48d77bf6066b46447e519fa193c0c299/google_genai-2.10.0-py3-none-any.whl", hash = "sha256:d5350311567ae660c24cbc1752aee4b3d660f89c0106d2dcd2a69978c35afe1e", size = 957974, upload-time = "2026-06-24T01:33:16.296Z" },
 ]
 
 [[package]]
@@ -873,6 +953,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz", hash = "sha256:88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d", size = 64808, upload-time = "2026-06-25T14:16:56.472Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl", hash = "sha256:5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a", size = 80330, upload-time = "2026-06-25T14:16:53.634Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -885,6 +978,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz", hash = "sha256:e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29", size = 83121, upload-time = "2026-06-25T14:16:57.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl", hash = "sha256:3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41", size = 76652, upload-time = "2026-06-25T14:16:55.23Z" },
 ]
 
 [[package]]
@@ -1085,6 +1194,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
     { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
     { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+]
+
+[[package]]
+name = "logfire-api"
+version = "4.37.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/04/471b916249fe7e22056818ca734af46418cd3ff9b9b920c1829c3627b4d2/logfire_api-4.37.0.tar.gz", hash = "sha256:0f62debd6ed593d51307277bd6d5636b57bda07935b5604b96db10fe64441af4", size = 88906, upload-time = "2026-06-12T20:47:08.163Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/2f/23e5b8fa22f75f73965c72e5c29e6fb8715263457394601e254fe26fbe31/logfire_api-4.37.0-py3-none-any.whl", hash = "sha256:1d756f8ba23aa56d438e0ba2c0f529a00fcac975b8785c561b058267f9465088", size = 138710, upload-time = "2026-06-12T20:47:05.526Z" },
 ]
 
 [[package]]
@@ -1849,6 +1967,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1870,6 +2009,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-ai-slim"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/d1/78fd15c9c68b95ac0bec2d2afe22feb3b2f46e4b8e3a6dd1cead61cde434/pydantic_ai_slim-2.1.0.tar.gz", hash = "sha256:f79dca2429dbb9d2e32a0e2c613cfb9b9d6f0dc81d42cff8a5c81ede8ca0a6c7", size = 738698, upload-time = "2026-06-29T09:51:18.634Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/c7/b531cf65a1f8b221ab39739a16fe08f7b6a56fd24db875b9c33010320c9c/pydantic_ai_slim-2.1.0-py3-none-any.whl", hash = "sha256:2afda56459606226113ab433ee659aac7ff29bb66feefa716c67144bd82e5ce2", size = 910109, upload-time = "2026-06-29T09:51:11.016Z" },
+]
+
+[package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
+google = [
+    { name = "google-genai" },
+]
+openai = [
+    { name = "openai" },
+    { name = "tiktoken" },
 ]
 
 [[package]]
@@ -1900,6 +2069,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-graph"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/20/018532c826aba3c29ffc37bda46c20f3db4584bb555a8c7dc2769866267d/pydantic_graph-2.1.0.tar.gz", hash = "sha256:36ed6af24543421fb628fee593ccf5553a286c1dd1677018f5064a4e44c4daba", size = 43052, upload-time = "2026-06-29T09:51:20.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/a8/7f32bdeda6cff28652bba1c21ab2155c81d1733abd4b8bfef46a26e8d3fe/pydantic_graph-2.1.0-py3-none-any.whl", hash = "sha256:bae1e99829abf590a8693442ba5693ace38d2d93a80ae48be55c610a503e3709", size = 50772, upload-time = "2026-06-29T09:51:14.161Z" },
 ]
 
 [[package]]
@@ -2466,6 +2650,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "google", "openai"] },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "scikit-learn" },
@@ -2504,6 +2689,7 @@ requires-dist = [
     { name = "protobuf", specifier = "==6.33.5" },
     { name = "pyarrow", specifier = ">=15.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic-ai-slim", extras = ["openai", "anthropic", "google"], specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -2649,6 +2835,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2772,6 +2967,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/f9/974eafebfd0bd442b8848899fe7d30675c93f750c313e1a6fe61acbde1e3/webob-1.8.10.tar.gz", hash = "sha256:1c963a11f307bc3f624fbab9dde737701eae255f32981b7a5486a88db1767c2b", size = 280796, upload-time = "2026-06-02T19:56:47.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/21/fce134877fb6fc6ad3c464e4a07ede0ee9219f705d26a981ae58ea36ca13/webob-1.8.10-py2.py3-none-any.whl", hash = "sha256:e68ad87fda378191081965ab02a185391c26e4e926adec855c3b0286a8369d49", size = 115825, upload-time = "2026-06-02T19:56:44.765Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Every themefinder LLM call went through a single OpenAI-SDK class (`OpenAILLM`), making provider switching hard. This replaces it with one Pydantic AI-backed `LLM` where the model is a single configurable value — `LLM("openai:gpt-4o")` vs `LLM("anthropic:claude-...")`, or the LiteLLM gateway via `base_url`+`api_key`.

## Changes proposed in this pull request

- **`llm.py`**: `OpenAILLM` → Pydantic AI `LLM` (same `ainvoke`/`invoke` interface). Direct mode (provider-prefixed string), gateway mode (`OpenAIChatModel`+`OpenAIProvider`), or a `Model` instance. Structured output kept on OpenAI-native behaviour via `NativeOutput`.
- **`llm_batch_processor.py`**: provider-agnostic error handling (`ModelHTTPError`/`UnexpectedModelBehavior`); `tiktoken` fallback for non-OpenAI model names.
- **`tasks.py`**: optional `stage_llms` on `find_themes` for per-stage models (backward compatible).
- **Consumers**: pipeline scripts + evals construct `LLM(...)`.
- **Tests**: unit coverage (`FunctionModel`/`TestModel`) + live gateway tests on `gambling_XS` data (skip without creds).
- **Deps**: add `pydantic-ai-slim[openai,anthropic,google]`.

## Guidance to review

`make test` (themefinder) for unit tests. Live tests run automatically when `LLM_GATEWAY_URL`/`LITELLM_CONSULT_OPENAI_API_KEY` are set — currently 8 pass.

## Outstanding (future PRs)

- Clean up and standardise environment variables and secrets.
- Standardise the model-selection registry.
- Improve consistency of langfuse logging.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)