### PR TITLE
Configure ElastiCache (Redis) alarms

### DIFF
--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -1,7 +1,7 @@
 module "elasticache" {
   # checkov:skip=CKV_TF_1: We're using semantic versions instead of commit hash
   # source          = "../../i-ai-core-infrastructure//modules/elasticache"
-  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/elasticache?ref=v1.1.0-elasticache"
+  source          = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/infrastructure/elasticache?ref=v1.3.0-elasticache"
   name            = local.name
   vpc_id          = data.terraform_remote_state.vpc.outputs.vpc_id
   private_subnets = data.terraform_remote_state.vpc.outputs.private_subnets
@@ -12,4 +12,25 @@ module "elasticache" {
       "lambda" = aws_security_group.lambda_sg.id
     }
   )
+}
+
+module "elasticache_alarms" {
+  source         = "git::https://github.com/i-dot-ai/i-dot-ai-core-terraform-modules.git//modules/observability/elasticache-alarms?ref=v1.0.0-elasticache-alarms"
+  name           = local.name
+  sns_topic_arns = [module.sns_topic.sns_topic_arn]
+
+  elasticache_metadata = {
+    cache_cluster_id = module.elasticache.cluster_id
+  }
+
+  alarms_config = {
+    # Redis backs the RQ queue, so any eviction is a dropped job (module default is 100).
+    evictions_high = {
+      threshold = 1
+    }
+    # Well below the node's ~65000 maxclients; catches a connection leak.
+    connections_high = {
+      threshold = 5000
+    }
+  }
 }


### PR DESCRIPTION
## Context

Redis backs the RQ queue and stays in the architecture (ADR-0007), but nothing alarmed on it, so cache issues went undetected.

## Changes proposed in this pull request

Adds an elasticache_alarms block in terraform/elasticache.tf, keyed off the existing Redis cluster and routed to the same Slack SNS topic as the RDS alarms. Covers CPU, engine CPU, memory, evictions, connections and replication lag.

Two thresholds are set for the cache.t2.micro node; the rest use module defaults:

- evictions at 1: Redis backs the RQ queue, so any eviction is a dropped job.
- connections at 5000: above normal RQ load, well below the node's ~65000 maxclients.

CPU, engine CPU and memory use the 90% defaults (percentages, so node size is irrelevant). Replication lag stays off; the cluster is single-node and never emits it.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
