### PR TITLE
Configure Lambda alarms for all 3 functions

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,3 +1,9 @@
+locals {
+  # 80% of the Lambda module's default 600s timeout, in milliseconds. Used by
+  # the import Lambda duration alarms below.
+  import_lambda_duration_threshold_ms = 480000
+}
+
 resource "aws_security_group" "lambda_sg" {
   name_prefix = "${local.name}-lambda-sg"
   vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -156,4 +162,80 @@ module "import_response_annotations_lambda" {
     REPO              = var.project_name
     EXECUTION_CONTEXT = "lambda"
   }
+}
+
+# Error-rate and throttle alarms for all 3 Lambdas, routed to the Slack SNS
+# topic. If an import Lambda fails, its Batch job completes but results are
+# never imported, so we need to hear about it. Alarm names embed the function
+# name, so the Slack alert says which Lambda fired and links to its logs.
+
+module "slack_notifier_lambda_alarm" {
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
+  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.2.0-lambda-alarms"
+  name            = "${local.name}-slack-notifier"
+  lambda_function = module.slack_notifier_lambda.function_name
+  sns_topic_arn   = [module.sns_topic.sns_topic_arn]
+}
+
+module "import_candidate_themes_lambda_alarm" {
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
+  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.2.0-lambda-alarms"
+  name            = "${local.name}-import-candidate-themes"
+  lambda_function = module.import_candidate_themes_lambda.function_name
+  sns_topic_arn   = [module.sns_topic.sns_topic_arn]
+}
+
+module "import_response_annotations_lambda_alarm" {
+  # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
+  # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
+  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.2.0-lambda-alarms"
+  name            = "${local.name}-import-response-annotations"
+  lambda_function = module.import_response_annotations_lambda.function_name
+  sns_topic_arn   = [module.sns_topic.sns_topic_arn]
+}
+
+# Duration alarms for the VPC-connected import Lambdas: on Redis + cold start
+# a run can near the 600s timeout and be killed mid-import. Fire at 480s (80%)
+# so slow runs surface first. The slack_notifier Lambda isn't VPC-connected, so
+# it gets no duration alarm.
+resource "aws_cloudwatch_metric_alarm" "import_candidate_themes_duration" {
+  alarm_name          = "${local.name}-import-candidate-themes-lambda-duration"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = local.import_lambda_duration_threshold_ms
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "import-candidate-themes Lambda run exceeded 480s (80% of its 600s timeout); check the function's logs."
+
+  dimensions = {
+    FunctionName = module.import_candidate_themes_lambda.function_name
+  }
+
+  # No ok_actions: a slow run recovering to normal isn't worth a Slack ping.
+  alarm_actions = [module.sns_topic.sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "import_response_annotations_duration" {
+  alarm_name          = "${local.name}-import-response-annotations-lambda-duration"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = local.import_lambda_duration_threshold_ms
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "import-response-annotations Lambda run exceeded 480s (80% of its 600s timeout); check the function's logs."
+
+  dimensions = {
+    FunctionName = module.import_response_annotations_lambda.function_name
+  }
+
+  # No ok_actions: a slow run recovering to normal isn't worth a Slack ping.
+  alarm_actions = [module.sns_topic.sns_topic_arn]
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,9 +1,3 @@
-locals {
-  # 80% of the Lambda module's default 600s timeout, in milliseconds. Used by
-  # the import Lambda duration alarms below.
-  import_lambda_duration_threshold_ms = 480000
-}
-
 resource "aws_security_group" "lambda_sg" {
   name_prefix = "${local.name}-lambda-sg"
   vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
@@ -168,11 +162,17 @@ module "import_response_annotations_lambda" {
 # topic. If an import Lambda fails, its Batch job completes but results are
 # never imported, so we need to hear about it. Alarm names embed the function
 # name, so the Slack alert says which Lambda fired and links to its logs.
+#
+# The two import Lambdas also get a duration alarm (via duration_threshold_ms):
+# they're VPC-connected, so on Redis + cold start a run can near the 600s
+# timeout and be killed mid-import. Fire at 480s (80% of the Lambda module's
+# default 600s timeout) so slow runs surface first. The slack_notifier Lambda
+# isn't VPC-connected, so it gets no duration alarm.
 
 module "slack_notifier_lambda_alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
-  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.2.0-lambda-alarms"
+  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.3.0-lambda-alarms"
   name            = "${local.name}-slack-notifier"
   lambda_function = module.slack_notifier_lambda.function_name
   sns_topic_arn   = [module.sns_topic.sns_topic_arn]
@@ -181,61 +181,19 @@ module "slack_notifier_lambda_alarm" {
 module "import_candidate_themes_lambda_alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
-  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.2.0-lambda-alarms"
-  name            = "${local.name}-import-candidate-themes"
-  lambda_function = module.import_candidate_themes_lambda.function_name
-  sns_topic_arn   = [module.sns_topic.sns_topic_arn]
+  source                = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.3.0-lambda-alarms"
+  name                  = "${local.name}-import-candidate-themes"
+  lambda_function       = module.import_candidate_themes_lambda.function_name
+  sns_topic_arn         = [module.sns_topic.sns_topic_arn]
+  duration_threshold_ms = 480000
 }
 
 module "import_response_annotations_lambda_alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
-  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.2.0-lambda-alarms"
-  name            = "${local.name}-import-response-annotations"
-  lambda_function = module.import_response_annotations_lambda.function_name
-  sns_topic_arn   = [module.sns_topic.sns_topic_arn]
-}
-
-# Duration alarms for the VPC-connected import Lambdas: on Redis + cold start
-# a run can near the 600s timeout and be killed mid-import. Fire at 480s (80%)
-# so slow runs surface first. The slack_notifier Lambda isn't VPC-connected, so
-# it gets no duration alarm.
-resource "aws_cloudwatch_metric_alarm" "import_candidate_themes_duration" {
-  alarm_name          = "${local.name}-import-candidate-themes-lambda-duration"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "Duration"
-  namespace           = "AWS/Lambda"
-  period              = 60
-  statistic           = "Maximum"
-  threshold           = local.import_lambda_duration_threshold_ms
-  treat_missing_data  = "notBreaching"
-  alarm_description   = "import-candidate-themes Lambda run exceeded 480s (80% of its 600s timeout); check the function's logs."
-
-  dimensions = {
-    FunctionName = module.import_candidate_themes_lambda.function_name
-  }
-
-  # No ok_actions: a slow run recovering to normal isn't worth a Slack ping.
-  alarm_actions = [module.sns_topic.sns_topic_arn]
-}
-
-resource "aws_cloudwatch_metric_alarm" "import_response_annotations_duration" {
-  alarm_name          = "${local.name}-import-response-annotations-lambda-duration"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "Duration"
-  namespace           = "AWS/Lambda"
-  period              = 60
-  statistic           = "Maximum"
-  threshold           = local.import_lambda_duration_threshold_ms
-  treat_missing_data  = "notBreaching"
-  alarm_description   = "import-response-annotations Lambda run exceeded 480s (80% of its 600s timeout); check the function's logs."
-
-  dimensions = {
-    FunctionName = module.import_response_annotations_lambda.function_name
-  }
-
-  # No ok_actions: a slow run recovering to normal isn't worth a Slack ping.
-  alarm_actions = [module.sns_topic.sns_topic_arn]
+  source                = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.3.0-lambda-alarms"
+  name                  = "${local.name}-import-response-annotations"
+  lambda_function       = module.import_response_annotations_lambda.function_name
+  sns_topic_arn         = [module.sns_topic.sns_topic_arn]
+  duration_threshold_ms = 480000
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -171,7 +171,6 @@ module "import_response_annotations_lambda" {
 
 module "slack_notifier_lambda_alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
-  # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
   source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.3.0-lambda-alarms"
   name            = "${local.name}-slack-notifier"
   lambda_function = module.slack_notifier_lambda.function_name
@@ -180,7 +179,6 @@ module "slack_notifier_lambda_alarm" {
 
 module "import_candidate_themes_lambda_alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
-  # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
   source                = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.3.0-lambda-alarms"
   name                  = "${local.name}-import-candidate-themes"
   lambda_function       = module.import_candidate_themes_lambda.function_name
@@ -190,7 +188,6 @@ module "import_candidate_themes_lambda_alarm" {
 
 module "import_response_annotations_lambda_alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
-  # source        = "../../i-dot-ai-core-terraform-modules/modules/observability/lambda-alarms"
   source                = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.3.0-lambda-alarms"
   name                  = "${local.name}-import-response-annotations"
   lambda_function       = module.import_response_annotations_lambda.function_name

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -158,17 +158,6 @@ module "import_response_annotations_lambda" {
   }
 }
 
-# Error-rate and throttle alarms for all 3 Lambdas, routed to the Slack SNS
-# topic. If an import Lambda fails, its Batch job completes but results are
-# never imported, so we need to hear about it. Alarm names embed the function
-# name, so the Slack alert says which Lambda fired and links to its logs.
-#
-# The two import Lambdas also get a duration alarm (via duration_threshold_ms):
-# they're VPC-connected, so on Redis + cold start a run can near the 600s
-# timeout and be killed mid-import. Fire at 480s (80% of the Lambda module's
-# default 600s timeout) so slow runs surface first. The slack_notifier Lambda
-# isn't VPC-connected, so it gets no duration alarm.
-
 module "slack_notifier_lambda_alarm" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/lambda-alarms?ref=v1.3.0-lambda-alarms"
@@ -183,7 +172,7 @@ module "import_candidate_themes_lambda_alarm" {
   name                  = "${local.name}-import-candidate-themes"
   lambda_function       = module.import_candidate_themes_lambda.function_name
   sns_topic_arn         = [module.sns_topic.sns_topic_arn]
-  duration_threshold_ms = 480000
+  duration_threshold_ms = 480000 # 80% of the 600s timeout
 }
 
 module "import_response_annotations_lambda_alarm" {
@@ -192,5 +181,5 @@ module "import_response_annotations_lambda_alarm" {
   name                  = "${local.name}-import-response-annotations"
   lambda_function       = module.import_response_annotations_lambda.function_name
   sns_topic_arn         = [module.sns_topic.sns_topic_arn]
-  duration_threshold_ms = 480000
+  duration_threshold_ms = 480000 # 80% of the 600s timeout
 }


### PR DESCRIPTION
## Context

The 3 Lambdas are critical but had no alarms. If an import Lambda fails, its Batch job completes but the results are never imported, and there's no retry beyond the Lambda's own. This wires alarms so those failures reach us in Slack.

## Changes proposed in this pull request

- Wire the shared `observability/lambda-alarms` module for all 3 Lambdas (slack-notifier and both import Lambdas), routing error-rate and throttle alarms to the existing Slack SNS topic.
- Add duration alarms for the two VPC-connected import Lambdas, firing at 480s (80% of the 600s timeout) to catch slow runs before they're killed mid-import.
- Alarm names embed the function name, so the Slack alert says which Lambda fired and links to its CloudWatch alarm and logs.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
