### PR TITLE
Feature/add dependabot trinkets

### DIFF
--- a/.github/scripts/create_linear_issue.py
+++ b/.github/scripts/create_linear_issue.py
@@ -57,11 +57,12 @@ def resolve_team(api_key: str, team_key: str) -> dict:
         }
     """, {"key": team_key})
 
-    teams = (resp.get("data") or {}).get("teams", {}).get("nodes", [])
-    if not teams:
+    try:
+        team = resp["data"]["teams"]["nodes"][0]
+    except (KeyError, IndexError):
         print(f"ERROR: could not find a Linear team with key '{team_key}'")
         sys.exit(1)
-    return teams[0]
+    return team
 
 
 def resolve_assignee_id(api_key: str, team_key: str) -> str | None:
@@ -79,14 +80,15 @@ def resolve_assignee_id(api_key: str, team_key: str) -> str | None:
         }
     """, {"key": team_key})
 
-    teams = (resp.get("data") or {}).get("teams", {}).get("nodes", [])
-    if not teams:
+    try:
+        team = resp["data"]["teams"]["nodes"][0]
+    except (KeyError, IndexError):
         print(f"WARNING: could not find a Linear team with key '{team_key}'")
         return None
 
-    pool = [u for u in teams[0]["members"]["nodes"] if u["isAssignable"]]
+    pool = [u for u in team["members"]["nodes"] if u["isAssignable"]]
     if not pool:
-        print(f"WARNING: team '{teams[0]['name']}' has no assignable members")
+        print(f"WARNING: team '{team['name']}' has no assignable members")
         return None
 
     chosen = random.choice(pool)

--- a/.github/scripts/create_linear_issue.py
+++ b/.github/scripts/create_linear_issue.py
@@ -129,10 +129,10 @@ def attach_pr(api_key: str, issue_id: str, pr_url: str, pr_title: str) -> None:
 
     success = (resp.get("data") or {}).get("attachmentLinkURL", {}).get("success")
     if success:
-        print(f"Attached PR to Linear issue")
+        print("Attached PR to Linear issue")
     else:
         # Non-fatal: issue was created, attachment is best-effort
-        print(f"WARNING: failed to attach PR URL to Linear issue")
+        print("WARNING: failed to attach PR URL to Linear issue")
         print(json.dumps(resp, indent=2))
 
 

--- a/.github/scripts/create_linear_issue.py
+++ b/.github/scripts/create_linear_issue.py
@@ -1,13 +1,21 @@
 """
-Create a Linear issue in the configured team's "In Review" state for a major dependency bump,
-randomly assigned to a member of the configured assignee team.
+Create a Linear issue for Dependabot PR events, randomly assigned to a member
+of the configured assignee team.
 
-Required environment variables:
+Supports two issue types, selected via the ISSUE_TYPE environment variable:
+
+  major-bump  - A major version dependency bump requiring manual review.
+  ci-failure  - CI checks failed on a minor/patch Dependabot PR.
+
+Required environment variables (all types):
   LINEAR_API_KEY                - Linear personal API key (lin_api_*)
-  LINEAR_TEAM_KEY               - Key of the Linear team to create the issue in (e.g. "PRO")
+  LINEAR_TEAM_KEY               - Key of the Linear team to create the issue in (e.g. "ENG")
   LINEAR_ASSIGNEE_TEAM_KEY      - Key of the Linear team to draw assignees from (e.g. "GIT")
+  ISSUE_TYPE                    - "major-bump" or "ci-failure"
   PR_TITLE                      - Title of the Dependabot PR
   PR_URL                        - URL of the Dependabot PR
+
+Required for major-bump only:
   DEPENDENCY_NAMES              - Name(s) of the dependency being bumped
   PREVIOUS_VERSION              - Version before the bump
   NEW_VERSION                   - Version after the bump
@@ -34,13 +42,34 @@ def linear_query(api_key: str, query: str, variables: dict | None = None) -> dic
     return result
 
 
-def resolve_assignee_id(api_key: str, team_key: str) -> str | None:
-    """Pick a random assignable member from the given Linear team."""
-    team_resp = linear_query(api_key, """
+def resolve_team(api_key: str, team_key: str) -> dict:
+    """Return the team node (id + states) for the given team key, or exit on failure."""
+    resp = linear_query(api_key, """
         query($key: String!) {
           teams(filter: { key: { eq: $key } }) {
             nodes {
               id
+              states {
+                nodes { id name }
+              }
+            }
+          }
+        }
+    """, {"key": team_key})
+
+    teams = (resp.get("data") or {}).get("teams", {}).get("nodes", [])
+    if not teams:
+        print(f"ERROR: could not find a Linear team with key '{team_key}'")
+        sys.exit(1)
+    return teams[0]
+
+
+def resolve_assignee_id(api_key: str, team_key: str) -> str | None:
+    """Pick a random assignable member from the given Linear team."""
+    resp = linear_query(api_key, """
+        query($key: String!) {
+          teams(filter: { key: { eq: $key } }) {
+            nodes {
               name
               members {
                 nodes { id email isAssignable }
@@ -50,12 +79,7 @@ def resolve_assignee_id(api_key: str, team_key: str) -> str | None:
         }
     """, {"key": team_key})
 
-    data = team_resp.get("data")
-    if not data:
-        print(f"WARNING: could not retrieve team data for key '{team_key}'")
-        return None
-
-    teams = data["teams"]["nodes"]
+    teams = (resp.get("data") or {}).get("teams", {}).get("nodes", [])
     if not teams:
         print(f"WARNING: could not find a Linear team with key '{team_key}'")
         return None
@@ -70,36 +94,57 @@ def resolve_assignee_id(api_key: str, team_key: str) -> str | None:
     return chosen["id"]
 
 
+def create_issue(api_key: str, issue_input: dict) -> str:
+    """Create a Linear issue and return its id."""
+    resp = linear_query(api_key, """
+        mutation IssueCreate($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue { id identifier url }
+          }
+        }
+    """, {"input": issue_input})
+
+    result = (resp.get("data") or {}).get("issueCreate", {})
+    if result.get("success"):
+        issue = result["issue"]
+        print(f"Created Linear issue {issue['identifier']}: {issue['url']}")
+        return issue["id"]
+
+    print("ERROR: Linear issue creation failed")
+    print(json.dumps(resp, indent=2))
+    sys.exit(1)
+
+
+def attach_pr(api_key: str, issue_id: str, pr_url: str, pr_title: str) -> None:
+    """Link the GitHub PR URL to the Linear issue as an attachment."""
+    resp = linear_query(api_key, """
+        mutation AttachPR($issueId: String!, $url: String!, $title: String) {
+          attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+            success
+            attachment { id }
+          }
+        }
+    """, {"issueId": issue_id, "url": pr_url, "title": pr_title})
+
+    success = (resp.get("data") or {}).get("attachmentLinkURL", {}).get("success")
+    if success:
+        print(f"Attached PR to Linear issue")
+    else:
+        # Non-fatal: issue was created, attachment is best-effort
+        print(f"WARNING: failed to attach PR URL to Linear issue")
+        print(json.dumps(resp, indent=2))
+
+
 def main() -> None:
     api_key = os.environ["LINEAR_API_KEY"]
     team_key = os.environ["LINEAR_TEAM_KEY"]
     assignee_team_key = os.environ["LINEAR_ASSIGNEE_TEAM_KEY"]
+    issue_type = os.environ["ISSUE_TYPE"]
     pr_title = os.environ["PR_TITLE"]
     pr_url = os.environ["PR_URL"]
-    dep_names = os.environ["DEPENDENCY_NAMES"]
-    prev_version = os.environ["PREVIOUS_VERSION"]
-    new_version = os.environ["NEW_VERSION"]
 
-    # Resolve team ID and "In Review" state ID from the team key
-    team_resp = linear_query(api_key, """
-        query($key: String!) {
-          teams(filter: { key: { eq: $key } }) {
-            nodes {
-              id
-              states {
-                nodes { id name type }
-              }
-            }
-          }
-        }
-    """, {"key": team_key})
-
-    teams = team_resp["data"]["teams"]["nodes"]
-    if not teams:
-        print(f"ERROR: could not find a Linear team with key '{team_key}'")
-        sys.exit(1)
-
-    team = teams[0]
+    team = resolve_team(api_key, team_key)
     team_id = team["id"]
 
     in_review_state = next(
@@ -107,45 +152,47 @@ def main() -> None:
         None,
     )
     if in_review_state is None:
-        print(f"ERROR: could not find an 'In Review' state in the {team_key} team workflow")
+        print(f"ERROR: could not find an 'In Review' state in the '{team_key}' team workflow")
         sys.exit(1)
 
     assignee_id = resolve_assignee_id(api_key, assignee_team_key)
 
-    issue_title = f"Review major dependency bump: {dep_names} {prev_version} -> {new_version}"
-    issue_description = (
-        f"Dependabot has opened a PR with a **major version bump** that requires manual review.\n\n"
-        f"**Dependency:** {dep_names}\n"
-        f"**Version change:** {prev_version} → {new_version}\n\n"
-        f"**PR:** [{pr_title}]({pr_url})"
-    )
+    if issue_type == "major-bump":
+        dep_names = os.environ["DEPENDENCY_NAMES"]
+        prev_version = os.environ["PREVIOUS_VERSION"]
+        new_version = os.environ["NEW_VERSION"]
+
+        title = f"Review major dependency bump: {dep_names} {prev_version} -> {new_version}"
+        description = (
+            f"Dependabot has opened a PR with a **major version bump** that requires manual review.\n\n"
+            f"**Dependency:** {dep_names}\n"
+            f"**Version change:** {prev_version} → {new_version}\n\n"
+            f"**PR:** [{pr_title}]({pr_url})"
+        )
+
+    elif issue_type == "ci-failure":
+        title = f"CI failure on Dependabot PR: {pr_title}"
+        description = (
+            f"CI checks failed on a Dependabot minor/patch PR that would normally be auto-merged.\n\n"
+            f"**PR:** [{pr_title}]({pr_url})\n\n"
+            f"Please investigate the failure and either fix the issue or manually merge/close the PR."
+        )
+
+    else:
+        print(f"ERROR: unknown ISSUE_TYPE '{issue_type}' — expected 'major-bump' or 'ci-failure'")
+        sys.exit(1)
 
     issue_input: dict = {
         "teamId": team_id,
         "stateId": in_review_state["id"],
-        "title": issue_title,
-        "description": issue_description,
+        "title": title,
+        "description": description,
     }
     if assignee_id:
         issue_input["assigneeId"] = assignee_id
 
-    create_resp = linear_query(api_key, """
-        mutation IssueCreate($input: IssueCreateInput!) {
-          issueCreate(input: $input) {
-            success
-            issue { identifier url }
-          }
-        }
-    """, {"input": issue_input})
-
-    result = create_resp["data"]["issueCreate"]
-    if result["success"]:
-        issue = result["issue"]
-        print(f"Created Linear issue {issue['identifier']}: {issue['url']}")
-    else:
-        print("ERROR: Linear issue creation failed")
-        print(json.dumps(create_resp, indent=2))
-        sys.exit(1)
+    issue_id = create_issue(api_key, issue_input)
+    attach_pr(api_key, issue_id, pr_url, pr_title)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -121,6 +121,7 @@ jobs:
           LINEAR_API_KEY: ${{ secrets.DEPENDABOT_LINEAR_KEY }}
           LINEAR_TEAM_KEY: ${{ secrets.LINEAR_TEAM_KEY }}
           LINEAR_ASSIGNEE_TEAM_KEY: ${{ secrets.LINEAR_ASSIGNEE_TEAM_KEY }}
+          ISSUE_TYPE: major-bump
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -77,12 +77,6 @@ jobs:
         run: gh pr merge --auto --rebase "$PR_URL"
 
       # ── Major bump: label, leave for manual review, and create Linear issue ──
-      - name: Create label if missing
-        if: steps.update-type.outputs.update-type == 'version-update:semver-major'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh label create major-version-bump --color e11d48 --description 'Contains a major version upgrade, requires manual review' || true
-
       - name: Check if already labelled for manual review
         id: already-labelled
         if: steps.update-type.outputs.update-type == 'version-update:semver-major'

--- a/.github/workflows/dependabot-ci-failure.yml
+++ b/.github/workflows/dependabot-ci-failure.yml
@@ -43,18 +43,12 @@ jobs:
             -f sha="$HEAD_SHA" \
             --jq '.data.repository.commit.associatedPullRequests.nodes[0]')
 
-          if [ "$(echo "$pr_data" | jq -r '.number')" = "null" ]; then
-            echo "No associated PR found, skipping"
-            exit 0
-          fi
-
           echo "number=$(echo "$pr_data" | jq -r '.number')" >> "$GITHUB_OUTPUT"
           echo "url=$(echo "$pr_data"    | jq -r '.url')"    >> "$GITHUB_OUTPUT"
           echo "title=$(echo "$pr_data"  | jq -r '.title')"  >> "$GITHUB_OUTPUT"
 
       - name: Check existing PR labels
         id: labels
-        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/dependabot-ci-failure.yml
+++ b/.github/workflows/dependabot-ci-failure.yml
@@ -67,13 +67,6 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create CI failure label if missing
-        if: steps.labels.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh label create ci-failure --color f97316 --description 'CI failed on a Dependabot PR' || true
-
       - name: Label PR with ci-failure
         if: steps.labels.outputs.skip == 'false'
         env:

--- a/.github/workflows/dependabot-ci-failure.yml
+++ b/.github/workflows/dependabot-ci-failure.yml
@@ -57,12 +57,9 @@ jobs:
           labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
           echo "list=$labels" >> "$GITHUB_OUTPUT"
 
-          # Skip if this is a major bump — it already has a Linear issue from dependabot-auto-merge
-          if echo "$labels" | grep -q "major-version-bump"; then
-            echo "skip=major-bump" >> "$GITHUB_OUTPUT"
-          # Skip if we already raised a CI failure issue for this PR
-          elif echo "$labels" | grep -q "ci-failure"; then
-            echo "skip=already-notified" >> "$GITHUB_OUTPUT"
+          # Skip if a major bump (already has a Linear issue) or ci-failure (already notified)
+          if echo "$labels" | grep -qE "major-version-bump|ci-failure"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/dependabot-ci-failure.yml
+++ b/.github/workflows/dependabot-ci-failure.yml
@@ -67,24 +67,20 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Label PR with ci-failure
-        if: steps.labels.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ steps.pr.outputs.url }}
-        run: gh pr edit "$PR_URL" --add-label "ci-failure"
-
       - name: Checkout repository
         if: steps.labels.outputs.skip == 'false'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Create Linear issue for CI failure
+      - name: Label PR and create Linear issue for CI failure
         if: steps.labels.outputs.skip == 'false'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.DEPENDABOT_LINEAR_KEY }}
           LINEAR_TEAM_KEY: ${{ secrets.LINEAR_TEAM_KEY }}
           LINEAR_ASSIGNEE_TEAM_KEY: ${{ secrets.LINEAR_ASSIGNEE_TEAM_KEY }}
           ISSUE_TYPE: ci-failure
           PR_TITLE: ${{ steps.pr.outputs.title }}
           PR_URL: ${{ steps.pr.outputs.url }}
-        run: python3 .github/scripts/create_linear_issue.py
+        run: |
+          gh pr edit "$PR_URL" --add-label "ci-failure"
+          python3 .github/scripts/create_linear_issue.py

--- a/.github/workflows/dependabot-ci-failure.yml
+++ b/.github/workflows/dependabot-ci-failure.yml
@@ -1,0 +1,97 @@
+name: Dependabot CI failure
+
+on:
+  workflow_run:
+    workflows: ["Required checks"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  notify-ci-failure:
+    runs-on: ubuntu-latest
+    # Only fire when CI failed/cancelled on a Dependabot PR
+    if: |
+      github.event.workflow_run.conclusion != 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    steps:
+      - name: Resolve PR from workflow run
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+          GQL_QUERY: |
+            query($owner:String!, $repo:String!, $sha:String!) {
+              repository(owner:$owner, name:$repo) {
+                commit: object(expression:$sha) {
+                  ... on Commit {
+                    associatedPullRequests(first:1) {
+                      nodes { number url title }
+                    }
+                  }
+                }
+              }
+            }
+        run: |
+          pr_data=$(gh api graphql \
+            -f query="$GQL_QUERY" \
+            -f owner="${REPO%%/*}" \
+            -f repo="${REPO##*/}" \
+            -f sha="$HEAD_SHA" \
+            --jq '.data.repository.commit.associatedPullRequests.nodes[0]')
+
+          echo "number=$(echo "$pr_data" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$pr_data"    | jq -r '.url')"    >> "$GITHUB_OUTPUT"
+          echo "title=$(echo "$pr_data"  | jq -r '.title')"  >> "$GITHUB_OUTPUT"
+
+      - name: Check existing PR labels
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          labels=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
+          echo "list=$labels" >> "$GITHUB_OUTPUT"
+
+          # Skip if this is a major bump — it already has a Linear issue from dependabot-auto-merge
+          if echo "$labels" | grep -q "major-version-bump"; then
+            echo "skip=major-bump" >> "$GITHUB_OUTPUT"
+          # Skip if we already raised a CI failure issue for this PR
+          elif echo "$labels" | grep -q "ci-failure"; then
+            echo "skip=already-notified" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create CI failure label if missing
+        if: steps.labels.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create ci-failure --color f97316 --description 'CI failed on a Dependabot PR' || true
+
+      - name: Label PR with ci-failure
+        if: steps.labels.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: gh pr edit "$PR_URL" --add-label "ci-failure"
+
+      - name: Checkout repository
+        if: steps.labels.outputs.skip == 'false'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Create Linear issue for CI failure
+        if: steps.labels.outputs.skip == 'false'
+        env:
+          LINEAR_API_KEY: ${{ secrets.DEPENDABOT_LINEAR_KEY }}
+          LINEAR_TEAM_KEY: ${{ secrets.LINEAR_TEAM_KEY }}
+          LINEAR_ASSIGNEE_TEAM_KEY: ${{ secrets.LINEAR_ASSIGNEE_TEAM_KEY }}
+          ISSUE_TYPE: ci-failure
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: python3 .github/scripts/create_linear_issue.py

--- a/.github/workflows/dependabot-ci-failure.yml
+++ b/.github/workflows/dependabot-ci-failure.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Check existing PR labels
         id: labels
+        if: steps.pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/dependabot-ci-failure.yml
+++ b/.github/workflows/dependabot-ci-failure.yml
@@ -43,6 +43,11 @@ jobs:
             -f sha="$HEAD_SHA" \
             --jq '.data.repository.commit.associatedPullRequests.nodes[0]')
 
+          if [ "$(echo "$pr_data" | jq -r '.number')" = "null" ]; then
+            echo "No associated PR found, skipping"
+            exit 0
+          fi
+
           echo "number=$(echo "$pr_data" | jq -r '.number')" >> "$GITHUB_OUTPUT"
           echo "url=$(echo "$pr_data"    | jq -r '.url')"    >> "$GITHUB_OUTPUT"
           echo "title=$(echo "$pr_data"  | jq -r '.title')"  >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Context

Dependabot is failing sometimes to either start checks (dealt with already hopefully), or the checks fail and the PR sits silently without any linear issue or person assigned to it.

## Changes proposed in this pull request

- Updated the existing workflow to pass in a `major` argument to the linear issue creation script
- Added a new workflow to only run if the `required-checks` fail, the PR actor is `dependabot` and there isn't already a `checks-failure` label assigned to the PR
  - PR is auto tagged to a use in the linear GIT team and put in-progress
- Added in a backlink to the linear issue creation so we get the automated management of the PR -> issue flow

## Guidance to review

This needs merging first and then checking unfortunately because of how the triggers work. It could be tested by changing all the params, but it's non-destructive and non-blocking so in my opinion it's easier to merge and then edit on a dependabot PR
