### PR TITLE
Migrate the 3 lambda functions to structuredlogger

### DIFF
--- a/lambda/import_candidate_themes/code/main.py
+++ b/lambda/import_candidate_themes/code/main.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 import redis  # type: ignore
@@ -28,6 +29,13 @@ if sentry_dsn:
     logger.info("Sentry initialized")
 
 
+def _epoch_ms_to_iso(epoch_ms: int | None) -> str | None:
+    """Convert an AWS Batch epoch-millisecond timestamp to an ISO-8601 string."""
+    if epoch_ms is None:
+        return None
+    return datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=datetime.UTC).isoformat()
+
+
 def lambda_handler(event, context):
     """
     Lambda triggered by EventBridge when find themes batch job completes.
@@ -39,6 +47,8 @@ def lambda_handler(event, context):
     detail = event["detail"]
     job_name = detail["jobName"]
     job_status = detail["status"]
+    start_date_time = _epoch_ms_to_iso(detail.get("startedAt"))
+    end_date_time = _epoch_ms_to_iso(detail.get("stoppedAt"))
 
     parameters = detail["parameters"]
     consultation_code = parameters["consultation_code"]
@@ -50,11 +60,13 @@ def lambda_handler(event, context):
     logger.set_context_field("consultation_code", consultation_code)
 
     logger.info(
-        "Batch job '{job_name}' completed with status: {job_status} consultation_code: {consultation_code} date: {run_date}",
+        "Batch job '{job_name}' completed with status: {job_status} consultation_code: {consultation_code} "
+        "start_date_time: {start_date_time} end_date_time: {end_date_time}",
         job_name=job_name,
         job_status=job_status,
         consultation_code=consultation_code,
-        run_date=run_date,
+        start_date_time=start_date_time,
+        end_date_time=end_date_time,
     )
 
     try:
@@ -103,10 +115,6 @@ def lambda_handler(event, context):
             job_count=len(queue),
         )
 
-    except Exception as e:
-        logger.exception(
-            "Failed to enqueue candidate themes import job: {error} ({exception_type})",
-            error=str(e),
-            exception_type=type(e).__name__,
-        )
+    except Exception:
+        logger.exception("Failed to enqueue candidate themes import job")
         raise

--- a/lambda/import_candidate_themes/code/main.py
+++ b/lambda/import_candidate_themes/code/main.py
@@ -28,13 +28,13 @@ if sentry_dsn:
     logger.info("Sentry initialized")
 
 
-def lambda_handler(event, _context):
+def lambda_handler(event, context):
     """
     Lambda triggered by EventBridge when find themes batch job completes.
 
     Enqueues a Django RQ job to import the candidate themes from S3 to the database.
     """
-    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": _context}])
+    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": context}])
 
     detail = event["detail"]
     job_name = detail["jobName"]

--- a/lambda/import_candidate_themes/code/main.py
+++ b/lambda/import_candidate_themes/code/main.py
@@ -60,6 +60,8 @@ def lambda_handler(event, _context):
     try:
         # Connect to Redis
         redis_host = os.environ.get("REDIS_HOST")
+        if redis_host is None:
+            raise ValueError("REDIS_HOST environment variable is required")
         redis_port = int(os.environ.get("REDIS_PORT", "6379"))
 
         logger.info(

--- a/lambda/import_candidate_themes/code/main.py
+++ b/lambda/import_candidate_themes/code/main.py
@@ -1,13 +1,22 @@
-import logging
 import os
 
 import redis  # type: ignore
 import sentry_sdk
+from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
+from i_dot_ai_utilities.logging.types.enrichment_types import (
+    ContextEnrichmentType,
+    ExecutionEnvironmentType,
+)
+from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 from rq import Queue
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
+logger = StructuredLogger(
+    level="info",
+    options={
+        "execution_environment": ExecutionEnvironmentType.LAMBDA,
+        "log_format": LogOutputFormat.JSON,
+    },
+)
 # Initialize Sentry if DSN is provided
 sentry_dsn = os.environ.get("SENTRY_DSN")
 if sentry_dsn:
@@ -25,6 +34,7 @@ def lambda_handler(event, _context):
 
     Enqueues a Django RQ job to import the candidate themes from S3 to the database.
     """
+    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": _context}])
 
     detail = event["detail"]
     job_name = detail["jobName"]
@@ -36,16 +46,27 @@ def lambda_handler(event, _context):
     user_id = parameters.get("user_id")
     model_name = parameters.get("model_name")
 
-    logger.info(f"Batch job '{job_name}' completed with status: {job_status}")
-    logger.info(f"Consultation code: {consultation_code}")
-    logger.info(f"Run date: {run_date}")
+    logger.set_context_field("batch_job_name", job_name)
+    logger.set_context_field("consultation_code", consultation_code)
+
+    logger.info(
+        "Batch job '{job_name}' completed with status: {job_status} consultation_code: {consultation_code} date: {run_date}",
+        job_name=job_name,
+        job_status=job_status,
+        consultation_code=consultation_code,
+        run_date=run_date,
+    )
 
     try:
         # Connect to Redis
         redis_host = os.environ.get("REDIS_HOST")
         redis_port = int(os.environ.get("REDIS_PORT", "6379"))
 
-        logger.info(f"Connecting to Redis: {redis_host}:{redis_port}")
+        logger.info(
+            "Connecting to Redis: {redis_host}:{redis_port}",
+            redis_host=redis_host,
+            redis_port=redis_port,
+        )
 
         redis_conn = redis.Redis(
             host=redis_host,
@@ -56,7 +77,7 @@ def lambda_handler(event, _context):
 
         # Test Redis connection
         ping_result = redis_conn.ping()
-        logger.info(f"✅ Redis PING result: {ping_result}")
+        logger.info("✅ Redis PING result: {ping_result}", ping_result=ping_result)
 
         # Enqueue the RQ job
         queue_name = "default"
@@ -70,17 +91,20 @@ def lambda_handler(event, _context):
             model_name,
         )
 
-        logger.info("✅ RQ job enqueued successfully!")
-        logger.info(f"Job ID: {job.id}")
-        logger.info(f"Job status: {job.get_status()}")
-        logger.info(f"Queue '{queue_name}' now has {len(queue)} jobs")
-
         logger.info(
-            f"✅ Successfully queued candidate themes import job {job.id} for: {consultation_code}"
+            "✅ Successfully queued candidate themes import job {job_id} for: {consultation_code}. "
+            "Job status: {job_status}, queue '{queue_name}' now has {job_count} jobs",
+            job_id=job.id,
+            consultation_code=consultation_code,
+            job_status=job.get_status(),
+            queue_name=queue_name,
+            job_count=len(queue),
         )
 
     except Exception as e:
-        error_msg = f"Failed to enqueue candidate themes import job: {str(e)}"
-        logger.error(f"ERROR: {error_msg}")
-        logger.error(f"Exception type: {type(e).__name__}")
+        logger.exception(
+            "Failed to enqueue candidate themes import job: {error} ({exception_type})",
+            error=str(e),
+            exception_type=type(e).__name__,
+        )
         raise

--- a/lambda/import_candidate_themes/code/requirements.txt
+++ b/lambda/import_candidate_themes/code/requirements.txt
@@ -2,3 +2,4 @@ redis==5.0.1
 rq==1.15.1
 urllib3==2.7.0
 sentry-sdk==2.59.0
+i-dot-ai-utilities==0.6.0

--- a/lambda/import_response_annotations/code/main.py
+++ b/lambda/import_response_annotations/code/main.py
@@ -61,6 +61,8 @@ def lambda_handler(event, _context):
     try:
         # Connect to Redis
         redis_host = os.environ.get("REDIS_HOST")
+        if redis_host is None:
+            raise ValueError("REDIS_HOST environment variable is required")
         redis_port = int(os.environ.get("REDIS_PORT", "6379"))
 
         logger.info(

--- a/lambda/import_response_annotations/code/main.py
+++ b/lambda/import_response_annotations/code/main.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 import redis  # type: ignore
@@ -28,6 +29,13 @@ if sentry_dsn:
     logger.info("Sentry initialized")
 
 
+def _epoch_ms_to_iso(epoch_ms: int | None) -> str | None:
+    """Convert an AWS Batch epoch-millisecond timestamp to an ISO-8601 string."""
+    if epoch_ms is None:
+        return None
+    return datetime.datetime.fromtimestamp(epoch_ms / 1000, tz=datetime.UTC).isoformat()
+
+
 def lambda_handler(event, context):
     """
     Lambda triggered by EventBridge when assign themes batch job completes.
@@ -39,6 +47,8 @@ def lambda_handler(event, context):
     detail = event["detail"]
     job_name = detail["jobName"]
     job_status = detail["status"]
+    start_date_time = _epoch_ms_to_iso(detail.get("startedAt"))
+    end_date_time = _epoch_ms_to_iso(detail.get("stoppedAt"))
 
     parameters = detail["parameters"]
     consultation_code = parameters["consultation_code"]
@@ -50,11 +60,13 @@ def lambda_handler(event, context):
 
     logger.info(
         "Batch job '{job_name}' completed with status: {job_status} "
-        "consultation_code: {consultation_code} date: {run_date} assignment_target: {assignment_target}",
+        "consultation_code: {consultation_code} start_date_time: {start_date_time} "
+        "end_date_time: {end_date_time} assignment_target: {assignment_target}",
         job_name=job_name,
         job_status=job_status,
         consultation_code=consultation_code,
-        run_date=run_date,
+        start_date_time=start_date_time,
+        end_date_time=end_date_time,
         assignment_target=assignment_target,
     )
 
@@ -111,10 +123,6 @@ def lambda_handler(event, context):
             job_count=len(queue),
         )
 
-    except Exception as e:
-        logger.exception(
-            "Failed to enqueue response annotations import job: {error} ({exception_type})",
-            error=str(e),
-            exception_type=type(e).__name__,
-        )
+    except Exception:
+        logger.exception("Failed to enqueue response annotations import job")
         raise

--- a/lambda/import_response_annotations/code/main.py
+++ b/lambda/import_response_annotations/code/main.py
@@ -1,13 +1,22 @@
-import logging
 import os
 
 import redis  # type: ignore
 import sentry_sdk
+from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
+from i_dot_ai_utilities.logging.types.enrichment_types import (
+    ContextEnrichmentType,
+    ExecutionEnvironmentType,
+)
+from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 from rq import Queue
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
+logger = StructuredLogger(
+    level="info",
+    options={
+        "execution_environment": ExecutionEnvironmentType.LAMBDA,
+        "log_format": LogOutputFormat.JSON,
+    },
+)
 # Initialize Sentry if DSN is provided
 sentry_dsn = os.environ.get("SENTRY_DSN")
 if sentry_dsn:
@@ -25,6 +34,7 @@ def lambda_handler(event, _context):
 
     Enqueues a Django RQ job to import response annotations from S3 to the database.
     """
+    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": _context}])
 
     detail = event["detail"]
     job_name = detail["jobName"]
@@ -35,17 +45,29 @@ def lambda_handler(event, _context):
     run_date = parameters["run_date"]
     assignment_target = parameters.get("assignment_target", "selected_themes")
 
-    logger.info(f"Batch job '{job_name}' completed with status: {job_status}")
-    logger.info(f"Consultation code: {consultation_code}")
-    logger.info(f"Run date: {run_date}")
-    logger.info(f"Assignment target: {assignment_target}")
+    logger.set_context_field("batch_job_name", job_name)
+    logger.set_context_field("consultation_code", consultation_code)
+
+    logger.info(
+        "Batch job '{job_name}' completed with status: {job_status} "
+        "consultation_code: {consultation_code} date: {run_date} assignment_target: {assignment_target}",
+        job_name=job_name,
+        job_status=job_status,
+        consultation_code=consultation_code,
+        run_date=run_date,
+        assignment_target=assignment_target,
+    )
 
     try:
         # Connect to Redis
         redis_host = os.environ.get("REDIS_HOST")
         redis_port = int(os.environ.get("REDIS_PORT", "6379"))
 
-        logger.info(f"Connecting to Redis: {redis_host}:{redis_port}")
+        logger.info(
+            "Connecting to Redis: {redis_host}:{redis_port}",
+            redis_host=redis_host,
+            redis_port=redis_port,
+        )
 
         redis_conn = redis.Redis(
             host=redis_host,
@@ -56,7 +78,7 @@ def lambda_handler(event, _context):
 
         # Test Redis connection
         ping_result = redis_conn.ping()
-        logger.info(f"✅ Redis PING result: {ping_result}")
+        logger.info("✅ Redis PING result: {ping_result}", ping_result=ping_result)
 
         # Enqueue the appropriate RQ job based on assignment target
         queue_name = "default"
@@ -76,18 +98,21 @@ def lambda_handler(event, _context):
             job_timeout=3_600,
         )
 
-        logger.info("✅ RQ job enqueued successfully!")
-        logger.info(f"Job ID: {job.id}")
-        logger.info(f"Job function: {rq_job_name}")
-        logger.info(f"Job status: {job.get_status()}")
-        logger.info(f"Queue '{queue_name}' now has {len(queue)} jobs")
-
         logger.info(
-            f"✅ Successfully queued import job {job.id} for: {consultation_code}"
+            "✅ Successfully queued import job {job_id} ({rq_job_name}) for: {consultation_code}. "
+            "Job status: {job_status}, queue '{queue_name}' now has {job_count} jobs",
+            job_id=job.id,
+            rq_job_name=rq_job_name,
+            consultation_code=consultation_code,
+            job_status=job.get_status(),
+            queue_name=queue_name,
+            job_count=len(queue),
         )
 
     except Exception as e:
-        error_msg = f"Failed to enqueue response annotations import job: {str(e)}"
-        logger.error(f"ERROR: {error_msg}")
-        logger.error(f"Exception type: {type(e).__name__}")
+        logger.exception(
+            "Failed to enqueue response annotations import job: {error} ({exception_type})",
+            error=str(e),
+            exception_type=type(e).__name__,
+        )
         raise

--- a/lambda/import_response_annotations/code/main.py
+++ b/lambda/import_response_annotations/code/main.py
@@ -28,13 +28,13 @@ if sentry_dsn:
     logger.info("Sentry initialized")
 
 
-def lambda_handler(event, _context):
+def lambda_handler(event, context):
     """
     Lambda triggered by EventBridge when assign themes batch job completes.
 
     Enqueues a Django RQ job to import response annotations from S3 to the database.
     """
-    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": _context}])
+    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": context}])
 
     detail = event["detail"]
     job_name = detail["jobName"]

--- a/lambda/import_response_annotations/code/requirements.txt
+++ b/lambda/import_response_annotations/code/requirements.txt
@@ -1,3 +1,4 @@
 redis==4.6.0
 django-rq
 sentry-sdk==2.59.0
+i-dot-ai-utilities==0.6.0

--- a/lambda/slack_notifier/Makefile
+++ b/lambda/slack_notifier/Makefile
@@ -4,5 +4,8 @@ BUILD_DIR=../build/${TOOL_NAME}
 .PHONY: build
 build:
 	rm -rf ${BUILD_DIR}
+	rm -rf code/package
 	mkdir -p -- ${BUILD_DIR}
+	uv pip install -r code/requirements.txt --target code/package
 	cp code/main.py ${BUILD_DIR}/
+	cp -r code/package/* ${BUILD_DIR}/

--- a/lambda/slack_notifier/code/main.py
+++ b/lambda/slack_notifier/code/main.py
@@ -162,10 +162,6 @@ def lambda_handler(event, context):
 
         logger.info("✅ Slack message sent")
 
-    except Exception as e:
-        logger.exception(
-            "Failed to send Slack notification: {error} ({exception_type})",
-            error=str(e),
-            exception_type=type(e).__name__,
-        )
+    except Exception:
+        logger.exception("Failed to send Slack notification")
         raise

--- a/lambda/slack_notifier/code/main.py
+++ b/lambda/slack_notifier/code/main.py
@@ -110,6 +110,9 @@ def send_slack_message(job: dict, consultation: dict, environment: str, user_id:
         )
 
     encoded_msg = json.dumps(message).encode("utf-8")
+    if SLACK_WEBHOOK_URL is None:
+        raise ValueError("SLACK_WEBHOOK_URL environment variable is required")
+
     response = http.request(
         "POST",
         SLACK_WEBHOOK_URL,

--- a/lambda/slack_notifier/code/main.py
+++ b/lambda/slack_notifier/code/main.py
@@ -1,13 +1,23 @@
 import json
-import logging
 import os
 
 import urllib3
+from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
+from i_dot_ai_utilities.logging.types.enrichment_types import (
+    ContextEnrichmentType,
+    ExecutionEnvironmentType,
+)
+from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 
 http = urllib3.PoolManager()
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger = StructuredLogger(
+    level="info",
+    options={
+        "execution_environment": ExecutionEnvironmentType.LAMBDA,
+        "log_format": LogOutputFormat.JSON,
+    },
+)
 
 SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
 
@@ -26,7 +36,9 @@ MESSAGE_TITLE = {
 
 
 def send_slack_message(job: dict, consultation: dict, environment: str, user_id: str):
-    message_title = f"{MESSAGE_TITLE[job['type']][job['status']]} {consultation['name']}"
+    message_title = (
+        f"{MESSAGE_TITLE[job['type']][job['status']]} {consultation['name']}"
+    )
 
     region = os.environ.get("LAMBDA_AWS_REGION", "eu-west-2")
     bucket = os.environ.get("AWS_BUCKET_NAME", "consult-data")
@@ -38,9 +50,7 @@ def send_slack_message(job: dict, consultation: dict, environment: str, user_id:
     else:
         s3_path = f"app_data/consultations/{consultation['code']}/outputs/mapping/"
 
-    s3_url = (
-        f"https://s3.console.aws.amazon.com/s3/buckets/{bucket}?prefix={s3_path}&region={region}"
-    )
+    s3_url = f"https://s3.console.aws.amazon.com/s3/buckets/{bucket}?prefix={s3_path}&region={region}"
 
     message = {
         "text": message_title,
@@ -108,8 +118,12 @@ def send_slack_message(job: dict, consultation: dict, environment: str, user_id:
     )
 
     if response.status != 200:
-        response_data = response.data.decode("utf-8") if response.data else "No response data"
-        error_message = f"Slack webhook failed with status {response.status}: {response_data}"
+        response_data = (
+            response.data.decode("utf-8") if response.data else "No response data"
+        )
+        error_message = (
+            f"Slack webhook failed with status {response.status}: {response_data}"
+        )
         logger.error(error_message)
         raise Exception(error_message)
 
@@ -119,18 +133,27 @@ def lambda_handler(event, _context):
     Lambda handler for sending Slack notifications, triggered by EventBridge,
     when AWS Batch job changes state.
     """
-    logger.info(f"Received event: {json.dumps(event)}")
+    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": _context}])
+
+    logger.info("Received event: {event}", event=json.dumps(event))
 
     detail = event["detail"]
     parameters = detail["parameters"]
 
-    job = {"id": detail["jobId"], "status": detail["status"], "type": parameters["job_type"]}
+    job = {
+        "id": detail["jobId"],
+        "status": detail["status"],
+        "type": parameters["job_type"],
+    }
     consultation = {
         "name": parameters["consultation_name"],
         "code": parameters["consultation_code"],
     }
     environment = os.environ.get("ENVIRONMENT", "unknown")
     user_id = parameters["user_id"]
+
+    logger.set_context_field("batch_job_name", detail.get("jobName", job["type"]))
+    logger.set_context_field("consultation_code", consultation["code"])
 
     send_slack_message(job, consultation, environment, user_id)
 

--- a/lambda/slack_notifier/code/main.py
+++ b/lambda/slack_notifier/code/main.py
@@ -127,37 +127,45 @@ def send_slack_message(job: dict, consultation: dict, environment: str, user_id:
         error_message = (
             f"Slack webhook failed with status {response.status}: {response_data}"
         )
-        logger.error(error_message)
         raise Exception(error_message)
 
 
-def lambda_handler(event, _context):
+def lambda_handler(event, context):
     """
     Lambda handler for sending Slack notifications, triggered by EventBridge,
     when AWS Batch job changes state.
     """
-    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": _context}])
+    logger.refresh_context([{"type": ContextEnrichmentType.LAMBDA, "object": context}])
 
     logger.info("Received event: {event}", event=json.dumps(event))
 
-    detail = event["detail"]
-    parameters = detail["parameters"]
+    try:
+        detail = event["detail"]
+        parameters = detail["parameters"]
 
-    job = {
-        "id": detail["jobId"],
-        "status": detail["status"],
-        "type": parameters["job_type"],
-    }
-    consultation = {
-        "name": parameters["consultation_name"],
-        "code": parameters["consultation_code"],
-    }
-    environment = os.environ.get("ENVIRONMENT", "unknown")
-    user_id = parameters["user_id"]
+        job = {
+            "id": detail["jobId"],
+            "status": detail["status"],
+            "type": parameters["job_type"],
+        }
+        consultation = {
+            "name": parameters["consultation_name"],
+            "code": parameters["consultation_code"],
+        }
+        environment = os.environ.get("ENVIRONMENT", "unknown")
+        user_id = parameters["user_id"]
 
-    logger.set_context_field("batch_job_name", detail.get("jobName", job["type"]))
-    logger.set_context_field("consultation_code", consultation["code"])
+        logger.set_context_field("batch_job_name", detail.get("jobName", job["type"]))
+        logger.set_context_field("consultation_code", consultation["code"])
 
-    send_slack_message(job, consultation, environment, user_id)
+        send_slack_message(job, consultation, environment, user_id)
 
-    logger.info("✅ Slack message sent")
+        logger.info("✅ Slack message sent")
+
+    except Exception as e:
+        logger.exception(
+            "Failed to send Slack notification: {error} ({exception_type})",
+            error=str(e),
+            exception_type=type(e).__name__,
+        )
+        raise

--- a/lambda/slack_notifier/code/requirements.txt
+++ b/lambda/slack_notifier/code/requirements.txt
@@ -1,0 +1,1 @@
+i-dot-ai-utilities==0.6.0

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -50,6 +50,8 @@ module "slack_notifier_lambda" {
     "SLACK_WEBHOOK_URL" = data.aws_ssm_parameter.slack_webhook_url.value,
     "LAMBDA_AWS_REGION" = data.aws_region.current.id,
     "ENVIRONMENT"       = terraform.workspace,
+    "APP_NAME"          = "${var.project_name}-slack-notifier",
+    "REPO"              = var.project_name,
     "AWS_BUCKET_NAME"   = module.app_bucket.id,
     "AWS_ACCOUNT_ID"    = data.aws_caller_identity.current.account_id
   }
@@ -99,6 +101,8 @@ module "import_candidate_themes_lambda" {
     AWS_ACCOUNT_ID    = data.aws_caller_identity.current.account_id
     SENTRY_DSN        = var.backend_sentry_dsn
     ENVIRONMENT       = terraform.workspace
+    APP_NAME          = "${var.project_name}-import-candidate-themes"
+    REPO              = var.project_name
   }
 }
 
@@ -146,5 +150,7 @@ module "import_response_annotations_lambda" {
     AWS_ACCOUNT_ID    = data.aws_caller_identity.current.account_id
     SENTRY_DSN        = var.backend_sentry_dsn
     ENVIRONMENT       = terraform.workspace
+    APP_NAME          = "${var.project_name}-import-response-annotations"
+    REPO              = var.project_name
   }
 }


### PR DESCRIPTION
## Context

All three Lambda entrypoints :`import_candidate_themes`, `import_response_annotations`, and `slack_notifier` — used stdlib `logging` (plain text). Their logs lacked `ship_logs:1`, so the core-logging subscription filter dropped them and they never reached OpenSearch. This migrates them to `StructuredLogger` (i-dot-ai-utilities) so they emit structured JSON that ships to OpenSearch with a per-invocation `context_id` and business context.

**Worth knowing for review:** each Lambda is a self-contained deployment artifact — there is no Django/runtime context inside a Lambda, so they instantiate their own `StructuredLogger` (with `ExecutionEnvironmentType.LAMBDA`) rather than importing the backend's. `slack_notifier` also had no `requirements.txt` and no dependency layer, so its deps are now bundled directly into its zip. The ~80% code overlap between the two import Lambdas is deliberately left as-is here and tracked separately in [PRO-573](https://linear.app/iai-consult/issue/PRO-573/extract-shared-code-across-the-3-lambda-functions) to keep this PR scoped.

## Changes proposed in this pull request

- Instantiate `StructuredLogger` per Lambda (`LAMBDA` execution env, JSON output, `ship_logs=True`).
- `refresh_context()` per invocation with the Lambda enricher (fresh `context_id`, request id, function ARN); set `batch_job_name` and `consultation_code` business context.
- Add `i-dot-ai-utilities==0.6.0` to each `requirements.txt` (new file for `slack_notifier`) and bundle deps into the `slack_notifier` zip via its Makefile.
- Collapse consecutive `logger.info` calls into single structured writes; replace the hand-built error logging with `logger.exception` (one write, auto-attaches traceback).
- Add `APP_NAME` and `REPO` env vars to all three Lambda blocks in terraform (the logger enrichers read them for base context; previously only `ENVIRONMENT` was set), matching the ECS convention.

## Guidance to review

- Key thing to verify: logs actually appear in OpenSearch in **dev** after deploy, carrying `context_id`, `ship_logs:1`, `timestamp`, `level`, `message`, etc.
- Check the `slack_notifier` deployment package stays within Lambda's size limit, since it now bundles `i-dot-ai-utilities` (+ transitive deps like `structlog`) directly rather than via a layer.

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
