### PR TITLE
Update ECS module source reference to v7.1.1-ecs

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -97,7 +97,7 @@ module "frontend" {
   # checkov:skip=CKV_SECRET_4:Skip secret check as these have to be used within the Github Action
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   #source                      = "../../i-dot-ai-core-terraform-modules//modules/infrastructure/ecs" # For testing local changes
-  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v7.1.0-ecs"
+  source                       = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/ecs?ref=v7.1.1-ecs"
   image_tag                    = data.aws_ssm_parameter.image_tags["frontend"].value
   ecr_repository_uri           = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.id}.amazonaws.com/${var.project_name}-frontend"
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id


### PR DESCRIPTION
## Why

GDS Internal Access now exposes OIDC-standard endpoints (`/oauth2/*`) alongside the legacy `/auth/*` family. We're migrating clients over one at a time; this bumps consult onto the current pin.

## What

- Bump the **frontend** ecs module pin `v7.1.0-ecs` → `v7.1.1-ecs`.
- Issuer, `client_id`, `client_secret` and JWKS are unchanged — only the three endpoint URLs move.

## Blast radius / rollback

`terraform plan` should show a change to a single resource — the frontend listener rule's `authenticate_oidc` block (three endpoint strings). Rollback is reverting this line.

## Verification after apply

- Sign in to the frontend through GDS Internal Access and confirm the round-trip completes.
- Confirm the SSO logs show this client's `authorization_request` with `route_family="oauth2"` (was `"legacy"`).
