### PR TITLE
PRO-671: Remove subtitle from consultation list page

### DIFF
--- a/e2e_tests/tests/consultations.e2e.ts
+++ b/e2e_tests/tests/consultations.e2e.ts
@@ -30,9 +30,6 @@ test.describe("Consultations - List Page", () => {
       page.getByRole("heading", { name: /Your consultations/i }),
     ).toBeVisible();
 
-    // Check for the description text
-    await expect(page.getByText(/review themes/i)).toBeVisible();
-
     // Check that at least one consultation is displayed
     const consultationItems = page
       .locator('[data-testid="consultation-item"]')

--- a/frontend/src/pages/consultations/index.astro
+++ b/frontend/src/pages/consultations/index.astro
@@ -10,8 +10,6 @@ import ConsultationList from "../../components/screens/ConsultationList/Consulta
   <Section>
     <Title level={1} text="Your consultations" />
 
-    <p>Click to review themes for your consultations</p>
-
     <ConsultationList client:load />
   </Section>
 </Layout>


### PR DESCRIPTION
## Context
The subtitle text on consultations list page was no longer applicable to the content below it. Also considering the upcoming PR to convert the consultations list into a table, the subtitle is no longer needed.

## Changes proposed in this pull request
<img width="884" height="340" alt="image" src="https://github.com/user-attachments/assets/73dae522-7b46-434d-b3bc-937b612b1718" />

## Guidance to review
View on /consultations route

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
