### PR TITLE
PRO-455: Only show Consultations in SETUP stage when finding themes

### DIFF
--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -290,6 +290,15 @@ class ConsultationViewSet(ModelViewSet):
         try:
             consultation = self.get_object()
 
+            if consultation.stage != Consultation.Stage.SETUP:
+                return Response(
+                    {
+                        "error": f"Consultation '{consultation.code}' not in setup stage",
+                        "detail": "ThemeFinder can only process consultations in the setup stage",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             free_text_questions = consultation.question_set.filter(has_free_text=True)
             if not free_text_questions.exists():
                 return Response(
@@ -500,7 +509,15 @@ class ConsultationViewSet(ModelViewSet):
 
         # Build a dict mapping code -> list of consultations (handles one-to-many relationship)
         consultations_by_code: dict[str, list[dict[str, Any]]] = {}
-        for c in Consultation.objects.filter(code__in=s3_codes).values("id", "code", "title"):
+
+        # We only want to show consultations in the setup stage for the find-themes view
+        consultations_filter = (
+            Q(code__in=s3_codes, stage=Consultation.Stage.SETUP)
+            if stage == "find-themes"
+            else Q(code__in=s3_codes)
+        )
+
+        for c in Consultation.objects.filter(consultations_filter).values("id", "code", "title"):
             code = c["code"]
             if code not in consultations_by_code:
                 consultations_by_code[code] = []

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -63,7 +63,11 @@ def staff_user_token(staff_user):
 
 @pytest.fixture
 def consultation(non_staff_user):
-    _consultation = ConsultationFactory(title="My First Consultation", code="my-first-consultation")
+    _consultation = ConsultationFactory(
+        title="My First Consultation",
+        code="my-first-consultation",
+        stage=Consultation.Stage.SETUP,
+    )
     _consultation.users.add(non_staff_user)
     _consultation.save()
     yield _consultation
@@ -410,6 +414,7 @@ def minio_client():
         boto3.client: S3 client configured for MinIO endpoint
     """
     from consultations.utils import s3 as s3_utils
+
     client = s3_utils.get_s3_client()
     return client
 

--- a/backend/tests/unit/api/views/test_consultation_views.py
+++ b/backend/tests/unit/api/views/test_consultation_views.py
@@ -670,10 +670,16 @@ class TestGetConsultationFoldersEndpoint:
     def test_get_folders_find_themes_stage_returns_consultations(self, client, staff_user_token):
         """Test find-themes stage returns consultations with matching S3 folders"""
         # Create consultations with codes matching S3 folders
-        c1 = ConsultationFactory(code="healthcare-2026", title="Healthcare Consultation")
-        c2 = ConsultationFactory(code="transport-2026", title="Transport Consultation")
+        c1 = ConsultationFactory(
+            code="healthcare-2026", title="Healthcare Consultation", stage=Consultation.Stage.SETUP
+        )
+        c2 = ConsultationFactory(
+            code="transport-2026", title="Transport Consultation", stage=Consultation.Stage.SETUP
+        )
         # Create consultation without matching S3 folder
-        ConsultationFactory(code="other-consultation", title="Other")
+        ConsultationFactory(
+            code="other-consultation", title="Other", stage=Consultation.Stage.SETUP
+        )
 
         url = reverse("consultations-folders")
 
@@ -719,8 +725,12 @@ class TestGetConsultationFoldersEndpoint:
 
     def test_get_folders_handles_one_to_many_relationship(self, client, staff_user_token):
         """Test endpoint handles multiple consultations with same code"""
-        c1 = ConsultationFactory(code="healthcare-2026", title="Healthcare Consultation V1")
-        c2 = ConsultationFactory(code="healthcare-2026", title="Healthcare Consultation V2")
+        c1 = ConsultationFactory(
+            code="healthcare-2026", title="Healthcare Consultation V1", stage=Consultation.Stage.SETUP
+        )
+        c2 = ConsultationFactory(
+            code="healthcare-2026", title="Healthcare Consultation V2", stage=Consultation.Stage.SETUP
+        )
 
         url = reverse("consultations-folders")
 
@@ -801,6 +811,21 @@ class TestFindThemesEndpoint:
         Question.objects.create(
             consultation=consultation, number=1, has_free_text=False, text="Test?"
         )
+
+        url = reverse("consultations-find-themes", kwargs={"pk": consultation.id})
+
+        response = client.post(
+            url,
+            headers={"Authorization": f"Bearer {staff_user_token}"},
+        )
+
+        assert response.status_code == 400
+
+    def test_find_themes_rejects_wrong_stage(self, client, staff_user_token, free_text_question):
+        """Test find themes endpoint rejects consultations not in setup stage"""
+        consultation = free_text_question.consultation
+        consultation.stage = Consultation.Stage.FINDING_THEMES
+        consultation.save(update_fields=["stage"])
 
         url = reverse("consultations-find-themes", kwargs={"pk": consultation.id})
 

--- a/backend/tests/unit/api/views/test_consultation_views.py
+++ b/backend/tests/unit/api/views/test_consultation_views.py
@@ -703,6 +703,31 @@ class TestGetConsultationFoldersEndpoint:
             assert result[1]["title"] == "Transport Consultation"
             assert result[1]["id"] == str(c2.id)
 
+    def test_get_folders_find_themes_stage_excludes_non_setup_consultations(
+        self, client, staff_user_token
+    ):
+        """Test find-themes stage excludes consultations not in SETUP stage"""
+        # Matching S3 folder, but not in SETUP stage - should be excluded
+        ConsultationFactory(
+            code="healthcare-2026",
+            title="Healthcare Consultation",
+            stage=Consultation.Stage.FINDING_THEMES,
+        )
+
+        url = reverse("consultations-folders")
+
+        with patch("data_pipeline.s3.get_consultation_folders") as mock_get_folders:
+            mock_get_folders.return_value = ["healthcare-2026", "education-2026"]
+
+            response = client.get(
+                url,
+                {"stage": "find-themes"},
+                headers={"Authorization": f"Bearer {staff_user_token}"},
+            )
+
+            assert response.status_code == 200
+            assert response.json() == []
+
     def test_get_folders_assign_themes_stage_returns_consultations(self, client, staff_user_token):
         """Test assign-themes stage returns consultations with matching S3 folders"""
         c1 = ConsultationFactory(code="healthcare-2026", title="Healthcare Consultation")


### PR DESCRIPTION
## Context
We have found errors created when 'assign themes' was triggered when consultations were at the incorrect stage. There is a fix for this in #1448 . To make this process more robust, we want to make sure that we only trigger the earlier 'finding themes' step for consultations in the SETUP stage.

## Changes proposed in this pull request
* Updates the API to make sure that only consultations in the 'setup' stage are displayed when selecting 'finding themes' in the data pipeline.

## Guidance to review
* If you go to the Data Pipeline stage 2, do you only see consultations in the SETUP stage?

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
