### PR TITLE
chore: pro-456 lock preprod environment to prevent ad hoc deployments

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - release-dev-**
-      - release-preprod-**
 
   release:
     types: [published]
@@ -45,8 +44,8 @@ jobs:
       sha-short: ${{ steps.export.outputs.sha-short }}
 
     steps:
-      - name: Validate prod deployment uses a release tag
-        if: github.event_name == 'workflow_dispatch' && inputs.environment == 'prod'
+      - name: Validate preprod/prod deployment uses a release tag
+        if: github.event_name == 'workflow_dispatch' && (inputs.environment == 'preprod' || inputs.environment == 'prod')
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_TAG: ${{ inputs.tag }}
@@ -56,7 +55,7 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             "https://api.github.com/repos/${GH_REPOSITORY}/releases/tags/${INPUT_TAG}")
           if [[ "$HTTP_STATUS" != "200" ]]; then
-            echo "::error::Production deployments must reference a published release tag. Got: '${INPUT_TAG}'"
+            echo "::error::Preprod and production deployments must reference a published release tag. Got: '${INPUT_TAG}'"
             exit 1
           fi
 

--- a/.github/workflows/release-infra.yml
+++ b/.github/workflows/release-infra.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - release-dev-**
-      - release-preprod-**
 
   release:
     types: [published]
@@ -46,8 +45,8 @@ jobs:
       sha-short: ${{ steps.export.outputs.sha-short }}
 
     steps:
-      - name: Validate prod deployment uses a release tag
-        if: github.event_name == 'workflow_dispatch' && inputs.environment == 'prod'
+      - name: Validate preprod/prod deployment uses a release tag
+        if: github.event_name == 'workflow_dispatch' && (inputs.environment == 'preprod' || inputs.environment == 'prod')
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_TAG: ${{ inputs.tag }}
@@ -57,7 +56,7 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             "https://api.github.com/repos/${GH_REPOSITORY}/releases/tags/${INPUT_TAG}")
           if [[ "$HTTP_STATUS" != "200" ]]; then
-            echo "::error::Production deployments must reference a published release tag. Got: '${INPUT_TAG}'"
+            echo "::error::Preprod and production deployments must reference a published release tag. Got: '${INPUT_TAG}'"
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -304,14 +304,8 @@ tf_import:
 
 # Release commands to deploy your app to AWS
 .PHONY: release
-release: ## Deploy app
-## bail if env is not set
-	@if [ -z "$(env)" ]; then \
-		echo "make release requires an env= argument"; \
-		exit 1; \
-	fi
-
-	chmod +x ./terraform/scripts/release.sh && ./terraform/scripts/release.sh $(env)
+release: ## Deploy app to dev (preprod/prod deploy automatically on merge to main, or via workflow_dispatch)
+	chmod +x ./terraform/scripts/release.sh && ./terraform/scripts/release.sh
 
 # Lambda build
 .PHONY: build_lambda_artifacts/ci

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Consult is a web application that combines AI with human oversight to process public consultation responses at scale to inform public policy. Once consultation responses are uploaded to the app, the AI identifies themes across the responses using the [themefinder](https://pypi.org/project/themefinder/) package. Users review and finalise these themes — selecting, editing, or creating new ones — before AI assigns the finalised themes to individual responses. The results are presented in a dashboard for users to analyse and draw insights from.
 
-The repository is split into a Django REST backend (`backend/`), an Astro and Svelte frontend (`frontend/`), AI processing pipelines that run on AWS Batch (`pipeline-sign-off/`, `pipeline-mapping/`), Lambda functions that sync pipeline results to the database (`lambda/`), and Terraform infrastructure (`terraform/`).
+The repository is split into a Django REST backend (`backend/`), an Astro and Svelte frontend (`frontend/`), AI processing pipelines that run on AWS Batch (`pipeline-sign-off/`, `pipeline-mapping/`), Lambda functions that sync pipeline results to the database (`lambda/`), and Terraform infrastructure ([`terraform/`](terraform/README.md)).
 
 > [!IMPORTANT]
 > Incubation Project: This project is an incubation project; as such, we don't recommend using this for critical use cases yet. We are currently in a research stage, trialling the tool for case studies across the Civil Service. If you are a civil servant and wish to take part in our research stage, please contact us at i-dot-ai-enquiries@cabinetoffice.gov.uk.

--- a/docs/release-workflows.md
+++ b/docs/release-workflows.md
@@ -6,12 +6,12 @@ There are two release workflows: `release-app` and `release-infra`. They are ind
 
 | Event | Environment | Notes |
 |---|---|---|
-| Push to `release-ENV-**` tag | dev or preprod | e.g. `release-dev-1.0.0` |
+| Push to `release-ENV-**` tag | dev | e.g. `release-dev-1.0.0`; preprod is no longer reachable via tag push |
 | Merge to `main` (via `deploy-main`) | preprod → prod | Runs the full CI suite, then deploys preprod, then prod only if preprod succeeds |
 | GitHub Release published | prod | Still available; deploys a specific tagged release to prod |
-| `workflow_dispatch` | dev / preprod / prod | Manual trigger; prod requires the tag to be a published GitHub Release |
+| `workflow_dispatch` | dev / preprod / prod | Manual trigger; preprod and prod both require the tag to be a published GitHub Release |
 
-The release-tag guard in `release-app`/`release-infra` only applies to manual dispatches; the `workflow_call` path from `deploy-main` bypasses it, with the full CI suite acting as the gate instead.
+The release-tag guard in `release-app`/`release-infra` applies to manual dispatches targeting preprod or prod; the `workflow_call` path from `deploy-main` bypasses it, with the full CI suite acting as the gate instead.
 
 On merge to main, `deploy-main` calls each release workflow with an explicit `environment`. They filter differently:
 * `release-app` skips individual services whose git SHA matches what is already deployed, so only services with code changes are built and redeployed.
@@ -116,6 +116,12 @@ The **GitHub Release** trigger, by contrast, starts both workflows at the same t
 The standard route is to publish a GitHub Release on GitHub — this triggers both `release-app` and `release-infra` automatically.
 
 Manual (`workflow_dispatch`) deployment to prod is available as an emergency fallback but requires the tag input to reference a published GitHub Release. Arbitrary SHAs or branch names are rejected.
+
+## Deploying to preprod
+
+The standard route is a merge to `main`, which `deploy-main` deploys automatically once CI passes. Ad hoc preprod deploys via tag push are not supported.
+
+Manual (`workflow_dispatch`) deployment to preprod is available as a fallback but, like prod, requires the tag input to reference a published GitHub Release. Arbitrary SHAs or branch names are rejected.
 
 ## Rollback
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -30,21 +30,21 @@
 
 2. **Once the workflow is complete it is ready to be released. PLEASE ENSURE THAT THE BUILD WORKFLOW HAS SUCCEEDED BEFORE THIS NEXT STEP.**
 
-3. **To deploy the app to a test environment run: `make release env=<ENV>`**
-   1. You will only be able to deploy to `dev` or `preprod` through this make command
-   2. This will deploy the image from ECR to the ECS cluster. This will also deploy changes to batch.
+3. **To deploy the app to `dev` run: `make release`**
+   1. This make command only deploys to `dev`. This will deploy the image from ECR to the ECS cluster. This will also deploy changes to batch.
 
 4. **See the changes live**
    1. Once the workflows finishes it will take some time to for ECS to swap out the images
-   2. When completed you will be able to see the changes at:
+   2. When it has completed you will be able to see the changes at:
       1. dev: consult-dev.ai.cabinetoffice.gov.uk
-      2. preprod: consult-preprod.ai.cabinetoffice.gov.uk
 
-5. **To release to `prod`**
+5. **To release to `preprod` or `prod`**
    1. Create a PR to main
-   2. Once approved and merged, this will trigger both a build action.  Please ensure that any terraform changes are PR'd carefully before merging into main, this will affect production deployments.
-   3. When the build has successfully finished it will automatically trigger a release to `prod` to update ECS
+   2. Once approved and merged, this will automatically deploy to `preprod`, then `prod` once the `preprod` deploy succeeds. Please ensure that any terraform changes are PR'd carefully before merging into main, this will affect production deployments.
+   3. `preprod` and `prod` can also be deployed manually via `workflow_dispatch` in GitHub Actions, referencing a published release tag.
+   4. Once completed you will be able to see the changes at:
       1. prod: consult.ai.cabinetoffice.gov.uk
+      2. preprod: consult-preprod.ai.cabinetoffice.gov.uk
 
 ## Passing environment variables into ECS - how to give your docker runtime environment variables.
 1. This is done through `./infrastructure/ecs.tf` in `environment_variables`
@@ -76,4 +76,3 @@
    3. If you're trying this for the first time, here's a massively useful tool:  https://github.com/aws-containers/amazon-ecs-exec-checker
    4. Run this command `aws ecs execute-command --cluster <cluster-name> --task <task-id> --container <container-name> --interactive --command "/bin/sh"
     `
-

--- a/terraform/scripts/release.sh
+++ b/terraform/scripts/release.sh
@@ -1,26 +1,18 @@
 #!/bin/bash
 # Usage:
-## Just pass the name of the env we want to tag and deploy.
-## This will create a tag locally with a format of $$ENV-$BRANCH-$CURRENT_USER-$TIMESTAMP
-## Then push it to the remote git.
-ENV=$1
+## Deploys to dev only, by pushing a release-dev-* tag.
+## preprod and prod both deploy automatically on merge to main (see
+## deploy-main.yml), and can also be deployed manually via workflow_dispatch in
+## GitHub Actions, referencing a published release tag.
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 CURRENT_USER=$(whoami)
 TIMESTAMP=$(date +%d-%m-%y--%H%M%S)
-TAG_NAME="release-$ENV-$BRANCH-$CURRENT_USER-$TIMESTAMP"
+TAG_NAME="release-dev-$BRANCH-$CURRENT_USER-$TIMESTAMP"
 
 echo "Current branch name is" "$BRANCH"
-echo "Current environment name is" "$ENV"
+echo "Deploying to dev"
 echo "Timestamp assigned will be $TIMESTAMP"
 echo "New tag name will be " "$TAG_NAME"
-
-if [ $ENV == 'prod' ]; then
-    echo ''
-    if [ $BRANCH != 'main' ]; then
-        echo -e "\033[0;31mYou can only deploy to prod through a PR into main\033[0m"
-        exit 0
-    fi
-fi
 
 ##
 echo "Removing Local tags"


### PR DESCRIPTION
# Context

Preprod could previously be deployed to ad hoc, outside the normal main → CI → auto-deploy path, in two ways:

1. Pushing a release-preprod-** git tag triggered release-app/release-infra directly against preprod, with no CI gate.
2. Manually dispatching either workflow with environment: preprod accepted any ref (branch, SHA, arbitrary tag) — unlike prod, which already required the dispatched tag to be a published GitHub Release.

This meant preprod didn't reliably reflect what CI had actually passed, undermining its use as a pre-prod gate. This PR locks preprod down to match prod's existing restrictions, so preprod can only be reached via the normal main merge pipeline or a manual dispatch of a previously published release.

# Changes proposed in this pull request

- Removed the release-preprod-** tag-push trigger from release-app.yml and release-infra.yml. Only release-dev-** tag pushes remain (dev ad hoc deploys are unaffected).
- Extended the existing prod-only release-tag validation step to also cover preprod: workflow_dispatch deployments to preprod now require the tag input to match a published GitHub Release, exactly like prod already does. Arbitrary SHAs/branches are rejected with an error.
- Updated docs/release-workflows.md to describe the new restrictions (trigger table, and a new "Deploying to preprod" section mirroring the existing prod one).

The automatic deploy-main → preprod path (triggered via workflow_call after the full CI suite passes on a main merge) is unaffected — the new validation only applies to workflow_dispatch events.

# Guidance to review

- Check the diff on release-app.yml/release-infra.yml: the on.push.tags list and the renamed Validate preprod/prod deployment uses a release tag step.
- Confirm the validation step's condition (inputs.environment == 'preprod' || inputs.environment == 'prod') matches intent — dev remains ungated.
- docs/release-workflows.md changes are documentation-only; worth a read to confirm they accurately describe the new behaviour.