### PR TITLE
feature: PRO-497 propagate context id into rq jobs and the pipeline

### DIFF
--- a/backend/consultations/dummy_data.py
+++ b/backend/consultations/dummy_data.py
@@ -3,7 +3,6 @@ from typing import Literal, Optional
 
 import yaml
 from django.conf import settings
-from django_rq import job
 
 from consultations.models import (
     Consultation,
@@ -21,6 +20,7 @@ from factories import (
     SelectedThemeFactory,
 )
 from hosting_environment import HostingEnvironment
+from rq_context import job
 
 logger = settings.LOGGER
 

--- a/backend/consultations/services/clone.py
+++ b/backend/consultations/services/clone.py
@@ -3,7 +3,6 @@ from uuid import UUID
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Model, QuerySet
-from django_rq import job
 
 from consultations.models import (
     CandidateTheme,
@@ -17,6 +16,7 @@ from consultations.models import (
     ResponseAnnotationTheme,
     SelectedTheme,
 )
+from rq_context import job
 
 logger = settings.LOGGER
 

--- a/backend/data_pipeline/batch.py
+++ b/backend/data_pipeline/batch.py
@@ -2,9 +2,10 @@ import datetime
 from typing import Literal
 
 import boto3
-import structlog
 from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
+
+from logging_context import get_or_create_context_id
 
 logger = settings.LOGGER
 
@@ -16,6 +17,7 @@ def submit_job(
     user_id: int,
     model_name: str,
     assignment_target: Literal["selected_themes", "candidate_themes"] = "selected_themes",
+    context_id: str | None = None,
 ) -> dict | None:
     """
     Submit a job to AWS Batch for ThemeFinder processing.
@@ -24,7 +26,14 @@ def submit_job(
     assignment_target controls how the results are imported:
     - "selected_themes": normal flow, imports into ResponseAnnotation
     - "candidate_themes": imports into CandidateThemeResponse (during finalising)
+
+    context_id defaults to the caller's current logging context_id if not supplied,
+    so it propagates through to the Batch job's parameters (and from there to the
+    EventBridge event and the Lambda that imports the results).
     """
+    context_id = context_id or get_or_create_context_id()
+    settings.LOGGER.set_context_field("context_id", context_id)
+
     if not settings.SUBMIT_BATCH_JOBS:
         logger.info(
             "SUBMIT_BATCH_JOBS disabled: skipping real AWS Batch submission for {job_type}",
@@ -49,6 +58,7 @@ def submit_job(
         "model_name": model_name,
         "run_date": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d"),
         "assignment_target": assignment_target,
+        "context_id": context_id,
     }
 
     batch = boto3.client("batch")
@@ -61,7 +71,6 @@ def submit_job(
 
     # Pass the current request's context_id as a CLI arg so the pipeline script's
     # logs can be joined to this request's logs in OpenSearch.
-    context_id = structlog.contextvars.get_contextvars().get("context_id")
     command = [
         "--subdir",
         consultation_code,
@@ -69,9 +78,9 @@ def submit_job(
         job_type,
         "--model-name",
         model_name,
+        "--context-id",
+        context_id,
     ]
-    if context_id:
-        command += ["--context-id", context_id]
 
     def _log_submit_job_failure(prefix: str) -> None:
         logger.exception(

--- a/backend/data_pipeline/jobs.py
+++ b/backend/data_pipeline/jobs.py
@@ -7,7 +7,8 @@ These functions are designed to be executed asynchronously via RQ (Redis Queue).
 from uuid import UUID
 
 from django.conf import settings
-from django_rq import job
+
+from rq_context import job
 
 logger = settings.LOGGER
 
@@ -24,8 +25,6 @@ def import_consultation(
     from data_pipeline.sync.consultation_setup import (
         import_consultation_from_s3,
     )
-
-    logger.refresh_context()
 
     try:
         return import_consultation_from_s3(
@@ -58,8 +57,6 @@ def import_candidate_themes(
         export_candidate_themes_to_s3,
         import_candidate_themes_from_s3,
     )
-
-    logger.refresh_context()
 
     try:
         import_candidate_themes_from_s3(
@@ -116,8 +113,6 @@ def import_response_annotations(
         import_response_annotations_from_s3,
     )
 
-    logger.refresh_context()
-
     try:
         import_response_annotations_from_s3(
             consultation_code=consultation_code,
@@ -142,8 +137,6 @@ def import_candidate_theme_responses(
     from data_pipeline.sync.candidate_themes import (
         import_candidate_theme_responses_from_s3,
     )
-
-    logger.refresh_context()
 
     try:
         import_candidate_theme_responses_from_s3(

--- a/backend/data_pipeline/sync/consultation_setup.py
+++ b/backend/data_pipeline/sync/consultation_setup.py
@@ -5,7 +5,6 @@ import tiktoken
 from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.db import transaction
-from django_rq import get_queue
 
 import data_pipeline.s3 as s3
 from authentication.models import User
@@ -25,6 +24,7 @@ from data_pipeline.models import (
     ResponseInput,
 )
 from embeddings import embed_text
+from rq_context import job
 
 logger = settings.LOGGER
 encoding = tiktoken.encoding_for_model("text-embedding-3-small")
@@ -628,6 +628,7 @@ def _ingest_responses(
 # =============================================================================
 
 
+@job("default", timeout=DEFAULT_TIMEOUT_SECONDS)
 def create_embeddings_for_question(question_id: UUID) -> None:
     """
     Create embeddings for all responses to a question.
@@ -718,7 +719,6 @@ def import_consultation_from_s3(
     # Enqueue async jobs for embeddings
     if enqueue_embeddings:
         consultation = Consultation.objects.get(id=consultation_id)
-        queue = get_queue(default_timeout=DEFAULT_TIMEOUT_SECONDS)
 
         for question in Question.objects.filter(consultation=consultation):
             if question.has_free_text:
@@ -726,7 +726,7 @@ def import_consultation_from_s3(
                     "Enqueueing embedding job for question {question_number}",
                     question_number=question.number,
                 )
-                queue.enqueue(create_embeddings_for_question, question.id)
+                create_embeddings_for_question.enqueue(question.id)
 
     logger.info("Completed S3 import for {consultation_code}", consultation_code=consultation_code)
     return consultation_id

--- a/backend/ingest/jobs.py
+++ b/backend/ingest/jobs.py
@@ -2,9 +2,9 @@ from uuid import UUID
 
 from django.conf import settings
 from django.db import connection
-from django_rq import job
 
 from consultations import models
+from rq_context import job
 
 logger = settings.LOGGER
 
@@ -110,7 +110,6 @@ def delete_consultation_job(consultation_id: UUID):
     Args:
         consultation_id: UUID of the consultation to delete
     """
-    logger.refresh_context()
 
     try:
         # Fetch the consultation from database

--- a/backend/logging_context.py
+++ b/backend/logging_context.py
@@ -1,0 +1,29 @@
+import uuid
+
+import structlog
+from django.conf import settings
+
+
+def get_or_create_context_id() -> str:
+    """Read the context_id currently bound to the logger, to propagate into an enqueued job.
+
+    Mints and binds a fresh one if nothing is bound yet, so callers always get a real,
+    stable id -- and so it sticks for the rest of this thread/process's ambient context,
+    rather than every downstream consumer independently minting its own when nothing
+    was ever bound. There's no non-destructive way to mint just a context_id via the
+    logger itself (refresh_context() would wipe any other fields already bound), so
+    this mints one the same way the library does internally and binds it via
+    set_context_field, consistent with rebind_context below."""
+    context_id = structlog.contextvars.get_contextvars().get("context_id")
+    if not context_id:
+        context_id = str(uuid.uuid4())
+        settings.LOGGER.set_context_field("context_id", context_id)
+    return context_id
+
+
+def rebind_context(context_id: str | None = None) -> None:
+    """Reset the logger context (clears stale fields from any previous job on this worker),
+    then rebind context_id to a propagated value if one was given."""
+    settings.LOGGER.refresh_context()
+    if context_id:
+        settings.LOGGER.set_context_field("context_id", context_id)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -62,6 +62,17 @@ override-dependencies = [
 line-length = 100
 target-version = 'py312'
 
+[tool.ruff.lint]
+extend-select = ["TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"django_rq.job".msg = "Use rq_context.job instead, so context_id propagates into the worker"
+"django_rq.get_queue".msg = "Use an rq_context.job-decorated function's .enqueue()/.delay() instead, so context_id propagates into the worker"
+"django_rq.enqueue".msg = "Use an rq_context.job-decorated function's .enqueue()/.delay() instead, so context_id propagates into the worker"
+
+[tool.ruff.lint.per-file-ignores]
+"rq_context.py" = ["TID251"]
+
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "settings.test"
 filterwarnings = [

--- a/backend/rq_context.py
+++ b/backend/rq_context.py
@@ -1,0 +1,33 @@
+import functools
+
+from django_rq import job as _rq_job
+
+from logging_context import get_or_create_context_id, rebind_context
+
+
+def job(*job_args, **job_kwargs):
+    """Drop-in replacement for django_rq.job that transparently propagates context_id:
+    - at enqueue time (.delay()/.enqueue()), auto-fills context_id from the caller's
+      current logger context if not explicitly supplied
+    - at execution time, strips context_id off and rebinds the worker's logger context
+      to it before running the job body
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def context_aware(*args, context_id: str | None = None, **kwargs):
+            rebind_context(context_id)
+            return func(*args, **kwargs)
+
+        decorated = _rq_job(*job_args, **job_kwargs)(context_aware)
+        enqueue_call = decorated.delay  # .delay and .enqueue are the same underlying function
+
+        @functools.wraps(func)
+        def enqueue_with_context(*args, context_id: str | None = None, **kwargs):
+            return enqueue_call(*args, context_id=context_id or get_or_create_context_id(), **kwargs)
+
+        decorated.delay = enqueue_with_context
+        decorated.enqueue = enqueue_with_context
+        return decorated
+
+    return decorator

--- a/backend/tests/unit/data_pipeline/sync/test_consultation_setup.py
+++ b/backend/tests/unit/data_pipeline/sync/test_consultation_setup.py
@@ -28,8 +28,8 @@ def _client_error(code: str) -> ClientError:
 
 @pytest.mark.django_db
 class TestImportConsultationFromS3:
-    @patch("data_pipeline.sync.consultation_setup.get_queue")
-    def test_import_consultation_from_s3(self, mock_get_queue, minio_test_bucket, minio_client):
+    @patch("data_pipeline.sync.consultation_setup.create_embeddings_for_question.enqueue")
+    def test_import_consultation_from_s3(self, mock_enqueue, minio_test_bucket, minio_client):
         """
         Test importing a complete consultation from S3 with multiple question types.
 
@@ -39,8 +39,6 @@ class TestImportConsultationFromS3:
         - Question 2: Multi choice only
         - Question 3: Hybrid (both free text and multi choice)
         """
-        # Setup: Mock the RQ queue (out of scope for S3 testing)
-        mock_queue = mock_get_queue.return_value
 
         # Track objects we create for cleanup
         created_keys = []
@@ -243,7 +241,7 @@ class TestImportConsultationFromS3:
             assert [opt.text for opt in q3_response_2.chosen_options.all()] == ["Not sure"]
 
             # Verify embedding jobs were enqueued for free text questions only
-            assert mock_queue.enqueue.call_count == 2
+            assert mock_enqueue.call_count == 2
 
         finally:
             # Cleanup: Delete all objects we created

--- a/backend/tests/unit/data_pipeline/test_batch.py
+++ b/backend/tests/unit/data_pipeline/test_batch.py
@@ -15,6 +15,13 @@ class TestSubmitBatchJob:
         setattr(mock_settings, f"{job_type}_BATCH_JOB_QUEUE", f"{job_type.lower()}-queue".replace("_", "-"))
         setattr(mock_settings, f"{job_type}_BATCH_JOB_DEFINITION", f"{job_type.lower()}-def".replace("_", "-"))
 
+    @staticmethod
+    def _context_id_from_command(command: list[str]) -> str | None:
+        """Reads the value following --context-id, wherever it falls in the command list."""
+        if "--context-id" not in command:
+            return None
+        return command[command.index("--context-id") + 1]
+
     @patch("data_pipeline.batch.boto3")
     @patch("data_pipeline.batch.settings")
     def test_submit_find_themes_job(self, mock_settings, mock_boto3):
@@ -78,13 +85,17 @@ class TestSubmitBatchJob:
         mock_boto3.client.return_value = mock_batch_client
 
         # Submit job
-        response = submit_job(
-            job_type="ASSIGN_THEMES",
-            consultation_code="test-code-2",
-            consultation_name="Test Consultation 2",
-            user_id=456,
-            model_name="my-model",
-        )
+        structlog.contextvars.bind_contextvars(context_id="request-context-id-2")
+        try:
+            response = submit_job(
+                job_type="ASSIGN_THEMES",
+                consultation_code="test-code-2",
+                consultation_name="Test Consultation 2",
+                user_id=456,
+                model_name="my-model",
+            )
+        finally:
+            structlog.contextvars.unbind_contextvars("context_id")
 
         # Verify batch client was called correctly
         call_args = mock_batch_client.submit_job.call_args.kwargs
@@ -98,64 +109,72 @@ class TestSubmitBatchJob:
             "ASSIGN_THEMES",
             "--model-name",
             "my-model",
+            "--context-id",
+            "request-context-id-2",
         ]
         assert call_args["parameters"]["job_type"] == "ASSIGN_THEMES"
+        assert call_args["parameters"]["context_id"] == "request-context-id-2"
 
         # Verify response
         assert response["jobId"] == "test-job-id-456"
 
-    @patch("data_pipeline.batch.boto3")
-    @patch("data_pipeline.batch.settings")
-    def test_submit_job_propagates_context_id(self, mock_settings, mock_boto3):
-        """The caller's context_id is appended as --context-id so pipeline logs can be joined"""
-        mock_settings.SUBMIT_BATCH_JOBS = True
-        mock_settings.FIND_THEMES_BATCH_JOB_NAME = "find-themes-job"
-        mock_settings.FIND_THEMES_BATCH_JOB_QUEUE = "find-themes-queue"
-        mock_settings.FIND_THEMES_BATCH_JOB_DEFINITION = "find-themes-def"
-
-        mock_batch_client = Mock()
-        mock_batch_client.submit_job.return_value = {"jobId": "test-job-id-789"}
-        mock_boto3.client.return_value = mock_batch_client
-
-        structlog.contextvars.bind_contextvars(context_id="request-context-abc")
-        try:
-            submit_job(
-                job_type="FIND_THEMES",
-                consultation_code="test-code",
-                consultation_name="Test Consultation",
-                user_id=123,
-                model_name="my-model",
-            )
-        finally:
-            structlog.contextvars.unbind_contextvars("context_id")
-
-        command = mock_batch_client.submit_job.call_args.kwargs["containerOverrides"]["command"]
-        assert "--context-id" in command
-        assert command[command.index("--context-id") + 1] == "request-context-abc"
-
-    @patch("data_pipeline.batch.boto3")
-    @patch("data_pipeline.batch.settings")
-    def test_submit_job_omits_context_id_when_absent(self, mock_settings, mock_boto3):
-        """When no context_id is bound, --context-id is omitted from the command"""
-        mock_settings.SUBMIT_BATCH_JOBS = True
-        mock_settings.FIND_THEMES_BATCH_JOB_NAME = "find-themes-job"
-        mock_settings.FIND_THEMES_BATCH_JOB_QUEUE = "find-themes-queue"
-        mock_settings.FIND_THEMES_BATCH_JOB_DEFINITION = "find-themes-def"
+    def _submit_find_themes_job(self, mock_settings, mock_boto3, **submit_job_kwargs):
+        """Configures FIND_THEMES settings/boto3, calls submit_job with the given kwargs
+        (over sensible defaults), and returns boto3's submit_job call kwargs."""
+        self._configure_batch_job_settings(mock_settings, "FIND_THEMES")
 
         mock_batch_client = Mock()
         mock_batch_client.submit_job.return_value = {"jobId": "test-job-id"}
         mock_boto3.client.return_value = mock_batch_client
 
-        submit_job(
-            job_type="FIND_THEMES",
-            consultation_code="test-code",
-            consultation_name="Test Consultation",
-            user_id=123,
-            model_name="my-model",
-        )
+        kwargs = {
+            "job_type": "FIND_THEMES",
+            "consultation_code": "test-code",
+            "consultation_name": "Test Consultation",
+            "user_id": 123,
+            "model_name": "my-model",
+            **submit_job_kwargs,
+        }
+        submit_job(**kwargs)
 
-        command = mock_batch_client.submit_job.call_args.kwargs["containerOverrides"]["command"]
-        assert "--context-id" not in command
+        return mock_batch_client.submit_job.call_args.kwargs
+
+    @patch("data_pipeline.batch.boto3")
+    @patch("data_pipeline.batch.settings")
+    def test_submit_job_propagates_context_id(self, mock_settings, mock_boto3):
+        """The caller's context_id is appended as --context-id so pipeline logs can be joined"""
+        structlog.contextvars.bind_contextvars(context_id="request-context-abc")
+        try:
+            call_args = self._submit_find_themes_job(mock_settings, mock_boto3)
+        finally:
+            structlog.contextvars.unbind_contextvars("context_id")
+
+        assert self._context_id_from_command(call_args["containerOverrides"]["command"]) == "request-context-abc"
+        assert call_args["parameters"]["context_id"] == "request-context-abc"
+
+    @patch("data_pipeline.batch.boto3")
+    @patch("data_pipeline.batch.settings")
+    def test_submit_job_explicit_context_id_overrides_ambient(self, mock_settings, mock_boto3):
+        """An explicit context_id wins over whatever's ambiently bound, in both the command and parameters"""
+        structlog.contextvars.bind_contextvars(context_id="ambient-id")
+        try:
+            call_args = self._submit_find_themes_job(mock_settings, mock_boto3, context_id="explicit-id")
+        finally:
+            structlog.contextvars.unbind_contextvars("context_id")
+
+        assert self._context_id_from_command(call_args["containerOverrides"]["command"]) == "explicit-id"
+        assert call_args["parameters"]["context_id"] == "explicit-id"
+
+    @patch("data_pipeline.batch.boto3")
+    @patch("data_pipeline.batch.settings")
+    def test_submit_job_mints_context_id_when_absent(self, mock_settings, mock_boto3):
+        """When nothing is bound and nothing explicit is passed, submit_job still mints a
+        real context_id rather than sending an empty one, and command/parameters agree."""
+        call_args = self._submit_find_themes_job(mock_settings, mock_boto3)
+
+        minted = self._context_id_from_command(call_args["containerOverrides"]["command"])
+        assert minted
+        assert call_args["parameters"]["context_id"] == minted
 
     @patch("data_pipeline.batch.boto3")
     @patch("data_pipeline.batch.settings")

--- a/backend/tests/unit/test_rq_context.py
+++ b/backend/tests/unit/test_rq_context.py
@@ -1,0 +1,95 @@
+import pytest
+import structlog
+
+import rq_context
+from logging_context import get_or_create_context_id, rebind_context
+
+
+@pytest.fixture(autouse=True)
+def clear_logging_context():
+    """Tests share process-global structlog contextvars and run with --random-order, so each needs a clean slate."""
+    structlog.contextvars.clear_contextvars()
+    yield
+    structlog.contextvars.clear_contextvars()
+
+
+@rq_context.job("default", timeout=60)
+def probe_job(value):
+    """Module-level so RQ can resolve it by dotted path at execution time."""
+    return get_or_create_context_id(), value
+
+
+@rq_context.job("default", timeout=60)
+def probe_job_kwargs(**kwargs):
+    return kwargs
+
+
+class TestGetOrCreateContextId:
+    def test_mints_and_binds_a_fresh_id_when_nothing_is_bound(self):
+        context_id = get_or_create_context_id()
+
+        assert context_id
+        assert get_or_create_context_id() == context_id  # stayed bound, not re-minted
+
+    def test_returns_the_currently_bound_context_id(self):
+        structlog.contextvars.bind_contextvars(context_id="bound-id")
+
+        assert get_or_create_context_id() == "bound-id"
+
+
+class TestRebindContext:
+    def test_binds_the_given_context_id(self):
+        rebind_context("known-id")
+
+        assert get_or_create_context_id() == "known-id"
+
+    def test_none_mints_a_fresh_context_id(self):
+        rebind_context(None)
+
+        assert get_or_create_context_id() is not None
+
+    def test_clears_fields_set_since_the_previous_call(self):
+        structlog.contextvars.bind_contextvars(consultation_code="stale-value")
+
+        rebind_context("known-id")
+
+        assert "consultation_code" not in structlog.contextvars.get_contextvars()
+
+
+class TestRQContextJob:
+    """rq_context.job auto-fills context_id at enqueue time and rebinds it at execution time;
+       ASYNC=False in tests runs .delay()/.enqueue() through the real path."""
+
+    def test_ambient_context_id_survives_a_real_delay_round_trip(self):
+        """Proves context_id survives the full enqueue -> execution round trip;
+           the job.kwargs check rules out a same-process leak masquerading as propagation."""
+        rebind_context("ambient-real-id")
+
+        job = probe_job.delay(42)
+
+        assert job.kwargs == {"context_id": "ambient-real-id"}
+        assert job.return_value() == ("ambient-real-id", 42)
+
+    def test_explicit_context_id_overrides_ambient_on_enqueue(self):
+        rebind_context("ambient-id")
+
+        job = probe_job.delay(7, context_id="explicit-id")
+
+        assert job.kwargs == {"context_id": "explicit-id"}
+
+    def test_context_id_is_stripped_and_never_reaches_the_job_body(self):
+        result = probe_job_kwargs(foo="bar", context_id="explicit-id")
+
+        assert result == {"foo": "bar"}
+
+    def test_stale_context_from_a_previous_call_does_not_leak(self):
+        """One job's context_id must never bleed into the next job on a long-lived worker."""
+        probe_job(1, context_id="first-call-id")
+
+        seen_context_id, _ = probe_job(2)
+
+        assert seen_context_id != "first-call-id"
+
+    def test_delay_and_enqueue_are_the_same_wrapped_function(self):
+        """Production calls both .delay() and .enqueue(); this is the only test guarding .enqueue."""
+        assert probe_job.delay is probe_job.enqueue

--- a/lambda/import_candidate_themes/code/main.py
+++ b/lambda/import_candidate_themes/code/main.py
@@ -55,9 +55,11 @@ def lambda_handler(event, context):
     run_date = parameters["run_date"]
     user_id = parameters.get("user_id")
     model_name = parameters.get("model_name")
+    context_id = parameters.get("context_id")
 
     logger.set_context_field("batch_job_name", job_name)
     logger.set_context_field("consultation_code", consultation_code)
+    logger.set_context_field("context_id", context_id)
 
     logger.info(
         "Batch job '{job_name}' completed with status: {job_status} consultation_code: {consultation_code} "
@@ -103,6 +105,7 @@ def lambda_handler(event, context):
             run_date,
             user_id,
             model_name,
+            context_id=context_id,
         )
 
         logger.info(

--- a/lambda/import_response_annotations/code/main.py
+++ b/lambda/import_response_annotations/code/main.py
@@ -54,9 +54,11 @@ def lambda_handler(event, context):
     consultation_code = parameters["consultation_code"]
     run_date = parameters["run_date"]
     assignment_target = parameters.get("assignment_target", "selected_themes")
+    context_id = parameters.get("context_id")
 
     logger.set_context_field("batch_job_name", job_name)
     logger.set_context_field("consultation_code", consultation_code)
+    logger.set_context_field("context_id", context_id)
 
     logger.info(
         "Batch job '{job_name}' completed with status: {job_status} "
@@ -110,6 +112,7 @@ def lambda_handler(event, context):
             consultation_code,
             run_date,
             job_timeout=3_600,
+            context_id=context_id,
         )
 
         logger.info(


### PR DESCRIPTION
# Context

PRO-496 (this branch's base) got context_id from the originating HTTP request through to the Batch container's own logs — via a request middleware, a --context-id CLI arg on the pipeline scripts, and a shared pipeline-common logging bootstrap. This PR closes the other half of the loop: RQ jobs.

Before this, every RQ job called logger.refresh_context() as its first line, which unconditionally mints a brand-new random context_id. So even once a request's id reached the Batch container correctly, any RQ job triggered along the way — or by the EventBridge → Lambda import step — logged under a completely unrelated id, breaking end-to-end correlation for exactly the actions you'd most want to trace (Find Themes, consultation setup, etc.).

What might surprise a reviewer: this isn't "thread a context_id parameter through every job function by hand." It's a decorator, rq_context.job, a drop-in replacement for django_rq.job, that auto-fills context_id at enqueue time from whatever's ambient in the calling process and strips/rebinds it at execution time. That means job bodies and most enqueue call sites needed zero code changes — only the job import swapped. Also worth flagging: while touching batch.py's existing context_id handling (from PRO-496), found and fixed a latent bug where the --context-id CLI arg and parameters["context_id"] could diverge — two independent reads of contextvars — whenever an explicit context_id was passed to submit_job. Dormant today (no caller does that yet), but fixed and tested here since it's the same code path this PR is already touching.

# Changes proposed in this pull request

- New backend/rq_context.py — job() decorator. Auto-fills context_id on .delay()/.enqueue() from the caller's ambient logging context (unless explicitly passed); strips it and rebinds the worker's logger context before the job body runs.
- New backend/logging_context.py — get_context_id() / rebind_context(), the primitives the decorator (and batch.py) build on.
- backend/data_pipeline/jobs.py, backend/ingest/jobs.py, backend/consultations/dummy_data.py, backend/consultations/services/clone.py, backend/data_pipeline/sync/consultation_setup.py — swap django_rq.job → rq_context.job; drop the now-redundant manual logger.refresh_context() calls. create_embeddings_for_question (previously a bare function enqueued via get_queue().enqueue(...)) is now itself a decorated job, so it gets propagation for free too.
- backend/data_pipeline/batch.py — submit_job gains an optional context_id param defaulting to the ambient value; included in the Batch parameters dict ("" not None — AWS requires a string) so it rides through to the EventBridge event. Fixed the CLI-arg/parameters divergence noted above by reusing one resolved value for both.
- backend/pyproject.toml — a ruff flake8-tidy-imports banned-api rule blocks from django_rq import job outside rq_context.py, so a future job can't silently opt out of propagation.
- Tests — new backend/tests/unit/test_rq_context.py (execution-time strip/rebind, enqueue-time auto-fill/override, a real unmocked .delay() round trip, the .delay/.enqueue aliasing guarantee); backend/tests/unit/data_pipeline/test_batch.py extended to assert context_id lands correctly in both parameters and the CLI arg across ambient/explicit/absent cases.

# Guidance to review

- backend/rq_context.py is the core of the change — it leans on an RQ internal (f.delay = delay; f.enqueue = delay), so worth checking the enqueue-time/execution-time split holds. test_rq_context.py::test_ambient_context_id_survives_a_real_delay_round_trip demonstrates it end-to-end rather than just against a mock.
- That round-trip test runs a real (unmocked) .delay() — needs RQ_QUEUES ASYNC=False (already set in test settings) and a live Redis (already a CI/local-dev dependency for other tests).
- Lambda-side forwarding — reading context_id out of detail.parameters and passing it into the enqueued import job — is intentionally not part of this PR; tracked separately.