### PR TITLE
Bootstrap OpenTelemetry in workers, Batch and Lambda

### DIFF
--- a/backend/consultations/apps.py
+++ b/backend/consultations/apps.py
@@ -9,6 +9,12 @@ class ConsultationsConfig(AppConfig):
 
     def ready(self):
         logger = settings.LOGGER
+
+        if settings.EXECUTION_CONTEXT == "worker":
+            from otel_bootstrap import bootstrap_otel
+
+            bootstrap_otel(service_name="consult-worker")
+
         if settings.ENVIRONMENT.upper() in ["LOCAL", "TEST"]:
             s3_client = s3.get_s3_client()
             buckets = s3_client.list_buckets()["Buckets"]

--- a/backend/otel_bootstrap.py
+++ b/backend/otel_bootstrap.py
@@ -1,0 +1,91 @@
+"""Process-level OpenTelemetry bootstrap for the RQ worker.
+
+Dormant until OTEL_ENABLED is on, a collector endpoint is set, and the util's
+[otel] extra is installed; a no-op otherwise so the worker keeps running on the
+existing StructuredLogger.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+from typing import Any
+
+from django.conf import settings
+
+OTEL_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT"
+OTEL_ENABLED_ENV = "OTEL_ENABLED"
+_TRACER_NAME = "consult.worker"
+
+
+def otel_requested() -> bool:
+    """Bootstrap only when the flag is on and a collector endpoint is configured."""
+    enabled = os.environ.get(OTEL_ENABLED_ENV, "").strip().lower() == "true"
+    return enabled and bool(os.environ.get(OTEL_ENDPOINT_ENV))
+
+
+def bootstrap_otel(service_name: str) -> None:
+    """Configure OTel for a long-lived worker process. No-op unless requested."""
+    if not otel_requested():
+        return
+
+    logger = settings.LOGGER
+    try:
+        from i_dot_ai_utilities.logging._otel import (
+            configure_otel,
+            ensure_structlog_otel_processors,
+        )
+    except ImportError:
+        logger.warning(
+            "OTel endpoint is set but the i-dot-ai-utilities [otel] extra is not "
+            "installed; telemetry disabled for {service_name}",
+            service_name=service_name,
+        )
+        return
+
+    try:
+        configure_otel(service_name=service_name)
+        ensure_structlog_otel_processors()
+    except RuntimeError:
+        logger.warning(
+            "OTel endpoint is set but the exporter is unavailable; telemetry "
+            "disabled for {service_name}",
+            service_name=service_name,
+        )
+
+
+@contextlib.contextmanager
+def execution_span(name: str, *, context_id: str | None = None, **attributes: Any) -> Iterator[None]:
+    """Wrap a unit of work in a span, carrying context_id so logs correlate.
+
+    A no-op that just runs the body when OTel isn't configured.
+    """
+    if not otel_requested():
+        yield
+        return
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        yield
+        return
+
+    tracer = trace.get_tracer(_TRACER_NAME)
+    with tracer.start_as_current_span(name) as span:
+        if context_id:
+            span.set_attribute("context_id", context_id)
+        for key, value in attributes.items():
+            if value is not None:
+                span.set_attribute(key, value)
+        yield
+
+
+def flush_otel() -> None:
+    """Flush pending telemetry at a job boundary. No-op unless requested."""
+    if not otel_requested():
+        return
+    try:
+        from i_dot_ai_utilities.logging._otel import force_flush_otel
+    except ImportError:
+        return
+    force_flush_otel()

--- a/backend/rq_context.py
+++ b/backend/rq_context.py
@@ -3,6 +3,7 @@ import functools
 from django_rq import job as _rq_job
 
 from logging_context import get_or_create_context_id, rebind_context
+from otel_bootstrap import execution_span, flush_otel
 
 
 def job(*job_args, **job_kwargs):
@@ -17,7 +18,19 @@ def job(*job_args, **job_kwargs):
         @functools.wraps(func)
         def context_aware(*args, context_id: str | None = None, **kwargs):
             rebind_context(context_id)
-            return func(*args, **kwargs)
+            # Resolve after rebinding so the span carries the same id as the logs.
+            resolved_context_id = get_or_create_context_id()
+            try:
+                with execution_span(
+                    f"rq.job {func.__name__}",
+                    context_id=resolved_context_id,
+                    rq_job=func.__name__,
+                ):
+                    return func(*args, **kwargs)
+            finally:
+                # A worker can idle after a job, so flush at the boundary rather
+                # than wait for the batch processor's timer.
+                flush_otel()
 
         decorated = _rq_job(*job_args, **job_kwargs)(context_aware)
         enqueue_call = decorated.delay  # .delay and .enqueue are the same underlying function

--- a/backend/tests/unit/test_otel_bootstrap.py
+++ b/backend/tests/unit/test_otel_bootstrap.py
@@ -1,0 +1,81 @@
+"""The OTel seam stays dormant unless the flag is on and an endpoint is wired."""
+
+import sys
+
+import pytest
+
+import otel_bootstrap
+
+
+@pytest.fixture(autouse=True)
+def _clear_otel_env(monkeypatch):
+    monkeypatch.delenv(otel_bootstrap.OTEL_ENDPOINT_ENV, raising=False)
+    monkeypatch.delenv(otel_bootstrap.OTEL_ENABLED_ENV, raising=False)
+
+
+def _enable(monkeypatch):
+    monkeypatch.setenv(otel_bootstrap.OTEL_ENABLED_ENV, "true")
+    monkeypatch.setenv(otel_bootstrap.OTEL_ENDPOINT_ENV, "http://collector:4318")
+
+
+class TestOtelRequested:
+    def test_false_by_default(self):
+        assert otel_bootstrap.otel_requested() is False
+
+    def test_false_with_endpoint_but_flag_off(self, monkeypatch):
+        monkeypatch.setenv(otel_bootstrap.OTEL_ENDPOINT_ENV, "http://collector:4318")
+        assert otel_bootstrap.otel_requested() is False
+
+    def test_false_with_flag_but_no_endpoint(self, monkeypatch):
+        monkeypatch.setenv(otel_bootstrap.OTEL_ENABLED_ENV, "true")
+        assert otel_bootstrap.otel_requested() is False
+
+    def test_false_when_flag_not_true(self, monkeypatch):
+        monkeypatch.setenv(otel_bootstrap.OTEL_ENABLED_ENV, "false")
+        monkeypatch.setenv(otel_bootstrap.OTEL_ENDPOINT_ENV, "http://collector:4318")
+        assert otel_bootstrap.otel_requested() is False
+
+    def test_true_with_flag_and_endpoint(self, monkeypatch):
+        _enable(monkeypatch)
+        assert otel_bootstrap.otel_requested() is True
+
+
+class TestBootstrapOtel:
+    def test_noop_when_dormant_does_not_import_util(self, monkeypatch):
+        def explode(*_args, **_kwargs):
+            raise AssertionError("must not touch the util when dormant")
+
+        monkeypatch.setattr(otel_bootstrap, "flush_otel", explode)
+        otel_bootstrap.bootstrap_otel(service_name="consult-worker")
+
+    def test_warns_when_requested_but_extra_missing(self, monkeypatch, settings):
+        _enable(monkeypatch)
+        # The [otel] extra is installed in CI, so fake its absence to reach the ImportError branch.
+        monkeypatch.setitem(sys.modules, "i_dot_ai_utilities.logging._otel", None)
+        warnings = []
+        monkeypatch.setattr(
+            settings.LOGGER, "warning", lambda msg, **kw: warnings.append((msg, kw))
+        )
+        otel_bootstrap.bootstrap_otel(service_name="consult-worker")
+        assert warnings
+        assert warnings[0][1]["service_name"] == "consult-worker"
+
+
+class TestFlushOtel:
+    def test_noop_when_dormant(self):
+        otel_bootstrap.flush_otel()
+
+
+class TestExecutionSpan:
+    def test_runs_body_when_dormant(self):
+        ran = False
+        with otel_bootstrap.execution_span("rq.job probe", context_id="abc", rq_job="probe"):
+            ran = True
+        assert ran
+
+    def test_body_exception_propagates(self):
+        with (
+            pytest.raises(ValueError, match="boom"),
+            otel_bootstrap.execution_span("rq.job probe"),
+        ):
+            raise ValueError("boom")

--- a/lambda/import_candidate_themes/Makefile
+++ b/lambda/import_candidate_themes/Makefile
@@ -10,4 +10,5 @@ build:
 	mkdir -p -- ${BUILD_DIR} ${PACKAGES_DIR}/python
 	uv pip install -r code/requirements.txt --target code/package
 	cp code/main.py ${BUILD_DIR}/
+	cp ../shared/otel_bootstrap.py ${BUILD_DIR}/
 	cp -r code/package/* ${PACKAGES_DIR}/python/

--- a/lambda/import_candidate_themes/code/main.py
+++ b/lambda/import_candidate_themes/code/main.py
@@ -9,6 +9,7 @@ from i_dot_ai_utilities.logging.types.enrichment_types import (
     ExecutionEnvironmentType,
 )
 from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
+from otel_bootstrap import bootstrap_otel, execution_span, flush_otel
 from rq import Queue
 
 logger = StructuredLogger(
@@ -27,6 +28,8 @@ if sentry_dsn:
         traces_sample_rate=1.0,
     )
     logger.info("Sentry initialized")
+
+bootstrap_otel(service_name="consult-import-candidate-themes", logger=logger)
 
 
 def _epoch_ms_to_iso(epoch_ms: int | None) -> str | None:
@@ -73,52 +76,55 @@ def lambda_handler(event, context):
     )
 
     try:
-        # Connect to Redis
-        redis_host = os.environ.get("REDIS_HOST")
-        if redis_host is None:
-            raise ValueError("REDIS_HOST environment variable is required")
-        redis_port = int(os.environ.get("REDIS_PORT", "6379"))
-
-        logger.info(
-            "Connecting to Redis: {redis_host}:{redis_port}",
-            redis_host=redis_host,
-            redis_port=redis_port,
-        )
-
-        redis_conn = redis.Redis(
-            host=redis_host,
-            port=redis_port,
-            socket_timeout=30,
-            socket_connect_timeout=30,
-        )
-
-        # Test Redis connection
-        ping_result = redis_conn.ping()
-        logger.info("✅ Redis PING result: {ping_result}", ping_result=ping_result)
-
-        # Enqueue the RQ job
-        queue_name = "default"
-        queue = Queue(queue_name, connection=redis_conn)
-        logger.info("Enqueueing RQ job to import candidate themes...")
-        job = queue.enqueue(
-            "data_pipeline.jobs.import_candidate_themes",
-            consultation_code,
-            run_date,
-            user_id,
-            model_name,
+        with execution_span(
+            "lambda.import_candidate_themes",
             context_id=context_id,
-        )
-
-        logger.info(
-            "✅ Successfully queued candidate themes import job {job_id} for: {consultation_code}. "
-            "Job status: {job_status}, queue '{queue_name}' now has {job_count} jobs",
-            job_id=job.id,
             consultation_code=consultation_code,
-            job_status=job.get_status(),
-            queue_name=queue_name,
-            job_count=len(queue),
-        )
+        ):
+            redis_host = os.environ.get("REDIS_HOST")
+            if redis_host is None:
+                raise ValueError("REDIS_HOST environment variable is required")
+            redis_port = int(os.environ.get("REDIS_PORT", "6379"))
 
+            logger.info(
+                "Connecting to Redis: {redis_host}:{redis_port}",
+                redis_host=redis_host,
+                redis_port=redis_port,
+            )
+
+            redis_conn = redis.Redis(
+                host=redis_host,
+                port=redis_port,
+                socket_timeout=30,
+                socket_connect_timeout=30,
+            )
+
+            ping_result = redis_conn.ping()
+            logger.info("✅ Redis PING result: {ping_result}", ping_result=ping_result)
+
+            queue_name = "default"
+            queue = Queue(queue_name, connection=redis_conn)
+            logger.info("Enqueueing RQ job to import candidate themes...")
+            job = queue.enqueue(
+                "data_pipeline.jobs.import_candidate_themes",
+                consultation_code,
+                run_date,
+                user_id,
+                model_name,
+                context_id=context_id,
+            )
+
+            logger.info(
+                "✅ Successfully queued candidate themes import job {job_id} for: {consultation_code}. "
+                "Job status: {job_status}, queue '{queue_name}' now has {job_count} jobs",
+                job_id=job.id,
+                consultation_code=consultation_code,
+                job_status=job.get_status(),
+                queue_name=queue_name,
+                job_count=len(queue),
+            )
     except Exception:
         logger.exception("Failed to enqueue candidate themes import job")
         raise
+    finally:
+        flush_otel()

--- a/lambda/import_response_annotations/Makefile
+++ b/lambda/import_response_annotations/Makefile
@@ -10,4 +10,5 @@ build:
 	mkdir -p -- ${BUILD_DIR} ${PACKAGES_DIR}/python
 	uv pip install -r code/requirements.txt --target code/package
 	cp code/main.py ${BUILD_DIR}/
+	cp ../shared/otel_bootstrap.py ${BUILD_DIR}/
 	cp -r code/package/* ${PACKAGES_DIR}/python/

--- a/lambda/import_response_annotations/code/main.py
+++ b/lambda/import_response_annotations/code/main.py
@@ -9,6 +9,7 @@ from i_dot_ai_utilities.logging.types.enrichment_types import (
     ExecutionEnvironmentType,
 )
 from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
+from otel_bootstrap import bootstrap_otel, execution_span, flush_otel
 from rq import Queue
 
 logger = StructuredLogger(
@@ -27,6 +28,8 @@ if sentry_dsn:
         traces_sample_rate=1.0,
     )
     logger.info("Sentry initialized")
+
+bootstrap_otel(service_name="consult-import-response-annotations", logger=logger)
 
 
 def _epoch_ms_to_iso(epoch_ms: int | None) -> str | None:
@@ -74,59 +77,63 @@ def lambda_handler(event, context):
     )
 
     try:
-        # Connect to Redis
-        redis_host = os.environ.get("REDIS_HOST")
-        if redis_host is None:
-            raise ValueError("REDIS_HOST environment variable is required")
-        redis_port = int(os.environ.get("REDIS_PORT", "6379"))
-
-        logger.info(
-            "Connecting to Redis: {redis_host}:{redis_port}",
-            redis_host=redis_host,
-            redis_port=redis_port,
-        )
-
-        redis_conn = redis.Redis(
-            host=redis_host,
-            port=redis_port,
-            socket_timeout=30,
-            socket_connect_timeout=30,
-        )
-
-        # Test Redis connection
-        ping_result = redis_conn.ping()
-        logger.info("✅ Redis PING result: {ping_result}", ping_result=ping_result)
-
-        # Enqueue the appropriate RQ job based on assignment target
-        queue_name = "default"
-        queue = Queue(queue_name, connection=redis_conn)
-
-        if assignment_target == "candidate_themes":
-            logger.info("Enqueueing RQ job to import candidate theme responses...")
-            rq_job_name = "data_pipeline.jobs.import_candidate_theme_responses"
-        else:
-            logger.info("Enqueueing RQ job to import response annotations...")
-            rq_job_name = "data_pipeline.jobs.import_response_annotations"
-
-        job = queue.enqueue(
-            rq_job_name,
-            consultation_code,
-            run_date,
-            job_timeout=3_600,
+        with execution_span(
+            "lambda.import_response_annotations",
             context_id=context_id,
-        )
-
-        logger.info(
-            "✅ Successfully queued import job {job_id} ({rq_job_name}) for: {consultation_code}. "
-            "Job status: {job_status}, queue '{queue_name}' now has {job_count} jobs",
-            job_id=job.id,
-            rq_job_name=rq_job_name,
             consultation_code=consultation_code,
-            job_status=job.get_status(),
-            queue_name=queue_name,
-            job_count=len(queue),
-        )
+            assignment_target=assignment_target,
+        ):
+            redis_host = os.environ.get("REDIS_HOST")
+            if redis_host is None:
+                raise ValueError("REDIS_HOST environment variable is required")
+            redis_port = int(os.environ.get("REDIS_PORT", "6379"))
 
+            logger.info(
+                "Connecting to Redis: {redis_host}:{redis_port}",
+                redis_host=redis_host,
+                redis_port=redis_port,
+            )
+
+            redis_conn = redis.Redis(
+                host=redis_host,
+                port=redis_port,
+                socket_timeout=30,
+                socket_connect_timeout=30,
+            )
+
+            ping_result = redis_conn.ping()
+            logger.info("✅ Redis PING result: {ping_result}", ping_result=ping_result)
+
+            queue_name = "default"
+            queue = Queue(queue_name, connection=redis_conn)
+
+            if assignment_target == "candidate_themes":
+                logger.info("Enqueueing RQ job to import candidate theme responses...")
+                rq_job_name = "data_pipeline.jobs.import_candidate_theme_responses"
+            else:
+                logger.info("Enqueueing RQ job to import response annotations...")
+                rq_job_name = "data_pipeline.jobs.import_response_annotations"
+
+            job = queue.enqueue(
+                rq_job_name,
+                consultation_code,
+                run_date,
+                job_timeout=3_600,
+                context_id=context_id,
+            )
+
+            logger.info(
+                "✅ Successfully queued import job {job_id} ({rq_job_name}) for: {consultation_code}. "
+                "Job status: {job_status}, queue '{queue_name}' now has {job_count} jobs",
+                job_id=job.id,
+                rq_job_name=rq_job_name,
+                consultation_code=consultation_code,
+                job_status=job.get_status(),
+                queue_name=queue_name,
+                job_count=len(queue),
+            )
     except Exception:
         logger.exception("Failed to enqueue response annotations import job")
         raise
+    finally:
+        flush_otel()

--- a/lambda/shared/otel_bootstrap.py
+++ b/lambda/shared/otel_bootstrap.py
@@ -1,0 +1,86 @@
+"""OpenTelemetry bootstrap for a short-lived Lambda handler.
+
+Dormant until OTEL_ENABLED is on, a collector endpoint is set, and the util's
+[otel] extra is vendored; a no-op otherwise.
+
+Shared by every Lambda: each Makefile copies this file into the build dir next
+to main.py, so keep it dependency-free beyond the util.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+from typing import Any
+
+OTEL_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT"
+OTEL_ENABLED_ENV = "OTEL_ENABLED"
+_TRACER_NAME = "consult.lambda"
+
+
+def otel_requested() -> bool:
+    enabled = os.environ.get(OTEL_ENABLED_ENV, "").strip().lower() == "true"
+    return enabled and bool(os.environ.get(OTEL_ENDPOINT_ENV))
+
+
+def bootstrap_otel(service_name: str, logger) -> None:
+    """Configure OTel for a Lambda cold start. No-op unless requested."""
+    if not otel_requested():
+        return
+
+    try:
+        from i_dot_ai_utilities.logging._otel import (
+            configure_otel_for_lambda,
+            ensure_structlog_otel_processors,
+        )
+    except ImportError:
+        logger.warning(
+            "OTel endpoint is set but the i-dot-ai-utilities [otel] extra is not "
+            "installed; telemetry disabled for {service_name}",
+            service_name=service_name,
+        )
+        return
+
+    try:
+        configure_otel_for_lambda(service_name=service_name)
+        ensure_structlog_otel_processors()
+    except RuntimeError:
+        logger.warning(
+            "OTel endpoint is set but the exporter is unavailable; telemetry "
+            "disabled for {service_name}",
+            service_name=service_name,
+        )
+
+
+@contextlib.contextmanager
+def execution_span(name: str, *, context_id: str | None = None, **attributes: Any) -> Iterator[None]:
+    """Wrap an invocation in a span, carrying context_id so logs correlate."""
+    if not otel_requested():
+        yield
+        return
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        yield
+        return
+
+    tracer = trace.get_tracer(_TRACER_NAME)
+    with tracer.start_as_current_span(name) as span:
+        if context_id:
+            span.set_attribute("context_id", context_id)
+        for key, value in attributes.items():
+            if value is not None:
+                span.set_attribute(key, value)
+        yield
+
+
+def flush_otel() -> None:
+    """Flush pending telemetry before the invocation returns. No-op unless requested."""
+    if not otel_requested():
+        return
+    try:
+        from i_dot_ai_utilities.logging._otel import force_flush_otel
+    except ImportError:
+        return
+    force_flush_otel()

--- a/lambda/slack_notifier/Makefile
+++ b/lambda/slack_notifier/Makefile
@@ -8,4 +8,5 @@ build:
 	mkdir -p -- ${BUILD_DIR}
 	uv pip install -r code/requirements.txt --target code/package
 	cp code/main.py ${BUILD_DIR}/
+	cp ../shared/otel_bootstrap.py ${BUILD_DIR}/
 	cp -r code/package/* ${BUILD_DIR}/

--- a/lambda/slack_notifier/code/main.py
+++ b/lambda/slack_notifier/code/main.py
@@ -8,6 +8,7 @@ from i_dot_ai_utilities.logging.types.enrichment_types import (
     ExecutionEnvironmentType,
 )
 from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
+from otel_bootstrap import bootstrap_otel, execution_span, flush_otel
 
 http = urllib3.PoolManager()
 
@@ -18,6 +19,7 @@ logger = StructuredLogger(
         "log_format": LogOutputFormat.JSON,
     },
 )
+bootstrap_otel(service_name="consult-slack-notifier", logger=logger)
 
 SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
 
@@ -158,11 +160,19 @@ def lambda_handler(event, context):
 
         logger.set_context_field("batch_job_name", detail.get("jobName", job["type"]))
         logger.set_context_field("consultation_code", consultation["code"])
+        logger.set_context_field("context_id", parameters.get("context_id"))
 
-        send_slack_message(job, consultation, environment, user_id)
+        with execution_span(
+            "lambda.slack_notifier",
+            context_id=parameters.get("context_id"),
+            consultation_code=consultation["code"],
+        ):
+            send_slack_message(job, consultation, environment, user_id)
 
         logger.info("✅ Slack message sent")
 
     except Exception:
         logger.exception("Failed to send Slack notification")
         raise
+    finally:
+        flush_otel()

--- a/pipeline-common/src/pipeline_common/__init__.py
+++ b/pipeline-common/src/pipeline_common/__init__.py
@@ -1,3 +1,4 @@
 from pipeline_common.logging_bootstrap import bootstrap_logger
+from pipeline_common.otel import execution_span, flush_otel
 
-__all__ = ["bootstrap_logger"]
+__all__ = ["bootstrap_logger", "execution_span", "flush_otel"]

--- a/pipeline-common/src/pipeline_common/logging_bootstrap.py
+++ b/pipeline-common/src/pipeline_common/logging_bootstrap.py
@@ -6,7 +6,8 @@ from i_dot_ai_utilities.logging.types.enrichment_types import ExecutionEnvironme
 from i_dot_ai_utilities.logging.types.log_output_format import LogOutputFormat
 
 
-def bootstrap_logger() -> StructuredLogger:
+def bootstrap_logger(service_name: str | None = None) -> StructuredLogger:
+    """Build the StructuredLogger. Pass service_name to also bootstrap OTel; omit it to skip OTel."""
     # The Fargate enricher reads ECS_CONTAINER_METADATA_URI_V4, which only exists on Fargate.
     _execution_environment = (
         ExecutionEnvironmentType.FARGATE
@@ -40,5 +41,12 @@ def bootstrap_logger() -> StructuredLogger:
             environment=os.environ.get("ENVIRONMENT", "unknown"),
             traces_sample_rate=1.0,
         )
+
+    # Configure OTel after the logger exists so the trace-context processor can
+    # be re-inserted into the structlog config the logger just set up.
+    if service_name:
+        from pipeline_common.otel import bootstrap_otel
+
+        bootstrap_otel(service_name, logger)
 
     return logger

--- a/pipeline-common/src/pipeline_common/otel.py
+++ b/pipeline-common/src/pipeline_common/otel.py
@@ -1,0 +1,86 @@
+"""OpenTelemetry bootstrap for the short-lived Batch scripts.
+
+Dormant until OTEL_ENABLED is on, a collector endpoint is set, and the util's
+[otel] extra is installed; a no-op otherwise.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
+
+OTEL_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT"
+OTEL_ENABLED_ENV = "OTEL_ENABLED"
+_TRACER_NAME = "consult.batch"
+
+
+def otel_requested() -> bool:
+    enabled = os.environ.get(OTEL_ENABLED_ENV, "").strip().lower() == "true"
+    return enabled and bool(os.environ.get(OTEL_ENDPOINT_ENV))
+
+
+def bootstrap_otel(service_name: str, logger: StructuredLogger) -> None:
+    """Configure OTel for a Batch process. No-op unless requested."""
+    if not otel_requested():
+        return
+
+    try:
+        from i_dot_ai_utilities.logging._otel import (
+            configure_otel,
+            ensure_structlog_otel_processors,
+        )
+    except ImportError:
+        logger.warning(
+            "OTel endpoint is set but the i-dot-ai-utilities [otel] extra is not "
+            "installed; telemetry disabled for {service_name}",
+            service_name=service_name,
+        )
+        return
+
+    try:
+        configure_otel(service_name=service_name)
+        ensure_structlog_otel_processors()
+    except RuntimeError:
+        logger.warning(
+            "OTel endpoint is set but the exporter is unavailable; telemetry "
+            "disabled for {service_name}",
+            service_name=service_name,
+        )
+
+
+@contextlib.contextmanager
+def execution_span(name: str, *, context_id: str | None = None, **attributes: Any) -> Iterator[None]:
+    """Wrap a Batch run in a span, carrying context_id so logs correlate."""
+    if not otel_requested():
+        yield
+        return
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        yield
+        return
+
+    tracer = trace.get_tracer(_TRACER_NAME)
+    with tracer.start_as_current_span(name) as span:
+        if context_id:
+            span.set_attribute("context_id", context_id)
+        for key, value in attributes.items():
+            if value is not None:
+                span.set_attribute(key, value)
+        yield
+
+
+def flush_otel() -> None:
+    """Flush pending telemetry before the process exits. No-op unless requested."""
+    if not otel_requested():
+        return
+    try:
+        from i_dot_ai_utilities.logging._otel import force_flush_otel
+    except ImportError:
+        return
+    force_flush_otel()

--- a/pipeline-common/tests/test_otel.py
+++ b/pipeline-common/tests/test_otel.py
@@ -1,0 +1,77 @@
+"""The Batch OTel seam stays dormant unless the flag is on and an endpoint is wired."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipeline_common import otel
+
+
+@pytest.fixture(autouse=True)
+def _clear_otel_env(monkeypatch):
+    monkeypatch.delenv(otel.OTEL_ENDPOINT_ENV, raising=False)
+    monkeypatch.delenv(otel.OTEL_ENABLED_ENV, raising=False)
+
+
+def _enable(monkeypatch):
+    monkeypatch.setenv(otel.OTEL_ENABLED_ENV, "true")
+    monkeypatch.setenv(otel.OTEL_ENDPOINT_ENV, "http://collector:4318")
+
+
+class TestOtelRequested:
+    def test_false_by_default(self):
+        assert otel.otel_requested() is False
+
+    def test_false_with_endpoint_but_flag_off(self, monkeypatch):
+        monkeypatch.setenv(otel.OTEL_ENDPOINT_ENV, "http://collector:4318")
+        assert otel.otel_requested() is False
+
+    def test_false_with_flag_but_no_endpoint(self, monkeypatch):
+        monkeypatch.setenv(otel.OTEL_ENABLED_ENV, "true")
+        assert otel.otel_requested() is False
+
+    def test_false_when_flag_not_true(self, monkeypatch):
+        monkeypatch.setenv(otel.OTEL_ENABLED_ENV, "false")
+        monkeypatch.setenv(otel.OTEL_ENDPOINT_ENV, "http://collector:4318")
+        assert otel.otel_requested() is False
+
+    def test_true_with_flag_and_endpoint(self, monkeypatch):
+        _enable(monkeypatch)
+        assert otel.otel_requested() is True
+
+
+class TestBootstrapOtel:
+    def test_noop_when_dormant(self):
+        logger = MagicMock()
+        otel.bootstrap_otel("consult-pipeline-sign-off", logger)
+        logger.warning.assert_not_called()
+
+    def test_warns_when_requested_but_extra_missing(self, monkeypatch):
+        _enable(monkeypatch)
+        # The [otel] extra is installed in CI, so fake its absence to reach the ImportError branch.
+        monkeypatch.setitem(sys.modules, "i_dot_ai_utilities.logging._otel", None)
+        logger = MagicMock()
+        otel.bootstrap_otel("consult-pipeline-sign-off", logger)
+        logger.warning.assert_called_once()
+        assert logger.warning.call_args.kwargs["service_name"] == "consult-pipeline-sign-off"
+
+
+class TestExecutionSpan:
+    def test_runs_body_when_dormant(self):
+        ran = False
+        with otel.execution_span("batch.find_themes", context_id="abc", consultation_code="X"):
+            ran = True
+        assert ran
+
+    def test_body_exception_propagates(self):
+        with (
+            pytest.raises(ValueError, match="boom"),
+            otel.execution_span("batch.find_themes"),
+        ):
+            raise ValueError("boom")
+
+
+class TestFlushOtel:
+    def test_noop_when_dormant(self):
+        otel.flush_otel()

--- a/pipeline-mapping/assign_themes_script.py
+++ b/pipeline-mapping/assign_themes_script.py
@@ -9,7 +9,7 @@ import boto3
 import pandas as pd
 import structlog
 import urllib3
-from pipeline_common import bootstrap_logger
+from pipeline_common import bootstrap_logger, execution_span, flush_otel
 
 from themefinder import (
     detail_detection,
@@ -19,7 +19,7 @@ from themefinder import (
 )
 from themefinder.llm import OpenAILLM
 
-logger = bootstrap_logger()
+logger = bootstrap_logger(service_name="consult-pipeline-mapping")
 
 
 BUCKET_NAME = os.getenv("DATA_S3_BUCKET")
@@ -329,13 +329,20 @@ if __name__ == "__main__":
     if args.context_id:
         logger.set_context_field("context_id", args.context_id)
 
-    # Log sentry initialization after context set
     sentry_dsn = os.environ.get("SENTRY_DSN")
     if sentry_dsn:
         logger.info("Sentry initialized")
 
     logger.info("Starting processing for subdirectory: {subdir}", subdir=args.subdir)
-    download_s3_subdir(args.subdir)
-    output_dir = asyncio.run(process_consultation(args.subdir, args.model_name))
-    upload_directory_to_s3(output_dir)
-    logger.info("Processing completed for subdirectory: {subdir}", subdir=args.subdir)
+    try:
+        with execution_span(
+            "batch.assign_themes",
+            context_id=args.context_id,
+            consultation_code=args.subdir,
+        ):
+            download_s3_subdir(args.subdir)
+            output_dir = asyncio.run(process_consultation(args.subdir, args.model_name))
+            upload_directory_to_s3(output_dir)
+            logger.info("Processing completed for subdirectory: {subdir}", subdir=args.subdir)
+    finally:
+        flush_otel()

--- a/pipeline-sign-off/find_themes_script.py
+++ b/pipeline-sign-off/find_themes_script.py
@@ -10,7 +10,7 @@ import pandas as pd
 import structlog
 import urllib3
 from openai import OpenAI
-from pipeline_common import bootstrap_logger
+from pipeline_common import bootstrap_logger, execution_span, flush_otel
 from pydantic import BaseModel
 
 from themefinder import (
@@ -43,7 +43,7 @@ class ThemeNodeList(BaseModel):
     theme_nodes: list[ThemeNode]
 
 
-logger = bootstrap_logger()
+logger = bootstrap_logger(service_name="consult-pipeline-sign-off")
 
 
 BUCKET_NAME = os.getenv("DATA_S3_BUCKET")
@@ -451,13 +451,20 @@ if __name__ == "__main__":
     if args.context_id:
         logger.set_context_field("context_id", args.context_id)
 
-    # Log sentry initialization after context set
     sentry_dsn = os.environ.get("SENTRY_DSN")
     if sentry_dsn:
         logger.info("Sentry initialized")
 
     logger.info("Starting processing for subdirectory: {subdir}", subdir=args.subdir)
-    download_s3_subdir(args.subdir)
-    output_dir = asyncio.run(process_consultation(args.subdir, args.model_name))
-    upload_directory_to_s3(output_dir)
-    logger.info("Processing completed for subdirectory: {subdir}", subdir=args.subdir)
+    try:
+        with execution_span(
+            "batch.find_themes",
+            context_id=args.context_id,
+            consultation_code=args.subdir,
+        ):
+            download_s3_subdir(args.subdir)
+            output_dir = asyncio.run(process_consultation(args.subdir, args.model_name))
+            upload_directory_to_s3(output_dir)
+            logger.info("Processing completed for subdirectory: {subdir}", subdir=args.subdir)
+    finally:
+        flush_otel()


### PR DESCRIPTION
## Context

Bootstraps OpenTelemetry on the surfaces with no auto-instrumentation: the RQ worker, the Batch scripts, and the import/notifier Lambdas. Without a root span per run their logs can't be correlated. It's a drop-in seam guarded on the `OTEL_ENABLED` flag and a collector endpoint, so it stays a no-op until both are set.

## Changes proposed in this pull request

- Add a guarded OTel seam (`bootstrap_otel`, `execution_span`, `flush_otel`) to pipeline-common, the backend, and each Lambda.
- Wrap each unit of work (RQ job, both Batch runs, all three Lambda handlers) in a root span carrying `context_id` and `consultation_code`, so logs correlate on the same id.
- Flush at the execution boundary on every surface, since the worker idles and Batch/Lambda are short-lived.
- Catch both `ImportError` and the endpoint-required `RuntimeError` in the Lambda bootstrap so a cold start degrades to a warning, not a crash.
- Add unit tests for the backend and pipeline-common seams.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
