### PR TITLE
PRO-515: fix local vs Langfuse eval consistency and reliability bugs

### DIFF
--- a/themefinder/evals/benchmark.py
+++ b/themefinder/evals/benchmark.py
@@ -734,11 +734,80 @@ class BenchmarkRunner:
         console.print(f"[green]Results saved to {output_path}[/green]")
 
 
-def query_langfuse_costs(benchmark_id: str) -> pd.DataFrame:
+def _fetch_langfuse_cost_rows(client, benchmark_id: str) -> pd.DataFrame:
+    """Fetch one snapshot of cost/token data for a benchmark from Langfuse.
+
+    Returns:
+        DataFrame with cost data per model/eval, sorted for stable comparison
+        across repeated calls (see query_langfuse_costs).
+    """
+    traces = client.api.trace.list(
+        tags=[f"benchmark:{benchmark_id}"],
+        limit=100,
+    )
+
+    rows = []
+    for trace in traces.data:
+        metadata = trace.metadata or {}
+
+        # TODO: this re-fetches every trace on every poll, even ones already
+        # confirmed stable - inefficient for a full eval sweep with many
+        # traces. Left as-is since this fix was about getting cost tracking
+        # working correctly, not optimising it; revisit alongside a broader
+        # refactor of the evals code.
+        full_trace = client.api.trace.get(trace.id)
+        input_tokens = 0
+        output_tokens = 0
+        total_tokens = 0
+        for obs in full_trace.observations:
+            if obs.usage:
+                input_tokens += obs.usage.input or 0
+                output_tokens += obs.usage.output or 0
+                total_tokens += obs.usage.total or 0
+
+        rows.append(
+            {
+                "model_tag": metadata.get("model_tag", "unknown"),
+                "eval": metadata.get("eval_type", "unknown"),
+                "run": metadata.get("run_number", 0),
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": total_tokens,
+                "cost_usd": trace.total_cost or 0,
+            }
+        )
+
+    if not rows:
+        return pd.DataFrame()
+    return (
+        pd.DataFrame(rows)
+        .sort_values(["model_tag", "eval", "run"])
+        .reset_index(drop=True)
+    )
+
+
+def query_langfuse_costs(
+    benchmark_id: str,
+    poll_interval_seconds: float = 4.0,
+    max_wait_seconds: float = 60.0,
+    stable_reads_required: int = 3,
+) -> pd.DataFrame:
     """Query Langfuse for cost data from benchmark runs.
+
+    Langfuse ingests traces asynchronously, so querying immediately after a
+    run can undercount tokens/cost. Token and cost figures only ever grow as
+    ingestion completes (never shrink or change once landed), so polling
+    until a read repeats unchanged `stable_reads_required` times in a row is
+    a reliable "ingestion has caught up" signal. Capped at max_wait_seconds
+    so a genuinely stuck observation can't hang the benchmark indefinitely -
+    whatever was last read is returned when the cap is hit.
 
     Args:
         benchmark_id: The benchmark ID to query.
+        poll_interval_seconds: Delay between polls.
+        max_wait_seconds: Give up and return the latest read after this long.
+        stable_reads_required: Consecutive identical reads needed to trust
+            the result.
 
     Returns:
         DataFrame with cost data per model/eval.
@@ -759,32 +828,39 @@ def query_langfuse_costs(benchmark_id: str) -> pd.DataFrame:
             host=base_url,
         )
 
-        # Fetch traces with benchmark tag
-        traces = client.api.trace.list(
-            tags=[f"benchmark:{benchmark_id}"],
-            limit=100,
-        )
+        deadline = time.monotonic() + max_wait_seconds
+        previous: pd.DataFrame | None = None
+        stable_count = 0
+        result = pd.DataFrame()
 
-        if not traces.data:
+        while True:
+            result = _fetch_langfuse_cost_rows(client, benchmark_id)
+
+            if result.empty:
+                stable_count = 0
+            else:
+                stable_count = (
+                    stable_count + 1
+                    if previous is not None and result.equals(previous)
+                    else 1
+                )
+            previous = result
+
+            if stable_count >= stable_reads_required:
+                break
+            if time.monotonic() >= deadline:
+                console.print(
+                    f"[yellow]Gave up waiting for Langfuse ingestion to "
+                    f"settle after {max_wait_seconds}s - cost/token figures "
+                    f"below may be incomplete[/yellow]"
+                )
+                break
+            time.sleep(poll_interval_seconds)
+
+        if result.empty:
             console.print("[yellow]No traces found for benchmark[/yellow]")
-            return pd.DataFrame()
 
-        rows = []
-        for trace in traces.data:
-            metadata = trace.metadata or {}
-            rows.append(
-                {
-                    "model_tag": metadata.get("model_tag", "unknown"),
-                    "eval": metadata.get("eval_type", "unknown"),
-                    "run": metadata.get("run_number", 0),
-                    "input_tokens": trace.usage.input if trace.usage else 0,
-                    "output_tokens": trace.usage.output if trace.usage else 0,
-                    "total_tokens": trace.usage.total if trace.usage else 0,
-                    "cost_usd": trace.usage.total_cost if trace.usage else 0,
-                }
-            )
-
-        return pd.DataFrame(rows)
+        return result
 
     except Exception as e:
         console.print(f"[red]Failed to query Langfuse costs: {e}[/red]")

--- a/themefinder/evals/eval_condensation.py
+++ b/themefinder/evals/eval_condensation.py
@@ -126,7 +126,7 @@ async def _run_with_langfuse(ctx, config: DatasetConfig, llm, eval_llm) -> dict:
                 trace.update(output=output)
 
             # LLM-as-judge: compression quality + information retention
-            quality_results = condensation_evaluator(
+            quality_results = await condensation_evaluator(
                 output={"themes": condensed_records},
                 expected_output={"themes": original_records},
             )
@@ -234,7 +234,7 @@ async def _run_local_fallback(config: DatasetConfig, llm, eval_llm) -> dict:
         all_results[f"{question_part}_output"] = {"condensed_themes": condensed_records}
 
         # LLM-as-judge: compression quality + information retention
-        quality_results = condensation_evaluator(
+        quality_results = await condensation_evaluator(
             output={"themes": condensed_records},
             expected_output={"themes": original_records},
         )

--- a/themefinder/evals/eval_condensation.py
+++ b/themefinder/evals/eval_condensation.py
@@ -275,4 +275,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     asyncio.run(evaluate_condensation(dataset=args.dataset))
-    asyncio.run(evaluate_condensation(dataset=args.dataset))

--- a/themefinder/evals/eval_generation.py
+++ b/themefinder/evals/eval_generation.py
@@ -23,12 +23,24 @@ from evaluators import (
     create_redundancy_evaluator,
     create_title_specificity_evaluator,
 )
-from metrics import calculate_generation_metrics
 from themefinder.llm import OpenAILLM
 
 from themefinder import theme_condensation, theme_generation, theme_refinement
 
 logger = logging.getLogger("themefinder.evals.generation")
+
+
+def _build_output(refined_df: pd.DataFrame) -> dict:
+    """Split combined "label: description" topic field into separate fields
+    for evaluators that need the label alone (specificity, redundancy)."""
+    themes = []
+    for record in refined_df.to_dict(orient="records"):
+        if "topic" in record and ":" in record["topic"]:
+            label, description = record["topic"].split(":", 1)
+            record["topic_label"] = label.strip()
+            record["topic_description"] = description.strip()
+        themes.append(record)
+    return {"themes": themes}
 
 
 async def evaluate_generation(
@@ -78,7 +90,7 @@ async def evaluate_generation(
             langfuse_ctx, config, llm, judge_llm=judge_llm
         )
     else:
-        result = await _run_local_fallback(config, llm)
+        result = await _run_local_fallback(config, llm, judge_llm=judge_llm)
 
     # Only flush if we created the context
     if owns_context:
@@ -104,7 +116,7 @@ async def _run_with_langfuse(ctx, config: DatasetConfig, llm, judge_llm=None) ->
         print(
             f"Dataset {config.name} not found in Langfuse, falling back to local: {e}"
         )
-        return await _run_local_fallback(config, llm)
+        return await _run_local_fallback(config, llm, judge_llm=judge_llm)
 
     # Use dedicated judge LLM if provided, otherwise fall back to task LLM
     eval_llm = judge_llm or llm
@@ -145,16 +157,7 @@ async def _run_with_langfuse(ctx, config: DatasetConfig, llm, judge_llm=None) ->
                 question=question,
             )
 
-            # Parse combined "label: description" topic field into separate fields
-            # for evaluators that need the label alone (specificity, redundancy)
-            themes = []
-            for record in refined_df.to_dict(orient="records"):
-                if "topic" in record and ":" in record["topic"]:
-                    label, description = record["topic"].split(":", 1)
-                    record["topic_label"] = label.strip()
-                    record["topic_description"] = description.strip()
-                themes.append(record)
-            output = {"themes": themes}
+            output = _build_output(refined_df)
 
             # Update trace with output
             if trace:
@@ -239,12 +242,20 @@ async def _run_with_langfuse(ctx, config: DatasetConfig, llm, judge_llm=None) ->
     return all_scores
 
 
-async def _run_local_fallback(config: DatasetConfig, llm) -> dict:
+async def _run_local_fallback(config: DatasetConfig, llm, judge_llm=None) -> dict:
     """Run evaluation without Langfuse (local development).
+
+    Calls the same evaluators as `_run_with_langfuse` (groundedness, coverage,
+    specificity, redundancy) instead of the separate `metrics.py` calculation,
+    so local and Langfuse runs score generation identically. Sequential, no
+    concurrency/timeout wrapper — unlike the Langfuse branch, there's no need
+    to protect a long dataset run here, and each evaluator already catches its
+    own errors internally.
 
     Args:
         config: DatasetConfig
         llm: LLM instance
+        judge_llm: Optional dedicated judge LLM (defaults to task llm)
 
     Returns:
         Dict containing evaluation scores
@@ -252,11 +263,20 @@ async def _run_local_fallback(config: DatasetConfig, llm) -> dict:
     data_items = load_local_data(config)
     all_scores = {}
 
+    # Use dedicated judge LLM if provided, otherwise fall back to task LLM
+    eval_llm = judge_llm or llm
+
+    # Create evaluator functions
+    groundedness_evaluator = create_groundedness_evaluator(eval_llm)
+    coverage_evaluator = create_coverage_evaluator(eval_llm)
+    specificity_evaluator = create_title_specificity_evaluator(eval_llm)
+    redundancy_evaluator = create_redundancy_evaluator()
+
     for item in data_items:
         question_part = item.get("metadata", {}).get("question_part", "unknown")
         responses_df = pd.DataFrame(item["input"]["responses"])
         question = item["input"]["question"]
-        theme_framework = item["expected_output"]["themes"]
+        expected_output = item["expected_output"]
 
         themes_df, _ = await theme_generation(
             responses_df=responses_df,
@@ -274,14 +294,29 @@ async def _run_local_fallback(config: DatasetConfig, llm) -> dict:
             question=question,
         )
 
-        eval_scores = calculate_generation_metrics(refined_df, theme_framework)
-        print(f"Theme Generation ({question_part}): \n {eval_scores}")
+        output = _build_output(refined_df)
 
-        # Collect scores with question prefix
-        for key, value in eval_scores.items():
-            if isinstance(value, (int, float)):
-                all_scores[f"{question_part}_{key}"] = value
+        eval_results = [
+            groundedness_evaluator(output=output, expected_output=expected_output),
+            coverage_evaluator(output=output, expected_output=expected_output),
+            specificity_evaluator(output=output, expected_output=expected_output),
+            redundancy_evaluator(output=output, expected_output=expected_output),
+        ]
 
+        for eval_result in eval_results:
+            if isinstance(eval_result, dict):
+                name = eval_result.get("name", "unknown")
+                value = eval_result.get("value", 0.0)
+            else:
+                name = eval_result.name
+                value = eval_result.value
+            all_scores[f"{question_part}_{name}"] = value
+            print(f"  {question_part}/{name}: {value}")
+
+        # Include pipeline output for disk persistence, matching _run_with_langfuse
+        all_scores[f"{question_part}_output"] = output
+
+    print("Theme Generation Eval Results (local)")
     return all_scores
 
 

--- a/themefinder/evals/eval_generation.py
+++ b/themefinder/evals/eval_generation.py
@@ -6,11 +6,9 @@ against a ground truth theme framework.
 
 import argparse
 import asyncio
-import contextvars
 import logging
 import os
 from datetime import datetime
-from functools import partial
 
 import dotenv
 import langfuse_utils
@@ -163,35 +161,16 @@ async def _run_with_langfuse(ctx, config: DatasetConfig, llm, judge_llm=None) ->
             if trace:
                 trace.update(output=output)
 
-            # Run LLM-based evaluators concurrently (copy context per task for logging)
-            loop = asyncio.get_event_loop()
-            llm_evaluators = [
-                groundedness_evaluator,
-                coverage_evaluator,
-                specificity_evaluator,
-            ]
-            llm_tasks = [
-                loop.run_in_executor(
-                    None,
-                    partial(
-                        contextvars.copy_context().run,
-                        evaluator,
-                        output=output,
-                        expected_output=item.expected_output,
-                    ),
-                )
-                for evaluator in llm_evaluators
-            ]
-            try:
-                llm_results = await asyncio.wait_for(
-                    asyncio.gather(*llm_tasks, return_exceptions=True),
-                    timeout=300,
-                )
-            except asyncio.TimeoutError:
-                logger.error("LLM evaluators timed out after 300s")
-                llm_results = [TimeoutError("LLM evaluators timed out")] * len(
-                    llm_evaluators
-                )
+            llm_results = await asyncio.gather(
+                groundedness_evaluator(
+                    output=output, expected_output=item.expected_output
+                ),
+                coverage_evaluator(output=output, expected_output=item.expected_output),
+                specificity_evaluator(
+                    output=output, expected_output=item.expected_output
+                ),
+                return_exceptions=True,
+            )
 
             # Run redundancy evaluator synchronously (embedding-based, no LLM call)
             redundancy_result = redundancy_evaluator(
@@ -247,9 +226,8 @@ async def _run_local_fallback(config: DatasetConfig, llm, judge_llm=None) -> dic
 
     Calls the same evaluators as `_run_with_langfuse` (groundedness, coverage,
     specificity, redundancy) instead of the separate `metrics.py` calculation,
-    so local and Langfuse runs score generation identically. Sequential, no
-    concurrency/timeout wrapper — unlike the Langfuse branch, there's no need
-    to protect a long dataset run here, and each evaluator already catches its
+    so local and Langfuse runs score generation identically. LLM-based
+    evaluators run concurrently via asyncio.gather(); each already catches its
     own errors internally.
 
     Args:
@@ -296,12 +274,15 @@ async def _run_local_fallback(config: DatasetConfig, llm, judge_llm=None) -> dic
 
         output = _build_output(refined_df)
 
-        eval_results = [
+        llm_results = await asyncio.gather(
             groundedness_evaluator(output=output, expected_output=expected_output),
             coverage_evaluator(output=output, expected_output=expected_output),
             specificity_evaluator(output=output, expected_output=expected_output),
-            redundancy_evaluator(output=output, expected_output=expected_output),
-        ]
+        )
+        redundancy_result = redundancy_evaluator(
+            output=output, expected_output=expected_output
+        )
+        eval_results = [*llm_results, redundancy_result]
 
         for eval_result in eval_results:
             if isinstance(eval_result, dict):

--- a/themefinder/evals/eval_refinement.py
+++ b/themefinder/evals/eval_refinement.py
@@ -125,7 +125,7 @@ async def _run_with_langfuse(ctx, config: DatasetConfig, llm, eval_llm) -> dict:
                 trace.update(output=output)
 
             # LLM-as-judge: 4-dimension quality evaluation
-            quality_results = refinement_evaluator(
+            quality_results = await refinement_evaluator(
                 output={"themes": refined_records},
                 expected_output={"themes": original_records},
             )
@@ -213,7 +213,7 @@ async def _run_local_fallback(config: DatasetConfig, llm, eval_llm) -> dict:
         all_results[f"{question_part}_output"] = {"refined_themes": refined_records}
 
         # LLM-as-judge: 4-dimension quality evaluation
-        quality_results = refinement_evaluator(
+        quality_results = await refinement_evaluator(
             output={"themes": refined_records},
             expected_output={"themes": original_records},
         )

--- a/themefinder/evals/evaluators.py
+++ b/themefinder/evals/evaluators.py
@@ -12,8 +12,16 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
+import openai
 from sklearn import metrics
 from sklearn.preprocessing import MultiLabelBinarizer
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from prompts import (
     condensation_eval_prompt,
@@ -23,6 +31,34 @@ from prompts import (
 )
 
 logger = logging.getLogger("themefinder.evals.evaluators")
+
+
+@retry(
+    wait=wait_random_exponential(min=1, max=20),
+    stop=stop_after_attempt(3),
+    retry=retry_if_exception_type(
+        (openai.APIConnectionError, openai.RateLimitError, openai.InternalServerError)
+    ),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
+async def _invoke_with_retry(llm: Any, prompt: str) -> Any:
+    """Call llm.ainvoke(), retrying on transient connection errors.
+
+    OpenAILLM.invoke()'s sync wrapper spins up a fresh event loop per call
+    while reusing a single shared AsyncOpenAI client - the client's
+    connection pool is bound to whichever loop first touched it, so reusing
+    it from a different loop occasionally raises a spurious
+    APIConnectionError. Calling ainvoke() directly (we're always inside a
+    running loop here) avoids that entirely; the retry is a backstop for
+    ordinary transient network issues, same as llm_batch_processor.py.
+
+    Only retries connection errors, rate limits, and server-side 5xxs -
+    APIConnectionError's own subclass APITimeoutError is covered too.
+    Non-transient errors (bad request, auth, etc.) reraise immediately
+    instead of burning retry attempts on something that won't change.
+    """
+    return await llm.ainvoke(prompt)
 
 
 def _parse_json_markdown(text: str) -> dict:
@@ -160,7 +196,7 @@ def _build_comment(result: dict[str, Any], metric_name: str) -> str:
     return f"{summary}\n" + "\n".join(decision_parts)
 
 
-def _calculate_groundedness_scores(
+async def _calculate_groundedness_scores(
     generated_themes: list[dict] | dict,
     expected_themes: dict,
     llm: Any,
@@ -178,17 +214,18 @@ def _calculate_groundedness_scores(
     shuffled_generated = _shuffle_themes(generated_themes)
     shuffled_expected = _shuffle_themes(expected_themes)
 
-    response = llm.invoke(
+    response = await _invoke_with_retry(
+        llm,
         generation_eval_prompt(
             topic_list_1=shuffled_generated,
             topic_list_2=shuffled_expected,
-        )
+        ),
     )
 
     return _parse_evaluation_response(response.parsed)
 
 
-def _calculate_coverage_scores(
+async def _calculate_coverage_scores(
     generated_themes: list[dict] | dict,
     expected_themes: dict,
     llm: Any,
@@ -207,11 +244,12 @@ def _calculate_coverage_scores(
     shuffled_expected = _shuffle_themes(expected_themes)
 
     # Reverse direction: expected -> generated
-    response = llm.invoke(
+    response = await _invoke_with_retry(
+        llm,
         generation_eval_prompt(
             topic_list_1=shuffled_expected,
             topic_list_2=shuffled_generated,
-        )
+        ),
     )
 
     return _parse_evaluation_response(response.parsed)
@@ -227,10 +265,12 @@ def create_groundedness_evaluator(llm: Any):
         Evaluator function compatible with run_experiment()
     """
 
-    def groundedness_evaluator(*, output: dict, expected_output: dict, **kwargs) -> Any:
+    async def groundedness_evaluator(
+        *, output: dict, expected_output: dict, **kwargs
+    ) -> Any:
         """Evaluate how well generated themes are grounded in expected themes."""
         try:
-            result = _calculate_groundedness_scores(
+            result = await _calculate_groundedness_scores(
                 output.get("themes", []),
                 expected_output.get("themes", {}),
                 llm,
@@ -256,10 +296,12 @@ def create_coverage_evaluator(llm: Any):
         Evaluator function compatible with run_experiment()
     """
 
-    def coverage_evaluator(*, output: dict, expected_output: dict, **kwargs) -> Any:
+    async def coverage_evaluator(
+        *, output: dict, expected_output: dict, **kwargs
+    ) -> Any:
         """Evaluate how well expected themes are covered by generated themes."""
         try:
-            result = _calculate_coverage_scores(
+            result = await _calculate_coverage_scores(
                 output.get("themes", []),
                 expected_output.get("themes", {}),
                 llm,
@@ -307,7 +349,7 @@ def mapping_f1_evaluator(*, output: dict, expected_output: dict, **kwargs) -> An
         return _make_evaluation("f1_score", 0.0, f"Error: {e}")
 
 
-def _calculate_title_specificity(
+async def _calculate_title_specificity(
     themes: list[dict] | dict,
     llm: Any,
 ) -> dict[str, Any]:
@@ -331,10 +373,11 @@ def _calculate_title_specificity(
     if not titles:
         return {"ratio": 0.0, "n_specific": 0, "n_total": 0, "details": []}
 
-    response = llm.invoke(
+    response = await _invoke_with_retry(
+        llm,
         title_specificity_eval_prompt(
             theme_titles=titles,
-        )
+        ),
     )
 
     parsed = _parse_json_markdown(response.parsed)
@@ -377,10 +420,12 @@ def create_title_specificity_evaluator(llm: Any):
         Evaluator function compatible with run_experiment().
     """
 
-    def specificity_evaluator(*, output: dict, expected_output: dict, **kwargs) -> Any:
+    async def specificity_evaluator(
+        *, output: dict, expected_output: dict, **kwargs
+    ) -> Any:
         """Evaluate how specific the generated theme titles are."""
         try:
-            result = _calculate_title_specificity(
+            result = await _calculate_title_specificity(
                 output.get("themes", []),
                 llm,
             )
@@ -402,7 +447,7 @@ def create_title_specificity_evaluator(llm: Any):
     return specificity_evaluator
 
 
-def _calculate_condensation_scores(
+async def _calculate_condensation_scores(
     condensed_themes: list[dict] | dict,
     original_themes: list[dict] | dict,
     llm: Any,
@@ -417,11 +462,12 @@ def _calculate_condensation_scores(
     Returns:
         Dict with compression_quality, information_retention, and reasoning.
     """
-    response = llm.invoke(
+    response = await _invoke_with_retry(
+        llm,
         condensation_eval_prompt(
             original_topics=original_themes,
             condensed_topics=condensed_themes,
-        )
+        ),
     )
 
     parsed = _parse_json_markdown(response.parsed)
@@ -448,12 +494,12 @@ def create_condensation_quality_evaluator(llm: Any):
         Evaluator function that returns a list of Evaluation objects.
     """
 
-    def condensation_evaluator(
+    async def condensation_evaluator(
         *, output: dict, expected_output: dict, **kwargs
     ) -> list:
         """Evaluate condensation quality on compression and information retention."""
         try:
-            result = _calculate_condensation_scores(
+            result = await _calculate_condensation_scores(
                 output.get("themes", []),
                 expected_output.get("themes", []),
                 llm,
@@ -485,7 +531,7 @@ REFINEMENT_METRICS = (
 )
 
 
-def _calculate_refinement_scores(
+async def _calculate_refinement_scores(
     refined_themes: list[dict] | dict,
     original_themes: list[dict] | dict,
     llm: Any,
@@ -500,11 +546,12 @@ def _calculate_refinement_scores(
     Returns:
         Dict with four metric scores and reasoning.
     """
-    response = llm.invoke(
+    response = await _invoke_with_retry(
+        llm,
         refinement_eval_prompt(
             original_topics=original_themes,
             new_topics=refined_themes,
-        )
+        ),
     )
 
     parsed = _parse_json_markdown(response.parsed)
@@ -525,10 +572,12 @@ def create_refinement_quality_evaluator(llm: Any):
         Evaluator function that returns a list of Evaluation objects.
     """
 
-    def refinement_evaluator(*, output: dict, expected_output: dict, **kwargs) -> list:
+    async def refinement_evaluator(
+        *, output: dict, expected_output: dict, **kwargs
+    ) -> list:
         """Evaluate refinement quality on four dimensions."""
         try:
-            result = _calculate_refinement_scores(
+            result = await _calculate_refinement_scores(
                 output.get("themes", []),
                 expected_output.get("themes", []),
                 llm,

--- a/themefinder/evals/metrics.py
+++ b/themefinder/evals/metrics.py
@@ -1,72 +1,7 @@
-import json
-import os
-
 import numpy as np
 import pandas as pd
-import utils_gateway
 from sklearn import metrics, utils
 from sklearn.preprocessing import MultiLabelBinarizer
-from themefinder.llm import OpenAILLM
-
-from prompts import generation_eval_prompt
-
-# Minimum score (0-5) to consider a topic well-grounded or captured
-GROUNDEDNESS_THRESHOLD = 3
-
-
-def calculate_generation_metrics(
-    generated_topics: pd.DataFrame,
-    topic_framework: dict,
-    llm=None,
-) -> dict[str, float | int]:
-    """Calculate precision and recall metrics for generated themes against a framework.
-
-    Args:
-        generated_topics (pd.DataFrame): DataFrame containing generated themes as columns
-        topic_framework (dict): Dictionary containing reference framework themes
-        llm: Optional LLM instance. If not provided, creates one from env vars.
-
-    Returns:
-        dict[str, float | int]: Dictionary with keys:
-            - Precision N topics: Number of generated topics
-            - Precision N not well grounded: Count of topics below threshold
-            - Precision Average Groundedness: Mean groundedness score
-            - Recall N not Captured: Count of framework topics not captured
-            - Recall Average topic Representation: Mean representation score
-    """
-    if llm is None:
-        base_url, api_key = utils_gateway.gateway_credentials()
-        llm = OpenAILLM(
-            model=os.getenv("AUTO_EVAL_4_1_SWEDEN_DEPLOYMENT"),
-            request_kwargs={"temperature": 0},
-            base_url=base_url,
-            api_key=api_key,
-        )
-    precision_response = llm.invoke(
-        generation_eval_prompt(
-            topic_list_1=generated_topics,
-            topic_list_2=topic_framework,
-        )
-    )
-    precision_scores = list(json.loads(precision_response.parsed).values())
-    recall_response = llm.invoke(
-        generation_eval_prompt(
-            topic_list_1=topic_framework,
-            topic_list_2=generated_topics,
-        )
-    )
-    recall_scores = list(json.loads(recall_response.parsed).values())
-    return {
-        "Precision N topics": len(generated_topics),
-        "Precision N not well grounded": sum(
-            score < GROUNDEDNESS_THRESHOLD for score in precision_scores
-        ),
-        "Precision Average Groundedness": np.mean(precision_scores).round(2),
-        "Recall N not Captured": sum(
-            score < GROUNDEDNESS_THRESHOLD for score in recall_scores
-        ),
-        "Recall Average topic Representation": np.mean(recall_scores).round(2),
-    }
 
 
 def calculate_mapping_metrics(

--- a/themefinder/pyproject.toml
+++ b/themefinder/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "httpx>=0.23.0",
     "pandas>=2.2.2",
     "python-dotenv>=1.0.1",
-    "langfuse>=3.12.1,<4.10.0",
+    "langfuse>=3.12.1,<4.0.0",
     "boto3>=1.29",
     "scikit-learn",
     "openpyxl>=3.1.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1051,11 +1051,12 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "4.9.1"
+version = "3.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "httpx" },
+    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -1063,9 +1064,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/9a/c2e4b5c33a225a0158de0e774396823612a6c5beea21cde42e95b196c398/langfuse-4.9.1.tar.gz", hash = "sha256:e3d7162a8004f71abd6ad90fba2f3a7d0088cbdce1c77deea521837d49580ab4", size = 339957, upload-time = "2026-06-19T09:30:49.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/db/08266f22e1843d4c2743a1d23b7f93828ec6d5f6a4445f7d2ad3074d8b95/langfuse-3.15.0.tar.gz", hash = "sha256:4b6453c82c8159e5f0655ced24b145ed8279b47382a6b4a6d7a57111ef922181", size = 237275, upload-time = "2026-05-21T11:12:59.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/9e/2b21989730ebb613118a667e59f652aebb5a1ca07de10984bf28a02a888f/langfuse-4.9.1-py3-none-any.whl", hash = "sha256:3feb00679aff2ff45b0e786574c748d7c40d23768452e17e3a02e8706b7cbce3", size = 599839, upload-time = "2026-06-19T09:30:48.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5b/1f16b421f5de996abfb10472d47c72bc829a56cbedacfbf908ebf8cc0469/langfuse-3.15.0-py3-none-any.whl", hash = "sha256:66a3c2b75af9402ffc13690fce73181325d6f78e723463e38844b317d37279ac", size = 424191, upload-time = "2026-05-21T11:12:57.493Z" },
 ]
 
 [[package]]
@@ -1669,11 +1670,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
@@ -2514,7 +2515,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.6.10" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "httpx", specifier = ">=0.23.0" },
-    { name = "langfuse", specifier = ">=3.12.1,<4.10.0" },
+    { name = "langfuse", specifier = ">=3.12.1,<4.0.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.50" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27.0" },
@@ -2824,22 +2825,21 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "2.2.2"
+version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
-    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
-    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
-    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
-    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
-    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Local (`--dataset` direct) and Langfuse-backed eval runs for `themefinder` were producing inconsistent, sometimes broken results, and the local generation eval was crashing outright. Digging into why surfaced a chain of infrastructure bugs in the shared eval harness (`evals/benchmark.py`, `evals/evaluators.py`, `evals/eval_generation.py`, etc.) that were masking or compounding each other - this PR fixes the root cause plus everything downstream of it that surfaced along the way.

## Changes proposed in this pull request

**Core consistency fix:**

- Local generation eval was crashing on every run (`TypeError` in `metrics.py`'s parser, which was never updated after the judge prompt moved to a decision-based schema). Local fallback now uses the same four evaluators the Langfuse branch already used; `metrics.py` deleted.

**Langfuse infrastructure bugs (all silently broken, not obvious from the UI):**

- Langfuse SDK was resolving to an unpinned v4 despite the tracing code being written for v3 (`start_as_current_span`, `DatasetItem.run()` - both removed in v4) - every trace/dataset-run silently failed. Pinned to `<4.0.0`.
- `query_langfuse_costs()` always raised `AttributeError` reading `trace.usage` - that field doesn't exist on any Langfuse trace type, on any SDK version (traced back to the exact upstream commit that introduced it - never worked). Fixed to fetch real per-observation usage; added stability-polling since ingestion is async and querying immediately undercounts.
- Intermittent `APIConnectionError` on judge LLM calls, reproduced on both branches - root cause was `OpenAILLM.invoke()`'s sync wrapper spinning a fresh thread+event loop per call while reusing one shared client, breaking its connection pool. Evaluators now call `ainvoke()` directly with a narrowly-scoped tenacity retry (transient connection/rate-limit/5xx errors only, not auth/malformed-request failures).
- Generation eval's concurrent judge calls were wrapped in a shared 300s timeout that discarded all three scores together on one slow call. Fixed by restoring safe concurrency (now that `ainvoke()` doesn't have the connection-pool bug) with `return_exceptions=True` so one bad call can't take the others down.
- Cost-query polling could falsely converge on "no data yet" within a few seconds instead of waiting out the full timeout, if Langfuse hadn't ingested anything yet when the first poll ran.

**Drive-by fixes, unrelated but noticed along the way:**

- `eval_condensation.py`'s `__main__` ran the eval twice per invocation (duplicated `asyncio.run` call).

## Guidance to review

Each fix was reasoned through and live-tested individually against `gambling_XS` (both the Langfuse-backed and local-fallback branches separately) before being committed - happy to walk through the reasoning on any of them. Worth particular attention:

- `evals/benchmark.py`'s `query_langfuse_costs`/`_fetch_langfuse_cost_rows` - worth being explicit that this is a backstop for the current setup, not necessarily the most efficient shape - it blocks the event loop for the duration of the poll and re-fetches every trace's full details each cycle, and fixing that properly means revisiting the sync/async boundary in this file. Langfuse's v4 SDK may offer a cleaner path (bulk observation fetches, real-time aggregate metrics) but that's untested against our pinned v3 setup and out of scope here.
- `evals/evaluators.py`'s `_invoke_with_retry` - the retry predicate and its interaction with the now-concurrent evaluator calls in `eval_generation.py`.

**Known, deliberately out of scope:**

- Local vs Langfuse mapping-stage metrics still differ (`f1` only on the Langfuse side vs `f1`/`accuracy_score`/`overlap_rate` locally) - real gap, deferred to follow-up full refactor ticket.
- `_fetch_langfuse_cost_rows` re-fetches every trace's full details on every poll cycle - fine at small scale, flagged with a `TODO` for a larger sweep; not fixed here since this PR was about correctness, not throughput.
- The standalone `eval_generation.py`/`eval_condensation.py`/`eval_refinement.py` scripts (run directly, not via `benchmark.py`) still have no explicit LLM timeout override - low impact (nothing in CI calls them directly), deferred.

## Things to check

- [x] No new ENV vars introduced - nothing to add to deployed environments or `.env.test`.