### PR TITLE
PRO-523: tune Sentry performance sampling per environment

### DIFF
--- a/backend/sentry_context.py
+++ b/backend/sentry_context.py
@@ -2,6 +2,20 @@ import sentry_sdk
 
 MANUAL_CAPTURE_TAG = "consult.manual_capture"
 
+# Error capture is independent of these rates: before_send runs regardless, so
+# lowering them doesn't drop errors.
+PROD_PERF_SAMPLE_RATE = 0.1
+NON_PROD_PERF_SAMPLE_RATE = 1.0
+
+
+def default_perf_sample_rate(environment):
+    """Env-aware default for trace/profile sampling. Overridable per environment via
+    the SENTRY_*_SAMPLE_RATE env vars; this is just the fallback when they're unset.
+    """
+    if environment.lower() == "prod":
+        return PROD_PERF_SAMPLE_RATE
+    return NON_PROD_PERF_SAMPLE_RATE
+
 
 def capture_handled_sentry_exception(error=None, **kwargs):
     """Drop-in replacement for sentry_sdk.capture_exception for exceptions the

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -4,7 +4,7 @@ from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
 from i_dot_ai_utilities.logging.types.enrichment_types import ExecutionEnvironmentType
 from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 
-from sentry_context import sentry_before_send
+from sentry_context import default_perf_sample_rate, sentry_before_send
 from settings.base import *
 
 CSRF_TRUSTED_ORIGINS = TRUSTED_ORIGINS
@@ -27,12 +27,16 @@ STORAGES["staticfiles"] = {
 }
 
 
+_perf_sample_rate = default_perf_sample_rate(ENVIRONMENT)
+
 sentry_sdk.init(
     dsn=SENTRY_DSN,
     environment=ENVIRONMENT,
     before_send=sentry_before_send,
-    traces_sample_rate=1.0,
-    profile_session_sample_rate=1.0,
+    traces_sample_rate=env.float("SENTRY_TRACES_SAMPLE_RATE", default=_perf_sample_rate),
+    profile_session_sample_rate=env.float(
+        "SENTRY_PROFILE_SESSION_SAMPLE_RATE", default=_perf_sample_rate
+    ),
     profile_lifecycle="trace",
 )
 

--- a/backend/tests/unit/test_sentry_context.py
+++ b/backend/tests/unit/test_sentry_context.py
@@ -1,8 +1,13 @@
 from unittest.mock import patch
 
+import pytest
+
 from sentry_context import (
     MANUAL_CAPTURE_TAG,
+    NON_PROD_PERF_SAMPLE_RATE,
+    PROD_PERF_SAMPLE_RATE,
     capture_handled_sentry_exception,
+    default_perf_sample_rate,
     sentry_before_send,
 )
 
@@ -77,3 +82,20 @@ class TestSentryBeforeSend:
         event = _event(mechanism={"type": "django", "handled": False})
 
         assert sentry_before_send(event, {}) is event
+
+
+class TestDefaultPerfSampleRate:
+    def test_prod_samples_a_fraction(self):
+        assert default_perf_sample_rate("prod") == PROD_PERF_SAMPLE_RATE
+
+    @pytest.mark.parametrize("environment", ["dev", "preprod", "local"])
+    def test_non_prod_keeps_everything(self, environment):
+        assert default_perf_sample_rate(environment) == NON_PROD_PERF_SAMPLE_RATE
+
+    @pytest.mark.parametrize("environment", ["PROD", "Prod"])
+    def test_prod_match_is_case_insensitive(self, environment):
+        assert default_perf_sample_rate(environment) == PROD_PERF_SAMPLE_RATE
+
+    def test_prod_default_is_lower_than_non_prod(self):
+        """The whole point of the ticket: prod deliberately samples less."""
+        assert PROD_PERF_SAMPLE_RATE < NON_PROD_PERF_SAMPLE_RATE


### PR DESCRIPTION
## Context

Prod was tracing and profiling 100% of transactions, which is expensive and rarely useful once a service is stable. This tunes Sentry performance sampling deliberately: prod samples a fraction while other envs keep everything for debugging. Error capture is untouched and stays at 100%.

## Changes proposed in this pull request

- Trace and profile session sample rates now read `SENTRY_TRACES_SAMPLE_RATE` and `SENTRY_PROFILE_SESSION_SAMPLE_RATE`, defaulting to 0.1 in prod and 1.0 elsewhere via a new `default_perf_sample_rate` helper.
- Helper lives in `sentry_context.py` so it's unit-testable without loading deployed-only settings.
- Added tests covering the prod fraction, non-prod envs, case-insensitive matching, and that prod is deliberately lower than non-prod.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
