### PR TITLE
chore: pro-522 Don't filter intentional Sentry captures

### DIFF
--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -2,7 +2,6 @@ import statistics
 from collections import Counter, defaultdict
 from typing import Any
 
-import sentry_sdk
 from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.db import transaction
@@ -48,6 +47,7 @@ from hosting_environment import HostingEnvironment
 from ingest.jobs import (
     delete_consultation_job,
 )
+from sentry_context import capture_handled_sentry_exception
 
 logger = settings.LOGGER
 
@@ -263,14 +263,14 @@ class ConsultationViewSet(ModelViewSet):
             logger.warning(
                 "Consultation setup request failed validation: {detail}", detail=e.detail
             )
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {"message": "An error occurred while starting the import"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception as e:
             logger.exception("Failed to start consultation setup import job")
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {"message": "An error occurred while starting the import"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -340,7 +340,7 @@ class ConsultationViewSet(ModelViewSet):
             logger.exception(
                 f"Error starting Find Themes job for consultation {consultation.title}: {e}"
             )
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to start Find Themes job",
@@ -405,7 +405,7 @@ class ConsultationViewSet(ModelViewSet):
                 "Failed to export selected themes to S3 for consultation {consultation_code}",
                 consultation_code=consultation.code,
             )
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to export themes to S3",
@@ -427,7 +427,7 @@ class ConsultationViewSet(ModelViewSet):
                 "Failed to submit ASSIGN_THEMES batch job for consultation {consultation_code}",
                 consultation_code=consultation.code,
             )
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to submit job to assign themes",
@@ -475,7 +475,7 @@ class ConsultationViewSet(ModelViewSet):
             s3_codes = s3.get_consultation_folders()
         except (ClientError, BotoCoreError) as e:
             logger.exception("Failed to list consultation folders from S3")
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to list consultation folders",
@@ -567,7 +567,7 @@ class ConsultationViewSet(ModelViewSet):
                 "Failed to add users to consultation {consultation_id}",
                 consultation_id=str(consultation.id),
             )
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {"error": "Failed to add users to consultation"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -846,7 +846,7 @@ class ConsultationViewSet(ModelViewSet):
                 consultation_id=str(target.id),
                 imported=imported_themes,
             )
-            sentry_sdk.capture_exception(e)
+            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": (

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -69,9 +69,11 @@ extend-select = ["TID251"]
 "django_rq.job".msg = "Use rq_context.job instead, so context_id propagates into the worker"
 "django_rq.get_queue".msg = "Use an rq_context.job-decorated function's .enqueue()/.delay() instead, so context_id propagates into the worker"
 "django_rq.enqueue".msg = "Use an rq_context.job-decorated function's .enqueue()/.delay() instead, so context_id propagates into the worker"
+"sentry_sdk.capture_exception".msg = "Use sentry_context.capture_handled_sentry_exception instead, so before_send doesn't silently drop it"
 
 [tool.ruff.lint.per-file-ignores]
 "rq_context.py" = ["TID251"]
+"sentry_context.py" = ["TID251"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "settings.test"

--- a/backend/sentry_context.py
+++ b/backend/sentry_context.py
@@ -10,7 +10,7 @@ def capture_handled_sentry_exception(error=None, **kwargs):
     of the handled/unhandled mechanism Sentry infers for manual captures.
     """
     new_kwargs = kwargs.copy()
-    new_kwargs.setdefault("tags", {})[MANUAL_CAPTURE_TAG] = "true"
+    new_kwargs["tags"] = {**kwargs.get("tags", {}), MANUAL_CAPTURE_TAG: "true"}
     return sentry_sdk.capture_exception(error, **new_kwargs)
 
 

--- a/backend/sentry_context.py
+++ b/backend/sentry_context.py
@@ -9,8 +9,9 @@ def capture_handled_sentry_exception(error=None, **kwargs):
     response). Tags the event so sentry_before_send always forwards it, regardless
     of the handled/unhandled mechanism Sentry infers for manual captures.
     """
-    kwargs.setdefault("tags", {})[MANUAL_CAPTURE_TAG] = "true"
-    return sentry_sdk.capture_exception(error, **kwargs)
+    new_kwargs = kwargs.copy()
+    new_kwargs.setdefault("tags", {})[MANUAL_CAPTURE_TAG] = "true"
+    return sentry_sdk.capture_exception(error, **new_kwargs)
 
 
 def sentry_before_send(event, hint):
@@ -35,17 +36,26 @@ def sentry_before_send(event, hint):
         dict: The modified event dictionary, or None if the event should be
             ignored.
     """
-    if event.get("tags", {}).get(MANUAL_CAPTURE_TAG):
-        return event
+    try:
+        # If the event was captured via capture_handled_sentry_exception, it will be
+        # tagged so we always send it, regardless of the handled/unhandled mechanism
+        # Sentry infers for manual captures.
+        if event["tags"][MANUAL_CAPTURE_TAG]:
+            return event
+    except KeyError:
+        pass
 
     # Ignore handled exceptions
-    exceptions = event.get("exception", {}).get("values", [])
-    if exceptions:
+    try:
+        exceptions = event["exception"]["values"]
+
         exc = exceptions[-1]
-        mechanism = exc.get("mechanism")
+        mechanism = exc["mechanism"]
 
         if mechanism:
-            if mechanism.get("handled"):
+            if mechanism["handled"]:
                 return None
+    except (KeyError, IndexError):
+        pass
 
     return event

--- a/backend/sentry_context.py
+++ b/backend/sentry_context.py
@@ -15,46 +15,16 @@ def capture_handled_sentry_exception(error=None, **kwargs):
 
 
 def sentry_before_send(event, hint):
-    """Filters Sentry events before sending.
-
-    Adapted from https://jkfran.com/capturing-unhandled-exceptions-sentry-python/
-
-    Explicit captures via capture_handled_sentry_exception are always sent.
-    Otherwise, this function filters out exceptions Sentry's own integrations marked
-    as handled, since those are typically caught and dealt with by application code
-    (see sentry_sdk.utils.single_exception_from_error_tuple: unmarked/manual captures
-    default to handled=True, while integration-driven captures of exceptions that
-    escaped uncaught mark handled=False).
-
-    Args:
-        event (dict): The event dictionary containing exception data.
-
-        hint (dict): Additional information about the event, including
-            the original exception.
-
-    Returns:
-        dict: The modified event dictionary, or None if the event should be
-            ignored.
+    """Drops integration-captured handled exceptions. Manual captures also default to
+    handled=True, so capture_handled_sentry_exception tags them to bypass this.
     """
+    if MANUAL_CAPTURE_TAG in event.get("tags", {}):
+        return event
+
     try:
-        # If the event was captured via capture_handled_sentry_exception, it will be
-        # tagged so we always send it, regardless of the handled/unhandled mechanism
-        # Sentry infers for manual captures.
-        if event["tags"][MANUAL_CAPTURE_TAG]:
-            return event
-    except KeyError:
-        pass
-
-    # Ignore handled exceptions
-    try:
-        exceptions = event["exception"]["values"]
-
-        exc = exceptions[-1]
-        mechanism = exc["mechanism"]
-
-        if mechanism:
-            if mechanism["handled"]:
-                return None
+        mechanism = event["exception"]["values"][-1]["mechanism"]
+        if mechanism and mechanism.get("handled") is True:
+            return None
     except (KeyError, IndexError):
         pass
 

--- a/backend/sentry_context.py
+++ b/backend/sentry_context.py
@@ -1,0 +1,51 @@
+import sentry_sdk
+
+MANUAL_CAPTURE_TAG = "consult.manual_capture"
+
+
+def capture_handled_sentry_exception(error=None, **kwargs):
+    """Drop-in replacement for sentry_sdk.capture_exception for exceptions the
+    application already caught and is handling (e.g. converting to a 4xx/5xx
+    response). Tags the event so sentry_before_send always forwards it, regardless
+    of the handled/unhandled mechanism Sentry infers for manual captures.
+    """
+    kwargs.setdefault("tags", {})[MANUAL_CAPTURE_TAG] = "true"
+    return sentry_sdk.capture_exception(error, **kwargs)
+
+
+def sentry_before_send(event, hint):
+    """Filters Sentry events before sending.
+
+    Adapted from https://jkfran.com/capturing-unhandled-exceptions-sentry-python/
+
+    Explicit captures via capture_handled_sentry_exception are always sent.
+    Otherwise, this function filters out exceptions Sentry's own integrations marked
+    as handled, since those are typically caught and dealt with by application code
+    (see sentry_sdk.utils.single_exception_from_error_tuple: unmarked/manual captures
+    default to handled=True, while integration-driven captures of exceptions that
+    escaped uncaught mark handled=False).
+
+    Args:
+        event (dict): The event dictionary containing exception data.
+
+        hint (dict): Additional information about the event, including
+            the original exception.
+
+    Returns:
+        dict: The modified event dictionary, or None if the event should be
+            ignored.
+    """
+    if event.get("tags", {}).get(MANUAL_CAPTURE_TAG):
+        return event
+
+    # Ignore handled exceptions
+    exceptions = event.get("exception", {}).get("values", [])
+    if exceptions:
+        exc = exceptions[-1]
+        mechanism = exc.get("mechanism")
+
+        if mechanism:
+            if mechanism.get("handled"):
+                return None
+
+    return event

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -4,6 +4,7 @@ from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
 from i_dot_ai_utilities.logging.types.enrichment_types import ExecutionEnvironmentType
 from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 
+from sentry_context import sentry_before_send
 from settings.base import *  # noqa
 
 CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGINS  # noqa: F405
@@ -24,36 +25,6 @@ STORAGES["staticfiles"] = {  # noqa: F405
     "BACKEND": "storages.backends.s3.S3Storage",
     "OPTIONS": {"bucket_name": env("AWS_BUCKET_NAME"), "location": "app_data/static/"},  # noqa: F405
 }
-
-
-def sentry_before_send(event, hint):
-    """Filters Sentry events before sending.
-
-    Adapted from https://jkfran.com/capturing-unhandled-exceptions-sentry-python/
-
-    This function filters out handled exceptions.
-
-    Args:
-        event (dict): The event dictionary containing exception data.
-
-        hint (dict): Additional information about the event, including
-            the original exception.
-
-    Returns:
-        dict: The modified event dictionary, or None if the event should be
-            ignored.
-    """
-    # Ignore handled exceptions
-    exceptions = event.get("exception", {}).get("values", [])
-    if exceptions:
-        exc = exceptions[-1]
-        mechanism = exc.get("mechanism")
-
-        if mechanism:
-            if mechanism.get("handled"):
-                return None
-
-    return event
 
 
 sentry_sdk.init(

--- a/backend/tests/unit/test_sentry_context.py
+++ b/backend/tests/unit/test_sentry_context.py
@@ -1,0 +1,79 @@
+from unittest.mock import patch
+
+from sentry_context import (
+    MANUAL_CAPTURE_TAG,
+    capture_handled_sentry_exception,
+    sentry_before_send,
+)
+
+
+class TestCaptureHandledSentryException:
+    def test_tags_the_capture_as_manual(self):
+        error = ValueError("boom")
+
+        with patch("sentry_context.sentry_sdk.capture_exception") as mock_capture:
+            capture_handled_sentry_exception(error)
+
+        mock_capture.assert_called_once_with(error, tags={MANUAL_CAPTURE_TAG: "true"})
+
+    def test_preserves_caller_supplied_tags(self):
+        error = ValueError("boom")
+
+        with patch("sentry_context.sentry_sdk.capture_exception") as mock_capture:
+            capture_handled_sentry_exception(error, tags={"consultation_code": "ABC123"})
+
+        mock_capture.assert_called_once_with(
+            error,
+            tags={"consultation_code": "ABC123", MANUAL_CAPTURE_TAG: "true"},
+        )
+
+    def test_returns_the_underlying_capture_result(self):
+        with patch("sentry_context.sentry_sdk.capture_exception", return_value="event-id"):
+            result = capture_handled_sentry_exception(ValueError("boom"))
+
+        assert result == "event-id"
+
+
+def _event(mechanism=None, tags=None):
+    exception_value = {}
+    if mechanism is not None:
+        exception_value["mechanism"] = mechanism
+    return {"exception": {"values": [exception_value]}, "tags": tags or {}}
+
+
+class TestSentryBeforeSend:
+    """capture_handled_sentry_exception tags manual captures so they always survive
+    filtering; only exceptions Sentry's own integrations marked handled=True (i.e.
+    already caught elsewhere) get dropped here."""
+
+    def test_manually_tagged_capture_is_always_sent(self):
+        event = _event(
+            mechanism={"type": "generic", "handled": True},
+            tags={MANUAL_CAPTURE_TAG: "true"},
+        )
+
+        assert sentry_before_send(event, {}) is event
+
+    def test_drops_untagged_handled_exception(self):
+        """The core case: a plain sentry_sdk.capture_exception() call, with no
+        manual-capture tag, defaults to handled=True and must be dropped."""
+        event = _event(mechanism={"type": "generic", "handled": True})
+
+        assert sentry_before_send(event, {}) is None
+
+    def test_still_drops_handled_exception_alongside_unrelated_tags(self):
+        """Only MANUAL_CAPTURE_TAG bypasses the filter - other tags on the event
+        don't count."""
+        event = _event(
+            mechanism={"type": "generic", "handled": True},
+            tags={"other_tag": "value"},
+        )
+
+        assert sentry_before_send(event, {}) is None
+
+    def test_keeps_untagged_unhandled_exception(self):
+        """e.g. mechanism={"type": "django", "handled": False} - an exception that
+        escaped uncaught and was only caught by the Django integration."""
+        event = _event(mechanism={"type": "django", "handled": False})
+
+        assert sentry_before_send(event, {}) is event


### PR DESCRIPTION
## Context

`sentry_before_send` (`backend/settings/production.py`) drops any event whose exception `mechanism.handled` is `True`. But `sentry_sdk.capture_exception()` — as called manually in the `except` blocks throughout `consultations/api/views/consultation.py` — always produces `mechanism = {"type": "generic", "handled": True}` by default, since the SDK only sets `handled: False` for exceptions its own integrations (Django, WSGI, threading, etc.) catch after they escape uncaught. The result: every one of those 8 manual `capture_exception(e)` calls was being silently dropped before reaching Sentry, even though the app explicitly wanted visibility into them.

## Changes proposed in this pull request

- Added `sentry_context.capture_handled_sentry_exception()`, a drop-in replacement for `sentry_sdk.capture_exception()` that tags the event as a deliberate, application-level capture.
- `sentry_before_send` now checks that tag first and always forwards the event if present, before falling back to the existing handled/unhandled mechanism filtering for everything else (auto-captured exceptions from Sentry integrations).
- Moved `sentry_before_send` out of `settings/production.py` into the new `backend/sentry_context.py` module, alongside the wrapper, so both share one `MANUAL_CAPTURE_TAG` constant and the filter is unit-testable without triggering `settings/production.py`'s module-level `sentry_sdk.init()`/required env vars.
- Added a `ruff` banned-api rule (mirroring the existing `django_rq.job` pattern) so `sentry_sdk.capture_exception` can no longer be called directly outside `sentry_context.py` — callers are pointed at the wrapper instead.
- Updated all 8 call sites in `consultations/api/views/consultation.py` to use `capture_handled_sentry_exception`.
- Added `backend/tests/unit/test_sentry_context.py` covering the wrapper (tags applied, caller-supplied tags preserved, return value passed through) and the filter (manual-tag bypass, handled exceptions still dropped even alongside unrelated tags, unhandled/auto-captured exceptions still kept).

## Guidance to review

- The core fix is the tag-check added at the top of `sentry_before_send` in `sentry_context.py` — worth confirming this doesn't change behaviour for genuinely auto-captured (integration) exceptions, which should still flow through unaffected.
- `settings/production.py` diff is a pure move, not a behaviour change for `sentry_sdk.init()`/env var loading. This move allows the same variable to be used consistently as the tagged that is passed and recognised by the filter.