### PR TITLE
Fix for breaking node change from v24 to v26

### DIFF
--- a/frontend/src/components/data/StepOneBPage/StepOneBPage.svelte
+++ b/frontend/src/components/data/StepOneBPage/StepOneBPage.svelte
@@ -14,11 +14,11 @@
   import Panel from "../../dashboard/Panel/Panel.svelte";
   import { makeSnippet } from "../../../global/utils";
 
-  let checkedItems: string[] = $state(getStoredItems() || []);
+  let checkedItems: string[] = $derived(getStoredItems() || []);
 
   export const LEARNINGS_DISPLAYED_KEY = "dataSetupLearningsDisplayed";
 
-  let displayLearnings = $state(!localStorage.getItem(LEARNINGS_DISPLAYED_KEY));
+  let displayLearnings = $derived(!localStorage?.getItem(LEARNINGS_DISPLAYED_KEY));
 
   const CHECKLIST_A_ITEMS = [
     {
@@ -131,11 +131,11 @@
   }
 
   function getStoredItems(): string[] {
-    const storedItemsString = localStorage.getItem("dataSetupCheckedItems");
+    const storedItemsString = localStorage?.getItem("dataSetupCheckedItems");
     return storedItemsString ? JSON.parse(storedItemsString) : [];
   }
   function setStoredItems(newItems: string[]) {
-    localStorage.setItem("dataSetupCheckedItems", JSON.stringify(newItems));
+    localStorage?.setItem("dataSetupCheckedItems", JSON.stringify(newItems));
   }
   function addToStorage(itemKey: string) {
     const storedItems = getStoredItems();
@@ -167,7 +167,7 @@
   }
 
   function handlePersistentClose() {
-    localStorage.setItem(LEARNINGS_DISPLAYED_KEY, "true");
+    localStorage?.setItem(LEARNINGS_DISPLAYED_KEY, "true");
     displayLearnings = false;
   }
 </script>


### PR DESCRIPTION
## Context
In Node 26, localStorage returns undefined. This breaks the logic of StepOneBPage component that relies on the previous return value.

## Changes proposed in this pull request
This PR adds guards around localStorage access.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
