### PR TITLE
Elliotmoore/pro 488 create django admin e2e test

### DIFF
--- a/e2e_tests/tests/admin-dashboard.e2e.ts
+++ b/e2e_tests/tests/admin-dashboard.e2e.ts
@@ -58,7 +58,7 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
     await page.waitForLoadState("networkidle");
     await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
 
-    const checkbox = page.getByRole('checkbox', { name: 'Select this object for an action - Test Consultation at Analysis Stage' });
+const checkbox = page.getByRole('checkbox', { name: `Select this object for an action - ${analysisConsultation.title}` });
     await expect(checkbox).toBeVisible();
     await checkbox.check();
     await expect(checkbox).toBeChecked();

--- a/e2e_tests/tests/admin-dashboard.e2e.ts
+++ b/e2e_tests/tests/admin-dashboard.e2e.ts
@@ -36,9 +36,7 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
       await expect(page).toHaveURL(/\/admin\/consultations\/consultation\/.+/);
 
       await expect(page.getByRole('heading', { name: analysisConsultation.title })).toBeVisible();
-      const title = await page.getByRole('heading', { name: analysisConsultation.title }).textContent();
-      const titleInput = await page.getByRole('textbox', { name: 'Title:' }).inputValue();
-      expect(title).toBe(titleInput);
+      await expect(page.getByRole('textbox', { name: 'Title:' })).toHaveValue(analysisConsultation.title);
 
       const userList = page.getByLabel('Users:');
       await expect(userList).toBeVisible();

--- a/e2e_tests/tests/admin-dashboard.e2e.ts
+++ b/e2e_tests/tests/admin-dashboard.e2e.ts
@@ -25,7 +25,7 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
     await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
     await page.waitForLoadState("networkidle");
     await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
-    const testConsultations = await page.getByRole('link', { name: 'Test Consultation' }).count();
+    const testConsultations = await page.getByRole('link', { name: analysisConsultation.title, exact: true }).count();
     expect(testConsultations).toBe(1);
   });
 
@@ -34,14 +34,14 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
     await page.waitForLoadState("networkidle");
     await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
 
-    const testConsultations = await page.getByRole('link', { name: 'Test Consultation' }).count();
+    const testConsultations = await page.getByRole('link', { name: analysisConsultation.title, exact: true }).count();
     expect(testConsultations).toBe(1);
-    await page.getByRole('link', { name: 'Test Consultation' }).first().click();
+    await page.getByRole('link', { name: analysisConsultation.title, exact: true }).first().click();
     await page.waitForLoadState("networkidle");
     await expect(page).toHaveURL(/\/admin\/consultations\/consultation\/.+/);
 
-    await expect(page.getByRole('heading', { name: 'Test Consultation' })).toBeVisible();
-    const title = await page.getByRole('heading', { name: 'Test Consultation' }).textContent();
+    await expect(page.getByRole('heading', { name: analysisConsultation.title })).toBeVisible();
+    const title = await page.getByRole('heading', { name: analysisConsultation.title }).textContent();
     const titleInput = await page.getByRole('textbox', { name: 'Title:' }).inputValue();
     expect(title).toBe(titleInput);
 
@@ -50,17 +50,7 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
     const userListItems = await userList.locator('option').count();
     expect(userListItems).toBeGreaterThanOrEqual(2);
 
-    let adminUserExists = false;
-    for (let i = 0; i < userListItems; i++) {
-      const userItem = userList.locator('option').nth(i);
-      await expect(userItem).toBeVisible();
-      const userEmail = await userItem.textContent();
-      if (userEmail === defaultUser.email) {
-        adminUserExists = true;
-        break;
-      }
-    }
-    expect(adminUserExists).toBe(true);
+    await expect(userList.locator('option', { hasText: defaultUser.email })).toBeVisible();
   });
 
   test("navigate to consultation list and attempt to clone", async ({ page }) => {
@@ -113,7 +103,7 @@ test.describe("Admin Dashboard - Delete Consultation", () => {
     await page.waitForLoadState("networkidle");
     await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
 
-    const checkbox = page.getByRole('checkbox', { name: 'Select this object for an action - Test Consultation at Analysis Stage' });
+    const checkbox = page.getByRole('checkbox', { name: `Select this object for an action - ${analysisConsultation.title}` });
     await expect(checkbox).toBeVisible();
     await checkbox.check();
     await expect(checkbox).toBeChecked();
@@ -136,7 +126,7 @@ test.describe("Admin Dashboard - Delete Consultation", () => {
     await page.waitForLoadState("networkidle");
     await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
 
-    const testConsultations = await page.getByRole('link', { name: 'Test Consultation' }).count();
+    const testConsultations = await page.getByRole('link', { name: analysisConsultation.title, exact: true }).count();
     expect(testConsultations).toBe(0);
   });
 

--- a/e2e_tests/tests/admin-dashboard.e2e.ts
+++ b/e2e_tests/tests/admin-dashboard.e2e.ts
@@ -1,0 +1,146 @@
+import { test, expect } from "@playwright/test";
+import { CleanupManager, createFixtureData } from "./helpers";
+import { defaultUser, analysisConsultation } from "../fixtures";
+import type { FixtureReference } from "../fixtures";
+
+test.describe("Admin Dashboard - Dashboard Page", () => {
+  const cleanupManager = new CleanupManager();
+  let testData: FixtureReference = {};
+
+  test.beforeAll(async ({ request }) => {
+    testData = await createFixtureData(request, {
+      consultations: [analysisConsultation],
+    });
+    cleanupManager.add(testData);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.goto("/admin");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("navigate to consultation list and assert count", async ({ page }) => {
+    await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+    const testConsultations = await page.getByRole('link', { name: 'Test Consultation' }).count();
+    expect(testConsultations).toBe(1);
+  });
+
+  test("navigate to consultation details and assert metadata", async ({ page }) => {
+    await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+
+    const testConsultations = await page.getByRole('link', { name: 'Test Consultation' }).count();
+    expect(testConsultations).toBe(1);
+    await page.getByRole('link', { name: 'Test Consultation' }).first().click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation\/.+/);
+
+    await expect(page.getByRole('heading', { name: 'Test Consultation' })).toBeVisible();
+    const title = await page.getByRole('heading', { name: 'Test Consultation' }).textContent();
+    const titleInput = await page.getByRole('textbox', { name: 'Title:' }).inputValue();
+    expect(title).toBe(titleInput);
+
+    const userList = page.getByLabel('Users:');
+    await expect(userList).toBeVisible();
+    const userListItems = await userList.locator('option').count();
+    expect(userListItems).toBeGreaterThanOrEqual(2);
+
+    let adminUserExists = false;
+    for (let i = 0; i < userListItems; i++) {
+      const userItem = userList.locator('option').nth(i);
+      await expect(userItem).toBeVisible();
+      const userEmail = await userItem.textContent();
+      if (userEmail === defaultUser.email) {
+        adminUserExists = true;
+        break;
+      }
+    }
+    expect(adminUserExists).toBe(true);
+  });
+
+  test("navigate to consultation list and attempt to clone", async ({ page }) => {
+    await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+
+    const checkbox = page.getByRole('checkbox', { name: 'Select this object for an action - Test Consultation at Analysis Stage' });
+    await expect(checkbox).toBeVisible();
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+
+    const actionSelect = page.getByLabel('Action: --------- Delete');
+    await expect(actionSelect).toBeVisible();
+    await actionSelect.selectOption('create_cloned_consultation');
+    await expect(actionSelect).toHaveValue('create_cloned_consultation');
+
+    const goButton = page.getByRole('button', { name: 'Run' });
+    await expect(goButton).toBeVisible();
+    await goButton.click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+  });
+
+  test.afterAll(async () => {
+    await cleanupManager.cleanup();
+  });
+});
+
+// The delete test is destructive so it gets its own fixture created and
+// cleaned up per test, preventing it from affecting the read-only suite above.
+test.describe("Admin Dashboard - Delete Consultation", () => {
+  const cleanupManager = new CleanupManager();
+  let testData: FixtureReference = {};
+
+  test.beforeEach(async ({ request, page }) => {
+    testData = await createFixtureData(request, {
+      consultations: [analysisConsultation],
+    });
+    cleanupManager.add(testData);
+
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await page.goto("/admin");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("navigate to consultation list and attempt to delete", async ({ page }) => {
+    await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+
+    const checkbox = page.getByRole('checkbox', { name: 'Select this object for an action - Test Consultation at Analysis Stage' });
+    await expect(checkbox).toBeVisible();
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+
+    const actionSelect = page.getByLabel('Action: --------- Delete');
+    await expect(actionSelect).toBeVisible();
+    await actionSelect.selectOption('delete_selected');
+    await expect(actionSelect).toHaveValue('delete_selected');
+
+    const goButton = page.getByRole('button', { name: 'Run' });
+    await expect(goButton).toBeVisible();
+    await goButton.click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+
+    // This button has a special character in it, but that's just django, don't change it
+    const confirmButton = page.getByRole('button', { name: 'Yes, I\u2019m sure' });
+    await expect(confirmButton).toBeVisible();
+    await confirmButton.click();
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+
+    const testConsultations = await page.getByRole('link', { name: 'Test Consultation' }).count();
+    expect(testConsultations).toBe(0);
+  });
+
+  test.afterEach(async () => {
+    await cleanupManager.cleanup();
+  });
+});

--- a/e2e_tests/tests/admin-dashboard.e2e.ts
+++ b/e2e_tests/tests/admin-dashboard.e2e.ts
@@ -58,12 +58,12 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
     await page.waitForLoadState("networkidle");
     await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
 
-const checkbox = page.getByRole('checkbox', { name: `Select this object for an action - ${analysisConsultation.title}` });
+    const checkbox = page.getByRole('checkbox', { name: `Select this object for an action - ${analysisConsultation.title}` });
     await expect(checkbox).toBeVisible();
     await checkbox.check();
     await expect(checkbox).toBeChecked();
 
-    const actionSelect = page.getByLabel('Action: --------- Delete');
+    const actionSelect = page.locator('select[name="action"]');
     await expect(actionSelect).toBeVisible();
     await actionSelect.selectOption('create_cloned_consultation');
     await expect(actionSelect).toHaveValue('create_cloned_consultation');
@@ -108,7 +108,7 @@ test.describe("Admin Dashboard - Delete Consultation", () => {
     await checkbox.check();
     await expect(checkbox).toBeChecked();
 
-    const actionSelect = page.getByLabel('Action: --------- Delete');
+    const actionSelect = page.locator('select[name="action"]');
     await expect(actionSelect).toBeVisible();
     await actionSelect.selectOption('delete_selected');
     await expect(actionSelect).toHaveValue('delete_selected');

--- a/e2e_tests/tests/admin-dashboard.e2e.ts
+++ b/e2e_tests/tests/admin-dashboard.e2e.ts
@@ -21,36 +21,33 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
     await page.waitForLoadState("networkidle");
   });
 
-  test("navigate to consultation list and assert count", async ({ page }) => {
-    await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
-    await page.waitForLoadState("networkidle");
-    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
-    const testConsultations = await page.getByRole('link', { name: analysisConsultation.title, exact: true }).count();
-    expect(testConsultations).toBe(1);
-  });
+  test.describe("Consultation List", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+      const consultationCount = await page.getByRole('link', { name: analysisConsultation.title, exact: true }).count();
+      expect(consultationCount).toBe(1);
+    });
 
-  test("navigate to consultation details and assert metadata", async ({ page }) => {
-    await page.locator('#consultations-consultation').getByRole('link', { name: 'Consultations' }).click();
-    await page.waitForLoadState("networkidle");
-    await expect(page).toHaveURL(/\/admin\/consultations\/consultation/);
+    test("navigate to consultation details and assert metadata", async ({ page }) => {
+      await page.getByRole('link', { name: analysisConsultation.title, exact: true }).first().click();
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(/\/admin\/consultations\/consultation\/.+/);
 
-    const testConsultations = await page.getByRole('link', { name: analysisConsultation.title, exact: true }).count();
-    expect(testConsultations).toBe(1);
-    await page.getByRole('link', { name: analysisConsultation.title, exact: true }).first().click();
-    await page.waitForLoadState("networkidle");
-    await expect(page).toHaveURL(/\/admin\/consultations\/consultation\/.+/);
+      await expect(page.getByRole('heading', { name: analysisConsultation.title })).toBeVisible();
+      const title = await page.getByRole('heading', { name: analysisConsultation.title }).textContent();
+      const titleInput = await page.getByRole('textbox', { name: 'Title:' }).inputValue();
+      expect(title).toBe(titleInput);
 
-    await expect(page.getByRole('heading', { name: analysisConsultation.title })).toBeVisible();
-    const title = await page.getByRole('heading', { name: analysisConsultation.title }).textContent();
-    const titleInput = await page.getByRole('textbox', { name: 'Title:' }).inputValue();
-    expect(title).toBe(titleInput);
+      const userList = page.getByLabel('Users:');
+      await expect(userList).toBeVisible();
+      const userListItems = await userList.locator('option').count();
+      const numberOfTestUsers = 2;
+      expect(userListItems).toBeGreaterThanOrEqual(numberOfTestUsers);
 
-    const userList = page.getByLabel('Users:');
-    await expect(userList).toBeVisible();
-    const userListItems = await userList.locator('option').count();
-    expect(userListItems).toBeGreaterThanOrEqual(2);
-
-    await expect(userList.locator('option', { hasText: defaultUser.email })).toBeVisible();
+      await expect(userList.locator('option', { hasText: defaultUser.email })).toBeVisible();
+    });
   });
 
   test("navigate to consultation list and attempt to clone", async ({ page }) => {

--- a/e2e_tests/tests/support-console-dashboard.e2e.ts
+++ b/e2e_tests/tests/support-console-dashboard.e2e.ts
@@ -5,7 +5,7 @@ import type { FixtureReference } from "../fixtures";
 
 // The User List and Question List groups only read the consultation dashboard,
 // so they share a single fixture created once for the whole block.
-test.describe("Admin Dashboard - Dashboard Page", () => {
+test.describe("Support Console Dashboard - Dashboard Page", () => {
   const cleanupManager = new CleanupManager();
   let testData: FixtureReference = {};
   let consultationId: string;
@@ -90,7 +90,7 @@ test.describe("Admin Dashboard - Dashboard Page", () => {
   });
 });
 
-test.describe("Admin Dashboard - Remove Question", () => {
+test.describe("Support Console Dashboard - Remove Question", () => {
   const cleanupManager = new CleanupManager();
   let testData: FixtureReference = {};
   let consultationId: string;


### PR DESCRIPTION
## Context

We need to update our packages, but some updates break the django admin, these test will ensure that we're confident it still works.

## Changes proposed in this pull request

- Add test to validate we can login to the admin site
- Add test to validate we can kick off a clone of the consultation (this won't work until the batch process is available)
- Add test to validate consultation details load
- Add test to validate consultation can be deleted

## Guidance to review

Run all the tests

## Things to know

If you cancel the run halfway through on the deletion test, you could have a consultation that doesn't get deleted in your test data as the afterAll deletion gets skipped
