### PR TITLE
Fix e2e test workflow name so the checks can find it

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: Playwright E2E Tests
+name: e2e-tests
 
 on:
   pull_request:


### PR DESCRIPTION
## Context

Branch protection rules currently target the file name, rather than the workflow name

## Changes proposed in this pull request

- change the workflow name to match the file name

## Guidance to review

the PR should be mergeable once approved

