### PR TITLE
Stop swallowing exceptions that hide failures in the rest of

### DIFF
--- a/backend/consultations/admin.py
+++ b/backend/consultations/admin.py
@@ -79,7 +79,13 @@ def import_candidate_themes_from_s3_job(modeladmin, request, queryset):
         try:
             import_candidate_themes.enqueue(consultation.code, consultation.timestamp)
         except Exception as e:
-            logger.error("failed to start import_candidate_themes: {error}", error=e)
+            logger.exception(
+                "failed to start import_candidate_themes for {code}", code=consultation.code
+            )
+            messages.error(
+                request,
+                f"Failed to start import for '{consultation.code}': {e}",
+            )
 
 
 @admin.action(description="Clone consultation")

--- a/backend/consultations/admin.py
+++ b/backend/consultations/admin.py
@@ -78,13 +78,13 @@ def import_candidate_themes_from_s3_job(modeladmin, request, queryset):
         )
         try:
             import_candidate_themes.enqueue(consultation.code, consultation.timestamp)
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "failed to start import_candidate_themes for {code}", code=consultation.code
             )
             messages.error(
                 request,
-                f"Failed to start import for '{consultation.code}': {e}",
+                f"Failed to start import for '{consultation.code}' (see logs for details)",
             )
 
 

--- a/backend/consultations/api/filters.py
+++ b/backend/consultations/api/filters.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import Count
 from django_filters import CharFilter, UUIDFilter
 from django_filters.rest_framework import BaseInFilter, BooleanFilter, FilterSet
@@ -8,6 +9,8 @@ from rest_framework.filters import SearchFilter
 from authentication.models import User
 from consultations.models import DemographicOption, Response
 from embeddings import embed_text
+
+logger = settings.LOGGER
 
 
 class ResponseFilter(FilterSet):
@@ -39,6 +42,9 @@ class ResponseFilter(FilterSet):
             )
         except (AttributeError, IndexError, ValueError):
             # Malformed filter value — fall back to no filtering rather than erroring.
+            logger.warning(
+                "Ignoring malformed unseenResponsesOnly filter value: {value}", value=value
+            )
             return queryset
 
         if show_unseen_only:

--- a/backend/consultations/api/filters.py
+++ b/backend/consultations/api/filters.py
@@ -38,6 +38,7 @@ class ResponseFilter(FilterSet):
                 else bool(value)
             )
         except (AttributeError, IndexError, ValueError):
+            # Malformed filter value — fall back to no filtering rather than erroring.
             return queryset
 
         if show_unseen_only:

--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -260,7 +260,9 @@ class ConsultationViewSet(ModelViewSet):
                 status=status.HTTP_202_ACCEPTED,
             )
         except serializers.ValidationError as e:
-            logger.exception("Consultation setup request failed validation")
+            logger.warning(
+                "Consultation setup request failed validation: {detail}", detail=e.detail
+            )
             sentry_sdk.capture_exception(e)
             return Response(
                 {"message": "An error occurred while starting the import"},

--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -260,12 +260,14 @@ class ConsultationViewSet(ModelViewSet):
                 status=status.HTTP_202_ACCEPTED,
             )
         except serializers.ValidationError as e:
+            logger.exception("Consultation setup request failed validation")
             sentry_sdk.capture_exception(e)
             return Response(
                 {"message": "An error occurred while starting the import"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as e:
+            logger.exception("Failed to start consultation setup import job")
             sentry_sdk.capture_exception(e)
             return Response(
                 {"message": "An error occurred while starting the import"},
@@ -396,6 +398,10 @@ class ConsultationViewSet(ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as e:
+            logger.exception(
+                "Failed to export selected themes to S3 for consultation {consultation_code}",
+                consultation_code=consultation.code,
+            )
             sentry_sdk.capture_exception(e)
             return Response(
                 {
@@ -414,6 +420,10 @@ class ConsultationViewSet(ModelViewSet):
                 model_name=consultation.model_name,
             )
         except Exception as e:
+            logger.exception(
+                "Failed to submit ASSIGN_THEMES batch job for consultation {consultation_code}",
+                consultation_code=consultation.code,
+            )
             sentry_sdk.capture_exception(e)
             return Response(
                 {
@@ -550,8 +560,13 @@ class ConsultationViewSet(ModelViewSet):
                 status=status.HTTP_201_CREATED,
             )
         except Exception as e:
+            logger.exception(
+                "Failed to add users to consultation {consultation_id}",
+                consultation_id=str(consultation.id),
+            )
+            sentry_sdk.capture_exception(e)
             return Response(
-                {"error": f"An error occurred: {str(e)}"},
+                {"error": "Failed to add users to consultation"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -822,10 +837,19 @@ class ConsultationViewSet(ModelViewSet):
         try:
             export_selected_themes_to_s3(target)
         except Exception as e:
-            logger.error("S3 export failed after theme import: {error}", error=str(e))
+            logger.exception(
+                "S3 export failed after theme import for consultation {consultation_id} "
+                "({imported} themes saved to the database)",
+                consultation_id=str(target.id),
+                imported=imported_themes,
+            )
+            sentry_sdk.capture_exception(e)
             return Response(
                 {
-                    "error": f"Themes were saved to the database ({imported_themes} imported) but S3 export failed: {e}",
+                    "error": (
+                        f"Themes were saved to the database ({imported_themes} imported) "
+                        "but S3 export failed"
+                    ),
                     "total_themes_imported": imported_themes,
                 },
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/backend/ingest/jobs.py
+++ b/backend/ingest/jobs.py
@@ -161,11 +161,10 @@ def delete_consultation_job(consultation_id: UUID):
             consultation_id=consultation_id,
         )
 
-    except Exception as e:
-        logger.error(
-            "Error deleting consultation '{consultation_title}' (ID: {consultation_id}): {error}",
+    except Exception:
+        logger.exception(
+            "Error deleting consultation '{consultation_title}' (ID: {consultation_id})",
             consultation_title=consultation_title,
             consultation_id=consultation_id,
-            error=e,
         )
         raise


### PR DESCRIPTION
## Context

Follow-up to PRO-493 (which scoped the fix to `data_pipeline/`). The same log-and-swallow pattern exists elsewhere in the backend: some `except` blocks leaked raw exception text to clients, others reported to Sentry only (so failures never reached OpenSearch), and one logged without a traceback. This PR covers those remaining call/suage sites.

Closes PRO-520.

## Changes proposed in this pull request

- **Stop leaking raw exception text to clients:**  `add_users` and `import_finalised_themes` no longer return `str(e)`/`{e}` in the HTTP response body; they return a generic message instead.
- **Route Sentry-only failures through the structured logger:**  `setup_consultation`, `assign_themes` (S3 export + batch submit), and `import_finalised_themes` now `logger.exception(...)` so failures reach OpenSearch (in addition to Sentry).
- **Log the full traceback on consultation deletion failure:**  `delete_consultation_job` used `logger.error` (message only); switched to `logger.exception` (re-raise retained).
- **Surface admin failures:** the candidate-themes admin action logs the traceback and shows the error via `messages.error` instead of silently continuing.
- **Document an intentional fallback:**  added an inline comment on the malformed-filter swallow in `ResponseFilter.filter_seen`.

## Things to check

- [x] No new ENV vars
