### PR TITLE
chore: pro-493 do not swallow exceptions and add proper exception/warning logging to data pipeline

### DIFF
--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -3,6 +3,7 @@ from collections import Counter, defaultdict
 from typing import Any
 
 import sentry_sdk
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Count, F, Q
@@ -457,7 +458,18 @@ class ConsultationViewSet(ModelViewSet):
         stage = query_serializer.validated_data.get("stage")
 
         # Get all S3 folder codes
-        s3_codes = s3.get_consultation_folders()
+        try:
+            s3_codes = s3.get_consultation_folders()
+        except (ClientError, BotoCoreError) as e:
+            logger.exception("Failed to list consultation folders from S3")
+            sentry_sdk.capture_exception(e)
+            return Response(
+                {
+                    "error": "Failed to list consultation folders",
+                    "detail": str(e) if settings.DEBUG else "An unexpected error occurred",
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
         if not s3_codes:
             return Response([])

--- a/backend/data_pipeline/batch.py
+++ b/backend/data_pipeline/batch.py
@@ -2,6 +2,7 @@ import datetime
 from typing import Literal
 
 import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 
 logger = settings.LOGGER
@@ -57,22 +58,39 @@ def submit_job(
         consultation_name=consultation_name,
     )
 
-    response = batch.submit_job(
-        jobName=job_name,
-        jobQueue=job_queue,
-        jobDefinition=job_definition,
-        containerOverrides={
-            "command": [
-                "--subdir",
-                consultation_code,
-                "--job-type",
-                job_type,
-                "--model-name",
-                model_name,
-            ]
-        },
-        parameters=parameters,
-    )
+    def _log_submit_job_failure(prefix: str) -> None:
+        logger.exception(
+            prefix + " {job_type} batch job for consultation_code={consultation_code} "
+            "(job_queue={job_queue}, job_definition={job_definition})",
+            job_type=job_type,
+            consultation_code=consultation_code,
+            job_queue=job_queue,
+            job_definition=job_definition,
+        )
+
+    try:
+        response = batch.submit_job(
+            jobName=job_name,
+            jobQueue=job_queue,
+            jobDefinition=job_definition,
+            containerOverrides={
+                "command": [
+                    "--subdir",
+                    consultation_code,
+                    "--job-type",
+                    job_type,
+                    "--model-name",
+                    model_name,
+                ]
+            },
+            parameters=parameters,
+        )
+    except (ClientError, BotoCoreError):
+        _log_submit_job_failure("Failed to submit")
+        raise
+    except Exception:
+        _log_submit_job_failure("Unexpected error submitting")
+        raise
 
     job_id = response["jobId"]
     logger.info("Batch job submitted: {job_id}", job_id=job_id)

--- a/backend/data_pipeline/jobs.py
+++ b/backend/data_pipeline/jobs.py
@@ -27,11 +27,21 @@ def import_consultation(
 
     logger.refresh_context()
 
-    return import_consultation_from_s3(
-        consultation_code=consultation_code,
-        consultation_title=consultation_name,
-        user_id=user_id,
-    )
+    try:
+        return import_consultation_from_s3(
+            consultation_code=consultation_code,
+            consultation_title=consultation_name,
+            user_id=user_id,
+        )
+    except Exception:
+        logger.exception(
+            "import_consultation job failed for consultation_code={consultation_code} "
+            "(consultation_name={consultation_name}, user_id={user_id})",
+            consultation_code=consultation_code,
+            consultation_name=consultation_name,
+            user_id=user_id,
+        )
+        raise
 
 
 @job("default", timeout=3600)
@@ -51,16 +61,40 @@ def import_candidate_themes(
 
     logger.refresh_context()
 
-    import_candidate_themes_from_s3(
-        consultation_code=consultation_code,
-        timestamp=run_date,
-    )
+    try:
+        import_candidate_themes_from_s3(
+            consultation_code=consultation_code,
+            timestamp=run_date,
+        )
+    except Exception:
+        logger.exception(
+            "import_candidate_themes_from_s3 failed for consultation_code={consultation_code}, "
+            "run_date={run_date}",
+            consultation_code=consultation_code,
+            run_date=run_date,
+        )
+        raise
 
     # After importing candidate themes, automatically start assign-themes
     # so users can review assigned responses during theme finalisation.
-    consultation = Consultation.objects.get(code=consultation_code)
+    try:
+        consultation = Consultation.objects.get(code=consultation_code)
+    except Exception:
+        logger.exception(
+            "Failed to fetch consultation for consultation_code={consultation_code} "
+            "after importing candidate themes",
+            consultation_code=consultation_code,
+        )
+        raise
 
-    export_candidate_themes_to_s3(consultation)
+    try:
+        export_candidate_themes_to_s3(consultation)
+    except Exception:
+        logger.exception(
+            "export_candidate_themes_to_s3 failed for consultation_code={consultation_code}",
+            consultation_code=consultation_code,
+        )
+        raise
 
     batch.submit_job(
         job_type="ASSIGN_THEMES",
@@ -84,10 +118,19 @@ def import_response_annotations(
 
     logger.refresh_context()
 
-    import_response_annotations_from_s3(
-        consultation_code=consultation_code,
-        timestamp=run_date,
-    )
+    try:
+        import_response_annotations_from_s3(
+            consultation_code=consultation_code,
+            timestamp=run_date,
+        )
+    except Exception:
+        logger.exception(
+            "import_response_annotations job failed for consultation_code={consultation_code}, "
+            "run_date={run_date}",
+            consultation_code=consultation_code,
+            run_date=run_date,
+        )
+        raise
 
 
 @job("default", timeout=3600)
@@ -102,7 +145,16 @@ def import_candidate_theme_responses(
 
     logger.refresh_context()
 
-    import_candidate_theme_responses_from_s3(
-        consultation_code=consultation_code,
-        timestamp=run_date,
-    )
+    try:
+        import_candidate_theme_responses_from_s3(
+            consultation_code=consultation_code,
+            timestamp=run_date,
+        )
+    except Exception:
+        logger.exception(
+            "import_candidate_theme_responses job failed for consultation_code={consultation_code}, "
+            "run_date={run_date}",
+            consultation_code=consultation_code,
+            run_date=run_date,
+        )
+        raise

--- a/backend/data_pipeline/s3.py
+++ b/backend/data_pipeline/s3.py
@@ -1,7 +1,7 @@
 import json
 from typing import Dict, List, Optional
 
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 
 from consultations.utils import s3 as s3_utils
@@ -92,6 +92,9 @@ def get_question_folders(inputs_path: str, bucket_name: str) -> List[str]:
         bucket_name: S3 bucket name
     Returns:
         Sorted list of question folder paths ending with /
+
+    Raises:
+        ClientError | BotoCoreError: If S3 cannot be reached or the request fails.
     """
     s3 = s3_utils.get_s3_client()
 
@@ -105,7 +108,7 @@ def get_question_folders(inputs_path: str, bucket_name: str) -> List[str]:
     if settings.ENVIRONMENT.upper() not in ["LOCAL", "TEST"]:
         params["ExpectedBucketOwner"] = settings.AWS_ACCOUNT_ID
 
-    question_folders = []
+    question_folders: List[str] = []
     continuation_token = None
     page_count = 0
 
@@ -121,7 +124,19 @@ def get_question_folders(inputs_path: str, bucket_name: str) -> List[str]:
         if continuation_token:
             params["ContinuationToken"] = continuation_token
 
-        response = s3.list_objects_v2(**params)
+        try:
+            response = s3.list_objects_v2(**params)
+        except (ClientError, BotoCoreError):
+            logger.exception(
+                "list_objects_v2 failed on page {page} (bucket={bucket}, prefix={prefix}, "
+                "{count} question folders found across {pages} prior page(s))",
+                page=page_count,
+                bucket=bucket_name,
+                prefix=inputs_path,
+                count=len(question_folders),
+                pages=page_count - 1,
+            )
+            raise
 
         # Process directory prefixes (CommonPrefixes contains directories)
         if "CommonPrefixes" in response:
@@ -167,103 +182,109 @@ def get_consultation_folders() -> list[str]:
     prefixes without iterating through individual files. Paginates through all results.
 
     Returns:
-        Sorted list of consultation codes (e.g., ['co_digital_id', 'healthcare-consultation'])
+        Sorted list of consultation codes (e.g., ['co_digital_id', 'healthcare-consultation']).
+        Returns an empty list if no consultation folders exist yet - this is a valid state,
+        not an error.
+
+    Raises:
+        ClientError | BotoCoreError: If S3 cannot be reached or the request fails.
     """
-    try:
-        s3 = s3_utils.get_s3_client()
-        params = {
-            "Bucket": settings.AWS_BUCKET_NAME,
-            "Prefix": "app_data/consultations/",
-            "Delimiter": "/",  # Group by directory to get only top-level consultation folders
-            "MaxKeys": 1000,   # Max allowed per page by AWS
-        }
+    s3 = s3_utils.get_s3_client()
+    params = {
+        "Bucket": settings.AWS_BUCKET_NAME,
+        "Prefix": "app_data/consultations/",
+        "Delimiter": "/",  # Group by directory to get only top-level consultation folders
+        "MaxKeys": 1000,   # Max allowed per page by AWS
+    }
 
-        if settings.ENVIRONMENT.upper() not in ["LOCAL", "TEST"]:
-            params["ExpectedBucketOwner"] = settings.AWS_ACCOUNT_ID
+    if settings.ENVIRONMENT.upper() not in ["LOCAL", "TEST"]:
+        params["ExpectedBucketOwner"] = settings.AWS_ACCOUNT_ID
 
-        s3_codes = set()
-        continuation_token = None
-        page_count = 0
-        total_prefixes_processed = 0
+    s3_codes = set()
+    continuation_token = None
+    page_count = 0
+    total_prefixes_processed = 0
 
-        logger.info(
-            "Starting S3 listing for consultation folders: bucket={bucket}, prefix={prefix}",
-            bucket=settings.AWS_BUCKET_NAME,
-            prefix="app_data/consultations/",
-        )
+    logger.info(
+        "Starting S3 listing for consultation folders: bucket={bucket}, prefix={prefix}",
+        bucket=settings.AWS_BUCKET_NAME,
+        prefix="app_data/consultations/",
+    )
 
-        # Paginate through all results
-        while True:
-            page_count += 1
-            if continuation_token:
-                params["ContinuationToken"] = continuation_token
+    # Paginate through all results
+    while True:
+        page_count += 1
+        if continuation_token:
+            params["ContinuationToken"] = continuation_token
 
+        try:
             response = s3.list_objects_v2(**params)
+        except (ClientError, BotoCoreError):
+            logger.exception(
+                "list_objects_v2 failed on page {page} (bucket={bucket}, prefix={prefix}, "
+                "processed {total} prefixes across {pages} prior page(s))",
+                page=page_count,
+                bucket=settings.AWS_BUCKET_NAME,
+                prefix="app_data/consultations/",
+                total=total_prefixes_processed,
+                pages=page_count - 1,
+            )
+            raise
 
-            # Process directory prefixes (CommonPrefixes contains directories)
-            if "CommonPrefixes" in response:
-                prefixes_in_page = []
-                codes_in_page = []
+        # Process directory prefixes (CommonPrefixes contains directories)
+        if "CommonPrefixes" in response:
+            prefixes_in_page = []
+            codes_in_page = []
 
-                for prefix_info in response["CommonPrefixes"]:
-                    prefix = prefix_info["Prefix"]
-                    prefixes_in_page.append(prefix)
-                    # Extract consultation code: app_data/consultations/CODE/ -> CODE
-                    code = prefix.rstrip("/").split("/")[-1]
-                    s3_codes.add(code)
-                    codes_in_page.append(code)
-                    total_prefixes_processed += 1
+            for prefix_info in response["CommonPrefixes"]:
+                prefix = prefix_info["Prefix"]
+                prefixes_in_page.append(prefix)
+                # Extract consultation code: app_data/consultations/CODE/ -> CODE
+                code = prefix.rstrip("/").split("/")[-1]
+                s3_codes.add(code)
+                codes_in_page.append(code)
+                total_prefixes_processed += 1
 
-                logger.info(
-                    "Page {page}: Found {count} consultation directories",
-                    page=page_count,
-                    count=len(prefixes_in_page),
-                )
-                logger.info(
-                    "Page {page} prefixes: {prefixes}",
-                    page=page_count,
-                    prefixes=prefixes_in_page,
-                )
-                logger.info(
-                    "Page {page} codes extracted: {codes}",
-                    page=page_count,
-                    codes=codes_in_page,
-                )
-            else:
-                logger.info("Page {page}: No CommonPrefixes found", page=page_count)
+            logger.info(
+                "Page {page}: Found {count} consultation directories, prefixes: {prefixes}, "
+                "codes extracted: {codes}",
+                page=page_count,
+                count=len(prefixes_in_page),
+                prefixes=prefixes_in_page,
+                codes=codes_in_page,
+            )
+        else:
+            logger.info("Page {page}: No CommonPrefixes found", page=page_count)
 
-            # Log files if any (shouldn't be any at this level, but good to know)
-            if "Contents" in response:
-                file_count = len(response["Contents"])
-                logger.info(
-                    "Page {page}: Also found {count} files at consultation root level",
-                    page=page_count,
-                    count=file_count,
-                )
+        # Log files if any (shouldn't be any at this level, but good to know)
+        if "Contents" in response:
+            file_count = len(response["Contents"])
+            logger.info(
+                "Page {page}: Also found {count} files at consultation root level",
+                page=page_count,
+                count=file_count,
+            )
 
-            # Check if more pages exist
-            if response.get("IsTruncated", False):
-                continuation_token = response.get("NextContinuationToken")
-                logger.info(
-                    "Page {page}: More results available, continuing pagination (processed {total} prefixes so far)...",
-                    page=page_count,
-                    total=total_prefixes_processed,
-                )
-            else:
-                logger.info(
-                    "Pagination complete after {pages} page(s), processed {total} total prefixes",
-                    pages=page_count,
-                    total=total_prefixes_processed,
-                )
-                break
+        # Check if more pages exist
+        if response.get("IsTruncated", False):
+            continuation_token = response.get("NextContinuationToken")
+            logger.info(
+                "Page {page}: More results available, continuing pagination (processed {total} prefixes so far)...",
+                page=page_count,
+                total=total_prefixes_processed,
+            )
+        else:
+            logger.info(
+                "Pagination complete after {pages} page(s), processed {total} total prefixes",
+                pages=page_count,
+                total=total_prefixes_processed,
+            )
+            break
 
-        sorted_codes = sorted(list(s3_codes))
-        logger.info(
-            "Final result: Found {count} unique consultation codes: {codes}",
-            count=len(sorted_codes),
-            codes=sorted_codes,
-        )
-        return sorted_codes
-    except Exception:
-        logger.exception("Failed to get S3 consultation folders")
-        return []
+    sorted_codes = sorted(list(s3_codes))
+    logger.info(
+        "Final result: Found {count} unique consultation codes: {codes}",
+        count=len(sorted_codes),
+        codes=sorted_codes,
+    )
+    return sorted_codes

--- a/backend/data_pipeline/sync/candidate_themes.py
+++ b/backend/data_pipeline/sync/candidate_themes.py
@@ -2,6 +2,7 @@ import csv
 import io
 from typing import Dict, List, Optional
 
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.db import transaction
 from themefinder.models import ThemeNode
@@ -416,9 +417,19 @@ def export_candidate_themes_to_s3(consultation: Consultation) -> int:
 
         s3_client = s3_utils.get_s3_client()
 
-        s3_client.put_object(
-            Bucket=settings.AWS_BUCKET_NAME, Key=s3_path, Body=csv_buffer.getvalue()
-        )
+        try:
+            s3_client.put_object(
+                Bucket=settings.AWS_BUCKET_NAME, Key=s3_path, Body=csv_buffer.getvalue()
+            )
+        except (ClientError, BotoCoreError):
+            logger.exception(
+                "put_object failed for question {question_number} at {s3_path} "
+                "({exported_so_far} question(s) already exported)",
+                question_number=question.number,
+                s3_path=s3_path,
+                exported_so_far=questions_exported,
+            )
+            raise
 
         logger.info(
             "Exported {themes_count} candidate themes for question {question_number} to {s3_path}",

--- a/backend/data_pipeline/sync/consultation_setup.py
+++ b/backend/data_pipeline/sync/consultation_setup.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 from uuid import UUID
 
 import tiktoken
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.db import transaction
 from django_rq import get_queue
@@ -53,7 +54,17 @@ def load_respondents_from_s3(
 
     logger.info("Loading respondents from {key}", key=key)
 
-    raw_data = s3.read_jsonl(bucket_name, key)
+    try:
+        raw_data = s3.read_jsonl(bucket_name, key)
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(
+            "Failed to load respondents file from S3: bucket={bucket}, key={key}",
+            bucket=bucket_name,
+            key=key,
+        )
+        if isinstance(e, ClientError) and e.response["Error"]["Code"] == "NoSuchKey":
+            raise ValueError(f"Respondents file not found: {key}") from e
+        raise
 
     respondents = [RespondentInput(**data) for data in raw_data]
 
@@ -83,7 +94,17 @@ def load_question_from_s3(
         "Loading question {question_number} from {key}", question_number=question_number, key=key
     )
 
-    data = s3.read_json(bucket_name, key)
+    try:
+        data = s3.read_json(bucket_name, key)
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(
+            "Failed to load question file from S3: bucket={bucket}, key={key}",
+            bucket=bucket_name,
+            key=key,
+        )
+        if isinstance(e, ClientError) and e.response["Error"]["Code"] == "NoSuchKey":
+            raise ValueError(f"Question file not found: {key}") from e
+        raise
 
     if data is None:
         raise ValueError(f"Question file not found or empty: {key}")
@@ -120,6 +141,13 @@ def load_responses_from_s3(
     )
 
     raw_data = s3.read_jsonl(bucket_name, key, raise_if_missing=False)
+    if not raw_data:
+        logger.info(
+            "No responses found for question {question_number} in S3 at {key}",
+            question_number=question_number,
+            key=key,
+        )
+        return []
 
     responses = []
     for data in raw_data:
@@ -158,6 +186,14 @@ def load_multi_choice_from_s3(
     )
 
     raw_data = s3.read_jsonl(bucket_name, key, raise_if_missing=False)
+
+    if not raw_data:
+        logger.info(
+            "No multi-choice data found for question {question_number} in S3 at {key}",
+            question_number=question_number,
+            key=key,
+        )
+        return []
 
     multi_choices = []
     for data in raw_data:

--- a/backend/data_pipeline/sync/response_annotations.py
+++ b/backend/data_pipeline/sync/response_annotations.py
@@ -1,15 +1,16 @@
 from typing import Dict, List, Optional
 
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.db import transaction
 
-import data_pipeline.s3 as s3
 from consultations.models import (
     Consultation,
     Question,
     ResponseAnnotation,
     SelectedTheme,
 )
+from data_pipeline import s3
 from data_pipeline.models import (
     AnnotationBatch,
     DetailDetectionInput,
@@ -54,10 +55,24 @@ def load_selected_themes_from_s3(
 
     logger.info("Loading selected themes from {key}", key=key)
 
-    # Read and parse JSON file
-    theme_data = s3.read_json(
-        bucket_name=bucket_name_str, key=key, raise_if_missing=True
-    )
+    try:
+        # Read and parse JSON file
+        theme_data = s3.read_json(
+            bucket_name=bucket_name_str, key=key, raise_if_missing=True
+        )
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(
+            "Failed to load selected themes from S3 for consultation '{consultation_code}',"
+            " question {question_number}",
+            consultation_code=consultation_code,
+            question_number=question_number
+        )
+        if isinstance(e, ClientError) and e.response["Error"]["Code"] == "NoSuchKey":
+            raise ValueError(
+                f"Selected themes file not found for consultation '{consultation_code}', "
+                f"question {question_number}: {key}"
+            ) from e
+        raise
 
     # Validate each theme using Pydantic
     # Note: theme_data is guaranteed to be non-None because raise_if_missing=True
@@ -99,10 +114,19 @@ def load_sentiments_from_s3(
 
     logger.info("Loading sentiments from {key}", key=key)
 
-    # Read JSONL file (raise_if_missing=False because sentiment is optional)
-    sentiment_data = s3.read_jsonl(
-        bucket_name=bucket_name_str, key=key, raise_if_missing=False
-    )
+    try:
+        # Read JSONL file (raise_if_missing=False because sentiment is optional)
+        sentiment_data = s3.read_jsonl(
+            bucket_name=bucket_name_str, key=key, raise_if_missing=False
+        )
+    except (ClientError, BotoCoreError):
+        logger.exception(
+            "Failed to load sentiments from S3 for consultation '{consultation_code}',"
+            " question {question_number}",
+            consultation_code=consultation_code,
+            question_number=question_number
+        )
+        raise
 
     if not sentiment_data:
         logger.info("No sentiment file found at {key} (this is optional)", key=key)
@@ -147,10 +171,24 @@ def load_detail_detections_from_s3(
 
     logger.info("Loading detail detections from {key}", key=key)
 
-    # Read JSONL file
-    detail_data = s3.read_jsonl(
-        bucket_name=bucket_name_str, key=key, raise_if_missing=True
-    )
+    try:
+        # Read JSONL file
+        detail_data = s3.read_jsonl(
+            bucket_name=bucket_name_str, key=key, raise_if_missing=True
+        )
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(
+            "Failed to load detail detections from S3 for consultation '{consultation_code}',"
+            " question {question_number}",
+            consultation_code=consultation_code,
+            question_number=question_number
+        )
+        if isinstance(e, ClientError) and e.response["Error"]["Code"] == "NoSuchKey":
+            raise ValueError(
+                f"Detail detections file not found for consultation '{consultation_code}', "
+                f"question {question_number}: {key}"
+            ) from e
+        raise
 
     # Validate each item using Pydantic
     validated_details = [DetailDetectionInput(**item) for item in detail_data]
@@ -191,10 +229,24 @@ def load_theme_mappings_from_s3(
 
     logger.info("Loading theme mappings from {key}", key=key)
 
-    # Read JSONL file
-    mapping_data = s3.read_jsonl(
-        bucket_name=bucket_name_str, key=key, raise_if_missing=True
-    )
+    try:
+        # Read JSONL file
+        mapping_data = s3.read_jsonl(
+            bucket_name=bucket_name_str, key=key, raise_if_missing=True
+        )
+    except (ClientError, BotoCoreError) as e:
+        logger.exception(
+            "Failed to load theme mappings from S3 for consultation '{consultation_code}',"
+            " question {question_number}",
+            consultation_code=consultation_code,
+            question_number=question_number
+        )
+        if isinstance(e, ClientError) and e.response["Error"]["Code"] == "NoSuchKey":
+            raise ValueError(
+                f"Theme mappings file not found for consultation '{consultation_code}', "
+                f"question {question_number}: {key}"
+            ) from e
+        raise
 
     # Validate each mapping using Pydantic
     validated_mappings = [ThemeMappingInput(**item) for item in mapping_data]
@@ -247,13 +299,19 @@ def load_annotation_batch(
                 .values_list("number", flat=True)
             )
         except Consultation.DoesNotExist:
+            logger.exception(
+                "Consultation with code '{consultation_code}' does not exist. "
+                "Base consultation data must be imported before annotations.",
+                consultation_code=consultation_code
+            )
             raise ValueError(
                 f"Consultation with code '{consultation_code}' does not exist. "
                 "Base consultation data must be imported before annotations."
             )
 
     logger.info(
-        "Loading annotations for consultation '{consultation_code}' (timestamp: {timestamp}) across {question_count} questions",
+        "Loading annotations for consultation '{consultation_code}' (timestamp: {timestamp}) across "
+        "{question_count} questions",
         consultation_code=consultation_code,
         timestamp=timestamp,
         question_count=len(question_numbers),

--- a/backend/data_pipeline/sync/selected_themes.py
+++ b/backend/data_pipeline/sync/selected_themes.py
@@ -1,6 +1,7 @@
 import csv
 import io
 
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 
 from consultations.constants import NO_REASON_GIVEN_THEME_NAME, OTHER_THEME_NAME
@@ -67,9 +68,19 @@ def export_selected_themes_to_s3(consultation: Consultation) -> int:
             f"app_data/consultations/{consultation.code}/inputs/"
             f"question_part_{question.number}/themes.csv"
         )
-        s3_client.put_object(
-            Bucket=settings.AWS_BUCKET_NAME, Key=s3_path, Body=csv_buffer.getvalue()
-        )
+        try:
+            s3_client.put_object(
+                Bucket=settings.AWS_BUCKET_NAME, Key=s3_path, Body=csv_buffer.getvalue()
+            )
+        except (ClientError, BotoCoreError):
+            logger.exception(
+                "Failed to export selected themes to S3 for consultation '{consultation_code}', "
+                "question {question_number}, s3_path={s3_path}",
+                consultation_code=consultation.code,
+                question_number=question.number,
+                s3_path=s3_path,
+            )
+            raise
 
         logger.info(
             "Exported {themes_count} themes for question {question_number} to {s3_path}",

--- a/backend/tests/unit/data_pipeline/sync/test_consultation_setup.py
+++ b/backend/tests/unit/data_pipeline/sync/test_consultation_setup.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 from django.conf import settings
 from django.db.models import Count
 
@@ -13,10 +14,16 @@ from consultations.models import (
 )
 from data_pipeline.sync.consultation_setup import (
     import_consultation_from_s3,
+    load_question_from_s3,
+    load_respondents_from_s3,
 )
 from factories import UserFactory
 
 logger = settings.LOGGER
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, "GetObject")
 
 
 @pytest.mark.django_db
@@ -248,3 +255,60 @@ class TestImportConsultationFromS3:
                     )
                 except Exception as e:
                     logger.warning("Failed to cleanup object {key}: {e}", key=key, e=e)
+
+
+class TestLoadRespondentsFromS3:
+    @patch("data_pipeline.sync.consultation_setup.s3.read_jsonl")
+    def test_raises_value_error_when_file_missing(self, mock_read_jsonl):
+        mock_read_jsonl.side_effect = _client_error("NoSuchKey")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_respondents_from_s3(
+                consultation_code="test-code",
+                bucket_name="test-bucket",
+            )
+
+        assert "respondents.jsonl" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, ClientError)
+
+    @patch("data_pipeline.sync.consultation_setup.s3.read_jsonl")
+    def test_propagates_non_missing_client_error_unchanged(self, mock_read_jsonl):
+        mock_read_jsonl.side_effect = _client_error("AccessDenied")
+
+        with pytest.raises(ClientError) as exc_info:
+            load_respondents_from_s3(
+                consultation_code="test-code",
+                bucket_name="test-bucket",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+
+
+class TestLoadQuestionFromS3:
+    @patch("data_pipeline.sync.consultation_setup.s3.read_json")
+    def test_raises_value_error_when_file_missing(self, mock_read_json):
+        mock_read_json.side_effect = _client_error("NoSuchKey")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_question_from_s3(
+                consultation_code="test-code",
+                question_number=1,
+                bucket_name="test-bucket",
+            )
+
+        message = str(exc_info.value)
+        assert "question_part_1" in message
+        assert isinstance(exc_info.value.__cause__, ClientError)
+
+    @patch("data_pipeline.sync.consultation_setup.s3.read_json")
+    def test_propagates_non_missing_client_error_unchanged(self, mock_read_json):
+        mock_read_json.side_effect = _client_error("AccessDenied")
+
+        with pytest.raises(ClientError) as exc_info:
+            load_question_from_s3(
+                consultation_code="test-code",
+                question_number=1,
+                bucket_name="test-bucket",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"

--- a/backend/tests/unit/data_pipeline/sync/test_response_annotations.py
+++ b/backend/tests/unit/data_pipeline/sync/test_response_annotations.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from consultations.models import (
     ResponseAnnotation,
@@ -8,6 +9,10 @@ from consultations.models import (
 )
 from data_pipeline.sync.response_annotations import (
     import_response_annotations_from_s3,
+    load_detail_detections_from_s3,
+    load_selected_themes_from_s3,
+    load_sentiments_from_s3,
+    load_theme_mappings_from_s3,
 )
 from factories import (
     ConsultationFactory,
@@ -15,6 +20,10 @@ from factories import (
     RespondentFactory,
     ResponseFactory,
 )
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, "GetObject")
 
 
 @pytest.mark.django_db
@@ -135,3 +144,136 @@ class TestImportResponseAnnotationsFromS3:
         theme_b.refresh_from_db()
         assert theme_a.key == "A"
         assert theme_b.key == "B"
+
+
+class TestLoadSelectedThemesFromS3:
+    @patch("data_pipeline.sync.response_annotations.s3.read_json")
+    def test_raises_value_error_when_themes_file_missing(self, mock_read_json):
+        mock_read_json.side_effect = _client_error("NoSuchKey")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_selected_themes_from_s3(
+                consultation_code="test-code",
+                question_number=1,
+                timestamp="2024-01-20",
+                bucket_name="test-bucket",
+            )
+
+        message = str(exc_info.value)
+        assert "test-code" in message
+        assert "1" in message
+        assert isinstance(exc_info.value.__cause__, ClientError)
+
+    @patch("data_pipeline.sync.response_annotations.s3.read_json")
+    def test_propagates_non_missing_client_error_unchanged(self, mock_read_json):
+        mock_read_json.side_effect = _client_error("AccessDenied")
+
+        with pytest.raises(ClientError) as exc_info:
+            load_selected_themes_from_s3(
+                consultation_code="test-code",
+                question_number=1,
+                timestamp="2024-01-20",
+                bucket_name="test-bucket",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+
+
+class TestLoadSentimentsFromS3:
+    """Sentiment data is optional, so unlike the other loaders a missing file must not raise."""
+
+    @patch("data_pipeline.sync.response_annotations.s3.read_jsonl")
+    def test_returns_empty_list_when_sentiment_file_missing(self, mock_read_jsonl):
+        # read_jsonl itself swallows NoSuchKey and returns [] when raise_if_missing=False,
+        # so that's what load_sentiments_from_s3 sees - it should never observe a NoSuchKey error.
+        mock_read_jsonl.return_value = []
+
+        result = load_sentiments_from_s3(
+            consultation_code="test-code",
+            question_number=1,
+            timestamp="2024-01-20",
+            bucket_name="test-bucket",
+        )
+
+        assert result == []
+        assert mock_read_jsonl.call_args.kwargs["raise_if_missing"] is False
+
+    @patch("data_pipeline.sync.response_annotations.s3.read_jsonl")
+    def test_propagates_other_client_errors(self, mock_read_jsonl):
+        mock_read_jsonl.side_effect = _client_error("AccessDenied")
+
+        with pytest.raises(ClientError) as exc_info:
+            load_sentiments_from_s3(
+                consultation_code="test-code",
+                question_number=1,
+                timestamp="2024-01-20",
+                bucket_name="test-bucket",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+
+
+class TestLoadDetailDetectionsFromS3:
+    @patch("data_pipeline.sync.response_annotations.s3.read_jsonl")
+    def test_raises_value_error_when_file_missing(self, mock_read_jsonl):
+        mock_read_jsonl.side_effect = _client_error("NoSuchKey")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_detail_detections_from_s3(
+                consultation_code="test-code",
+                question_number=2,
+                timestamp="2024-01-20",
+                bucket_name="test-bucket",
+            )
+
+        message = str(exc_info.value)
+        assert "test-code" in message
+        assert "2" in message
+        assert isinstance(exc_info.value.__cause__, ClientError)
+
+    @patch("data_pipeline.sync.response_annotations.s3.read_jsonl")
+    def test_propagates_non_missing_client_error_unchanged(self, mock_read_jsonl):
+        mock_read_jsonl.side_effect = _client_error("AccessDenied")
+
+        with pytest.raises(ClientError) as exc_info:
+            load_detail_detections_from_s3(
+                consultation_code="test-code",
+                question_number=2,
+                timestamp="2024-01-20",
+                bucket_name="test-bucket",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+
+
+class TestLoadThemeMappingsFromS3:
+    @patch("data_pipeline.sync.response_annotations.s3.read_jsonl")
+    def test_raises_value_error_when_file_missing(self, mock_read_jsonl):
+        mock_read_jsonl.side_effect = _client_error("NoSuchKey")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_theme_mappings_from_s3(
+                consultation_code="test-code",
+                question_number=3,
+                timestamp="2024-01-20",
+                bucket_name="test-bucket",
+            )
+
+        message = str(exc_info.value)
+        assert "test-code" in message
+        assert "3" in message
+        assert isinstance(exc_info.value.__cause__, ClientError)
+
+    @patch("data_pipeline.sync.response_annotations.s3.read_jsonl")
+    def test_propagates_non_missing_client_error_unchanged(self, mock_read_jsonl):
+        mock_read_jsonl.side_effect = _client_error("AccessDenied")
+
+        with pytest.raises(ClientError) as exc_info:
+            load_theme_mappings_from_s3(
+                consultation_code="test-code",
+                question_number=3,
+                timestamp="2024-01-20",
+                bucket_name="test-bucket",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"

--- a/backend/tests/unit/data_pipeline/test_batch.py
+++ b/backend/tests/unit/data_pipeline/test_batch.py
@@ -1,18 +1,24 @@
 from unittest.mock import Mock, patch
 
+import pytest
+from botocore.exceptions import ClientError
+
 from data_pipeline.batch import submit_job
 
 
 class TestSubmitBatchJob:
+    @staticmethod
+    def _configure_batch_job_settings(mock_settings, job_type: str) -> None:
+        mock_settings.SUBMIT_BATCH_JOBS = True
+        setattr(mock_settings, f"{job_type}_BATCH_JOB_NAME", f"{job_type.lower()}-job".replace("_", "-"))
+        setattr(mock_settings, f"{job_type}_BATCH_JOB_QUEUE", f"{job_type.lower()}-queue".replace("_", "-"))
+        setattr(mock_settings, f"{job_type}_BATCH_JOB_DEFINITION", f"{job_type.lower()}-def".replace("_", "-"))
+
     @patch("data_pipeline.batch.boto3")
     @patch("data_pipeline.batch.settings")
     def test_submit_find_themes_job(self, mock_settings, mock_boto3):
         """Test submitting a FIND_THEMES batch job"""
-        # Mock settings
-        mock_settings.SUBMIT_BATCH_JOBS = True
-        mock_settings.FIND_THEMES_BATCH_JOB_NAME = "find-themes-job"
-        mock_settings.FIND_THEMES_BATCH_JOB_QUEUE = "find-themes-queue"
-        mock_settings.FIND_THEMES_BATCH_JOB_DEFINITION = "find-themes-def"
+        self._configure_batch_job_settings(mock_settings, "FIND_THEMES")
 
         # Mock boto3 batch client
         mock_batch_client = Mock()
@@ -57,11 +63,7 @@ class TestSubmitBatchJob:
     @patch("data_pipeline.batch.settings")
     def test_submit_assign_themes_job(self, mock_settings, mock_boto3):
         """Test submitting an ASSIGN_THEMES batch job"""
-        # Mock settings
-        mock_settings.SUBMIT_BATCH_JOBS = True
-        mock_settings.ASSIGN_THEMES_BATCH_JOB_NAME = "assign-themes-job"
-        mock_settings.ASSIGN_THEMES_BATCH_JOB_QUEUE = "assign-themes-queue"
-        mock_settings.ASSIGN_THEMES_BATCH_JOB_DEFINITION = "assign-themes-def"
+        self._configure_batch_job_settings(mock_settings, "ASSIGN_THEMES")
 
         # Mock boto3 batch client
         mock_batch_client = Mock()
@@ -115,3 +117,57 @@ class TestSubmitBatchJob:
         # A stub response with a jobId is returned so callers keep working
         assert "jobId" in response
         assert "test-code-3" in response["jobId"]
+
+    @patch("data_pipeline.batch.logger")
+    @patch("data_pipeline.batch.boto3")
+    @patch("data_pipeline.batch.settings")
+    def test_submit_job_reraises_boto_errors(self, mock_settings, mock_boto3, mock_logger):
+        """Boto-specific errors are logged via the ClientError/BotoCoreError branch and re-raised unchanged"""
+        self._configure_batch_job_settings(mock_settings, "FIND_THEMES")
+
+        mock_batch_client = Mock()
+        mock_batch_client.submit_job.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "AccessDenied"}}, "SubmitJob"
+        )
+        mock_boto3.client.return_value = mock_batch_client
+
+        with pytest.raises(ClientError):
+            submit_job(
+                job_type="FIND_THEMES",
+                consultation_code="test-code",
+                consultation_name="Test Consultation",
+                user_id=123,
+                model_name="my-model",
+            )
+
+        mock_logger.exception.assert_called_once()
+        message, kwargs = mock_logger.exception.call_args[0][0], mock_logger.exception.call_args[1]
+        assert "Failed to submit" in message
+        assert kwargs["job_type"] == "FIND_THEMES"
+        assert kwargs["consultation_code"] == "test-code"
+
+    @patch("data_pipeline.batch.logger")
+    @patch("data_pipeline.batch.boto3")
+    @patch("data_pipeline.batch.settings")
+    def test_submit_job_reraises_unexpected_errors(self, mock_settings, mock_boto3, mock_logger):
+        """Non-boto errors hit the separate catch-all branch, are logged, and re-raised, not swallowed"""
+        self._configure_batch_job_settings(mock_settings, "FIND_THEMES")
+
+        mock_batch_client = Mock()
+        mock_batch_client.submit_job.side_effect = ValueError("unexpected failure")
+        mock_boto3.client.return_value = mock_batch_client
+
+        with pytest.raises(ValueError, match="unexpected failure"):
+            submit_job(
+                job_type="FIND_THEMES",
+                consultation_code="test-code",
+                consultation_name="Test Consultation",
+                user_id=123,
+                model_name="my-model",
+            )
+
+        mock_logger.exception.assert_called_once()
+        message, kwargs = mock_logger.exception.call_args[0][0], mock_logger.exception.call_args[1]
+        assert "Unexpected error submitting" in message
+        assert kwargs["job_type"] == "FIND_THEMES"
+        assert kwargs["consultation_code"] == "test-code"


### PR DESCRIPTION
# Context

We had several places in the data pipeline where exceptions were being swallowed or allowed to fail silently, most notably get_consultation_folders() catching every Exception and returning [] on failure — indistinguishable from "no consultations exist yet". This made pipeline failures (S3 outage, permissions issues, etc.) invisible in logs/Sentry and hard to debug. 

This PR removes the silent catches, adds logger.exception logging with useful context (consultation code, question number, S3 key, page/counts where relevant) at every S3/Batch/RQ boundary, and raises more specific errors (e.g. a ValueError naming the exact missing file) instead of a bare ClientError.

# Changes proposed in this pull request

- data_pipeline/s3.py: get_question_folders/get_consultation_folders no longer swallow S3 errors and return an empty list — they now log via logger.exception (with page/prefix/counts-so-far context) and re-raise.
- data_pipeline/batch.py: submit_job logs and re-raises on ClientError/BotoCoreError from AWS Batch instead of letting the failure propagate with no context.
- data_pipeline/jobs.py: all RQ jobs (import_consultation, import_candidate_themes, import_response_annotations, import_candidate_theme_responses) now wrap their work in try/except that logs and re-raises, so RQ correctly marks the job as failed instead of an unlogged exception disappearing into the worker.
- data_pipeline/sync/response_annotations.py & consultation_setup.py: S3 loaders (selected themes, detail detections, theme mappings, respondents, questions) catch ClientError/BotoCoreError, log with consultation/question context, and translate a NoSuchKey error into a specific ValueError naming the missing file (original exception preserved via raise ... from e). Sentiment loading remains intentionally optional — a missing file still returns [] — but any other S3 error is now logged and re-raised instead of swallowed.
- data_pipeline/sync/candidate_themes.py & selected_themes.py: put_object failures during theme export are now logged (including how many questions were already exported before the failure) and re-raised.
- consultations/api/views/consultation.py: the folders endpoint now returns a proper 500 with a Sentry capture when S3 listing fails, rather than an unhandled exception; response detail is only included when settings.DEBUG.
- Tests: added unit tests covering the NoSuchKey → ValueError translation (and that non-NoSuchKey errors propagate unchanged) for load_selected_themes_from_s3, load_detail_detections_from_s3, load_theme_mappings_from_s3, load_respondents_from_s3, load_question_from_s3; plus a test confirming load_sentiments_from_s3 stays silent on a missing (optional) file but still propagates other S3 errors.


# Guidance to review

- get_consultation_folders used to return [] on any error; it now raises. Worth checking there's no other caller relying on the old swallow-and-return-empty behaviour.
- Check the new RQ job re-raises don't produce noisy double-logging given the existing RQ/Sentry failure handling.
- Sanity-check the new error messages (consultation code + question number + S3 key) are what you'd want to see when triaging a failure in logs/Sentry.