### PR TITLE
feature: pro-499 add real worker healthcheck

### DIFF
--- a/backend/consultations/management/commands/healthcheck_worker.py
+++ b/backend/consultations/management/commands/healthcheck_worker.py
@@ -1,0 +1,47 @@
+import socket
+from datetime import datetime, timezone
+
+import redis
+from django.core.management.base import BaseCommand, CommandError
+from django_rq import get_connection
+from rq.defaults import DEFAULT_WORKER_TTL
+from rq.worker import Worker
+
+# A worker only re-heartbeats every ~30s while a job is running. While idle - its normal
+# state - RQ's dequeue loop blocks for up to worker_ttl - 15 (~405s by default) between
+# heartbeats, so basing the threshold on worker_ttl (rather than the job-monitoring
+# interval) avoids false positives on healthy idle workers. This is RQ's *default*
+# worker_ttl, not something read from the live worker; if start-worker.sh ever overrides
+# it, update this too.
+STALE_HEARTBEAT_SECONDS = DEFAULT_WORKER_TTL + 120
+
+
+class Command(BaseCommand):
+    help = (
+        "Checks that an RQ worker is registered for this host and has a recent heartbeat. "
+        "Exits non-zero otherwise; intended for use as an ECS container health check."
+    )
+
+    def handle(self, *args, **options):
+        connection = get_connection("default")
+        hostname = socket.gethostname()
+
+        try:
+            worker = next(
+                (w for w in Worker.all(connection=connection) if w.hostname == hostname), None
+            )
+        except redis.exceptions.RedisError as exc:
+            raise CommandError(f"Could not reach Redis: {exc}") from exc
+        if worker is None:
+            raise CommandError(f"No RQ worker registered for host '{hostname}'")
+
+        if worker.last_heartbeat is None:
+            raise CommandError(f"RQ worker '{worker.name}' has no recorded heartbeat")
+
+        age_seconds = (datetime.now(timezone.utc) - worker.last_heartbeat).total_seconds()
+        if age_seconds > STALE_HEARTBEAT_SECONDS:
+            raise CommandError(
+                f"RQ worker '{worker.name}' heartbeat is stale ({age_seconds:.0f}s old)"
+            )
+
+        self.stdout.write("ok")

--- a/backend/tests/unit/test_healthcheck_worker.py
+++ b/backend/tests/unit/test_healthcheck_worker.py
@@ -1,0 +1,65 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+import redis
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django_rq import get_connection
+from rq.utils import now, utcformat
+from rq.worker import Worker
+
+from consultations.management.commands.healthcheck_worker import STALE_HEARTBEAT_SECONDS
+
+
+def _deregister_stray_workers(connection):
+    for worker in Worker.all(connection=connection):
+        worker.register_death()
+
+
+@pytest.fixture(autouse=True)
+def clean_worker_registry():
+    """A leftover worker key from a previous failed run would false-negative these
+    tests, since the command matches on hostname and the test host is fixed."""
+    connection = get_connection("default")
+    _deregister_stray_workers(connection)
+    yield
+    _deregister_stray_workers(connection)
+
+
+@pytest.fixture
+def rq_worker():
+    worker = Worker(["default"], connection=get_connection("default"))
+    worker.register_birth()
+    return worker
+
+
+@pytest.fixture
+def rq_worker_with_no_heartbeat(rq_worker):
+    rq_worker.connection.hdel(rq_worker.key, "last_heartbeat")
+    return rq_worker
+
+
+class TestHealthcheckWorker:
+    def test_fails_when_no_worker_is_registered(self):
+        with pytest.raises(CommandError, match="No RQ worker registered"):
+            call_command("healthcheck_worker")
+
+    def test_fails_when_a_worker_has_no_heartbeat(self, rq_worker_with_no_heartbeat):
+        with pytest.raises(CommandError, match="has no recorded heartbeat"):
+            call_command("healthcheck_worker")
+
+    def test_succeeds_when_a_worker_has_a_fresh_heartbeat(self, rq_worker):
+        call_command("healthcheck_worker")
+
+    def test_fails_when_the_worker_heartbeat_is_stale(self, rq_worker):
+        stale_heartbeat = now() - timedelta(seconds=STALE_HEARTBEAT_SECONDS + 1)
+        rq_worker.connection.hset(rq_worker.key, "last_heartbeat", utcformat(stale_heartbeat))
+
+        with pytest.raises(CommandError, match="heartbeat is stale"):
+            call_command("healthcheck_worker")
+
+    def test_fails_with_a_clear_message_when_redis_is_unreachable(self):
+        with patch("rq.worker.Worker.all", side_effect=redis.exceptions.ConnectionError("boom")):
+            with pytest.raises(CommandError, match="Could not reach Redis"):
+                call_command("healthcheck_worker")

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -190,13 +190,16 @@ module "worker" {
 
   container_port = local.backend_port
 
-  health_check = {
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    accepted_response   = "200"
-    path                = "/"
-    timeout             = 6
-    port                = 8000
+  # The worker runs `manage.py rqworker` (backend/start-worker.sh), not an HTTP server, so
+  # this uses a command-based container health check backed by the RQ worker's own Redis
+  # heartbeat rather than an ALB-style HTTP probe.
+  http_healthcheck = false
+  container_healthcheck = {
+    command     = ["CMD-SHELL", "venv/bin/python3.12 manage.py healthcheck_worker"]
+    interval    = 60
+    timeout     = 20
+    retries     = 3
+    startPeriod = 60
   }
 
   autoscaling_minimum_target = 3


### PR DESCRIPTION
## Context

The worker ECS service had an HTTP-based health_check left over from copying the backend's config, but the worker container only ever runs `manage.py rqworker default` (`backend/start-worker.sh`) — there's no HTTP server for anything to hit.

It was more broken than just using the wrong protocol though: the worker module set `create_networking = false`, so the ECS service never registered its tasks in that target group and since `http_healthcheck` wasn't overridden it defaulted to `true`, which explicitly nulls out the container-level healthcheck too. Net effect: the worker had **no functioning health check at all**, just a dead config block referencing an endpoint that never existed.

## Changes proposed in this pull request

- **New management command** `backend/consultations/management/commands/healthcheck_worker.py` — checks that an RQ worker is registered in Redis for the current hostname and that its `last_heartbeat` is recent. Raises an error otherwise. This catches a hung/stuck worker as well as a crashed one, which a plain process-liveness check wouldn't.
- **`terraform/ecs.tf`** — worker module now sets `http_healthcheck = false` and a `container_healthcheck` that runs the new healthcheck.
- **Tests** (`backend/tests/unit/test_healthcheck_worker.py`) covering: no worker registered, a worker with a fresh heartbeat, and a worker with a stale heartbeat.

## Note

The tests added here cover the Django `healthecheck_worker` command, but it would have been non-trivial to add tests for the full container healthcheck itself due to the lack of testing framework for this. I've added https://linear.app/iai-consult/issue/PRO-600/no-container-testing-framework as a tech debt ticket for us to consider if we should add this in future.

## Guidance to review

- The core question is whether the hostname-matching approach in `healthcheck_worker.py` is sound: one `rqworker` process runs per ECS task/container (`start-worker.sh`), and each Fargate task gets its own hostname, so matching on `socket.gethostname()` should reliably identify "this container's worker" — but worth a second pair of eyes given it's the crux of the check.
- The timeout value is fixed to 4 times the default heartbeat interval - open to suggestions of an alternative. If the heartbeat interval is overridden in `start-worker.sh` this wouldn't be picked up and I couldn't see a way around that.