### PR TITLE
Restore missing ground-truth themes.json files for the local dataset

### DIFF
--- a/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_1/themes.json
+++ b/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_1/themes.json
@@ -1,0 +1,80 @@
+[
+    {
+        "topic_id": "A",
+        "topic_label": "Complete Ban Support",
+        "topic_description": "Strong support for completely banning gambling advertisements during sports broadcasts to protect vulnerable individuals and families.",
+        "topic": "Complete Ban Support: Strong support for completely banning gambling advertisements during sports broadcasts to protect vulnerable individuals and families."
+    },
+    {
+        "topic_id": "B",
+        "topic_label": "Economic Impact Concerns",
+        "topic_description": "Concerns about negative economic impacts on sports funding, broadcasting, employment, and grassroots sports if gambling advertising is banned.",
+        "topic": "Economic Impact Concerns: Concerns about negative economic impacts on sports funding, broadcasting, employment, and grassroots sports if gambling advertising is banned."
+    },
+    {
+        "topic_id": "C",
+        "topic_label": "Personal Freedom Arguments",
+        "topic_description": "Arguments emphasizing personal responsibility and freedom of choice, opposing government intervention in legal advertising.",
+        "topic": "Personal Freedom Arguments: Arguments emphasizing personal responsibility and freedom of choice, opposing government intervention in legal advertising."
+    },
+    {
+        "topic_id": "D",
+        "topic_label": "Addiction and Harm Testimonies",
+        "topic_description": "Personal stories and testimonies about gambling addiction, financial ruin, and family destruction caused by gambling.",
+        "topic": "Addiction and Harm Testimonies: Personal stories and testimonies about gambling addiction, financial ruin, and family destruction caused by gambling."
+    },
+    {
+        "topic_id": "E",
+        "topic_label": "Child Protection Focus",
+        "topic_description": "Emphasis on protecting children and young people from gambling exposure and normalization through sports viewing.",
+        "topic": "Child Protection Focus: Emphasis on protecting children and young people from gambling exposure and normalization through sports viewing."
+    },
+    {
+        "topic_id": "F",
+        "topic_label": "Partial Restriction Proposals",
+        "topic_description": "Suggestions for compromise solutions like watershed restrictions, frequency limits, or content restrictions rather than complete bans.",
+        "topic": "Partial Restriction Proposals: Suggestions for compromise solutions like watershed restrictions, frequency limits, or content restrictions rather than complete bans."
+    },
+    {
+        "topic_id": "G",
+        "topic_label": "Industry Regulation Criticism",
+        "topic_description": "Criticism of current self-regulation, calling for stronger government oversight and enforcement of gambling advertising.",
+        "topic": "Industry Regulation Criticism: Criticism of current self-regulation, calling for stronger government oversight and enforcement of gambling advertising."
+    },
+    {
+        "topic_id": "H",
+        "topic_label": "Cultural Normalization Concerns",
+        "topic_description": "Worries about how gambling has become normalized and integrated into sports culture and commentary.",
+        "topic": "Cultural Normalization Concerns: Worries about how gambling has become normalized and integrated into sports culture and commentary."
+    },
+    {
+        "topic_id": "I",
+        "topic_label": "Alternative Funding Models",
+        "topic_description": "Discussion of how sports could find alternative funding sources to replace gambling sponsorship revenue.",
+        "topic": "Alternative Funding Models: Discussion of how sports could find alternative funding sources to replace gambling sponsorship revenue."
+    },
+    {
+        "topic_id": "J",
+        "topic_label": "Comparison to Other Restrictions",
+        "topic_description": "Comparisons to tobacco advertising bans or arguments about consistency with other harmful product advertising.",
+        "topic": "Comparison to Other Restrictions: Comparisons to tobacco advertising bans or arguments about consistency with other harmful product advertising."
+    },
+    {
+        "topic_id": "K",
+        "topic_label": "Gender and Demographic Targeting",
+        "topic_description": "Concerns about gambling companies specifically targeting vulnerable demographics, particularly young men.",
+        "topic": "Gender and Demographic Targeting: Concerns about gambling companies specifically targeting vulnerable demographics, particularly young men."
+    },
+    {
+        "topic_id": "X",
+        "topic_label": "None of the Above",
+        "topic_description": "The response discusses a topic not covered by the listed themes (only use this if no other theme applies).",
+        "topic": "None of the Above: The response discusses a topic not covered by the listed themes (only use this if no other theme applies)."
+    },
+    {
+        "topic_id": "Y",
+        "topic_label": "No Reason Given",
+        "topic_description": "The response does not provide a substantive answer to the question.",
+        "topic": "No Reason Given: The response does not provide a substantive answer to the question."
+    }
+]

--- a/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_2/themes.json
+++ b/themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_2/themes.json
@@ -1,0 +1,80 @@
+[
+    {
+        "topic_id": "A",
+        "topic_label": "Education and Awareness Programs",
+        "topic_description": "Proposals for educational initiatives in schools, communities, and public health campaigns about gambling risks and probability.",
+        "topic": "Education and Awareness Programs: Proposals for educational initiatives in schools, communities, and public health campaigns about gambling risks and probability."
+    },
+    {
+        "topic_id": "B",
+        "topic_label": "Technology-Based Solutions",
+        "topic_description": "Suggestions for using technology like AI monitoring, app restrictions, smart delays, and digital interventions to prevent problem gambling.",
+        "topic": "Technology-Based Solutions: Suggestions for using technology like AI monitoring, app restrictions, smart delays, and digital interventions to prevent problem gambling."
+    },
+    {
+        "topic_id": "C",
+        "topic_label": "Financial Controls and Limits",
+        "topic_description": "Proposals for deposit limits, loss limits, income verification, credit restrictions, and other financial safeguards.",
+        "topic": "Financial Controls and Limits: Proposals for deposit limits, loss limits, income verification, credit restrictions, and other financial safeguards."
+    },
+    {
+        "topic_id": "D",
+        "topic_label": "Treatment and Support Services",
+        "topic_description": "Emphasis on improving access to counseling, support groups, helplines, and addiction treatment services.",
+        "topic": "Treatment and Support Services: Emphasis on improving access to counseling, support groups, helplines, and addiction treatment services."
+    },
+    {
+        "topic_id": "E",
+        "topic_label": "Industry Accountability Measures",
+        "topic_description": "Requirements for gambling companies to fund treatment, report on harm, train staff, and take responsibility for addiction.",
+        "topic": "Industry Accountability Measures: Requirements for gambling companies to fund treatment, report on harm, train staff, and take responsibility for addiction."
+    },
+    {
+        "topic_id": "F",
+        "topic_label": "Regulatory and Legal Changes",
+        "topic_description": "Proposals for new laws, licensing requirements, enforcement mechanisms, and regulatory frameworks.",
+        "topic": "Regulatory and Legal Changes: Proposals for new laws, licensing requirements, enforcement mechanisms, and regulatory frameworks."
+    },
+    {
+        "topic_id": "G",
+        "topic_label": "Warning and Information Requirements",
+        "topic_description": "Suggestions for mandatory warnings, transparent odds display, reality checks, and clear information about risks.",
+        "topic": "Warning and Information Requirements: Suggestions for mandatory warnings, transparent odds display, reality checks, and clear information about risks."
+    },
+    {
+        "topic_id": "H",
+        "topic_label": "Community and Social Interventions",
+        "topic_description": "Focus on peer support, workplace programs, community activities, and social alternatives to gambling.",
+        "topic": "Community and Social Interventions: Focus on peer support, workplace programs, community activities, and social alternatives to gambling."
+    },
+    {
+        "topic_id": "I",
+        "topic_label": "Self-Exclusion and Control Tools",
+        "topic_description": "Improvements to self-exclusion systems, personal limit setting, and tools for individuals to control their gambling.",
+        "topic": "Self-Exclusion and Control Tools: Improvements to self-exclusion systems, personal limit setting, and tools for individuals to control their gambling."
+    },
+    {
+        "topic_id": "J",
+        "topic_label": "Marketing and Sponsorship Alternatives",
+        "topic_description": "Ideas for replacing gambling sponsorship with ethical alternatives and changing how gambling is marketed.",
+        "topic": "Marketing and Sponsorship Alternatives: Ideas for replacing gambling sponsorship with ethical alternatives and changing how gambling is marketed."
+    },
+    {
+        "topic_id": "K",
+        "topic_label": "Early Intervention Strategies",
+        "topic_description": "Approaches to identify and help at-risk individuals before addiction develops, including screening and assessment.",
+        "topic": "Early Intervention Strategies: Approaches to identify and help at-risk individuals before addiction develops, including screening and assessment."
+    },
+    {
+        "topic_id": "XX",
+        "topic_label": "None of the Above",
+        "topic_description": "The response discusses a topic not covered by the listed themes (only use this if no other theme applies).",
+        "topic": "None of the Above: The response discusses a topic not covered by the listed themes (only use this if no other theme applies)."
+    },
+    {
+        "topic_id": "XY",
+        "topic_label": "No Reason Given",
+        "topic_description": "The response does not provide a substantive answer to the question.",
+        "topic": "No Reason Given: The response does not provide a substantive answer to the question."
+    }
+]


### PR DESCRIPTION
## Context

When `themefinder` was subtree-merged into `consult`, a blanket `*.json` `.gitignore` rule (meant to keep GCP credential files out of git) silently dropped every `.json` file under the eval dataset too — not just credentials. Only the `.jsonl` files survived the merge.

`e29a7710` ("Re-add missing themefinder files") partially fixed this: it added a `.gitignore` negation and restored the two `question.json` input files, but not the two `themes.json` ground-truth files under `outputs/mapping/2025-07-22/question_part_*/`. Without them, `evals/datasets.py::_load_themes` raises `FileNotFoundError`, and every eval that scores against ground truth (`mapping`, `generation`, `condensation`, `refinement`) fails outright — confirmed by running `benchmark.py --quick` locally.

## Changes proposed in this pull request

- Add `themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_1/themes.json`
- Add `themefinder/evals/data/gambling_XS/outputs/mapping/2025-07-22/question_part_2/themes.json`

Both copied verbatim from upstream `themefinder` (commit `09918eb2`, per ADR-0009) — sha256-verified identical to both the original repo's copies.

## Guidance to review

`diff -rq` the `gambling_XS` folder here against `i-dot-ai/themefinder`'s `evals/data/gambling_XS` at commit `09918eb2` — should come back empty. Or run `uv run python evals/benchmark.py --quick` from `themefinder/` locally; `mapping`, `condensation`, and `refinement` should now produce real scores instead of `FileNotFoundError`.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo

_(n/a — no new env vars, data files only)_