### PR TITLE
feature: pro-451 add comprehensive required status checks before merging to

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,16 +1,9 @@
 name: Backend CI
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "backend/**"
-      - "Makefile"
-      - ".github/workflows/backend-ci.yml"
   workflow_dispatch:
-  # Called by deploy-main as a gate before deploying. When called this way the
-  # path filters above do not apply, so the suite always runs in full.
+  # Called by required-checks.yml (PR gate, after path filtering) and deploy-main
+  # (no path filtering — always runs in full before a deploy).
   workflow_call:
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,11 +1,8 @@
 name: e2e-tests
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
-  # Called by deploy-main as a gate before deploying.
+  # Called by required-checks.yml (PR gate) and deploy-main.
   workflow_call:
 
 jobs:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,14 +1,9 @@
 name: Frontend CI
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "frontend/**"
   workflow_dispatch:
-  # Called by deploy-main as a gate before deploying. When called this way the
-  # path filters above do not apply, so the suite always runs in full.
+  # Called by required-checks.yml (PR gate, after path filtering) and deploy-main
+  # (no path filtering — always runs in full before a deploy).
   workflow_call:
 
 env:

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -1,0 +1,54 @@
+name: Required checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'Makefile'
+              - '.github/workflows/backend-ci.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/frontend-ci.yml'
+
+  pre-commit:
+    uses: ./.github/workflows/run_precommit.yml
+
+  backend-ci:
+    needs: [changes, pre-commit]
+    if: needs.changes.outputs.backend == 'true'
+    uses: ./.github/workflows/backend-ci.yml
+
+  frontend-ci:
+    needs: [changes, pre-commit]
+    if: needs.changes.outputs.frontend == 'true'
+    uses: ./.github/workflows/frontend-ci.yml
+
+  e2e-tests:
+    needs: pre-commit
+    uses: ./.github/workflows/e2e-tests.yml
+
+  all-checks-passed:
+    needs: [backend-ci, frontend-ci, e2e-tests, pre-commit]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: All required checks passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/run_precommit.yml
+++ b/.github/workflows/run_precommit.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+  # Called by required-checks.yml on pull requests.
+  workflow_call:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
# Context

GitHub required status checks need a single, always-present check to gate PRs on — but our CI workflows use path filters so they only run when relevant code changes. A check that is skipped (because its paths didn't match) is absent from the PR, which means it cannot be used as a required status check.

Once this change is on main it will be possibe to enable the gate via Settings → Branches → Branch protection rules → main and add Required checks / all-checks-passed as a required status check.

# Changes proposed in this pull request

- Adds `.github/workflows/required-checks.yml`, a new gate workflow that runs on every PR to main. It uses `dorny/paths-filter` to replicate the existing path conditions, calls `backend-ci` and `frontend-ci` conditionally, and always calls `e2e-tests` and `pre-commit`. A final all-checks-passed job succeeds when all dependencies either passed or were skipped, and fails on any failure or cancellation.
- Removes the `pull_request` triggers from `backend-ci.yml`, `frontend-ci.yml`, `e2e-tests.yml`, and `run_precommit.yml` to prevent each CI suite running twice per PR. They are still callable via `workflow_dispatch` and `workflow_call`.
- Adds `workflow_call` to `run_precommit.yml` so it can be invoked by the gate.

# Guidance to review

Verify the path filters in `required-checks.yml` match those previously in `backend-ci.yml` (`backend/**`, `Makefile`, `.github/workflows/backend-ci.yml`) and `frontend-ci.yml` (`frontend/**`).
