### PR TITLE
PRO-489: Mock formatted timedelta text

### DIFF
--- a/frontend/src/components/finalising-themes/SelectedThemeCard/__snapshots__/SelectedThemeCard.test.ts.snap
+++ b/frontend/src/components/finalising-themes/SelectedThemeCard/__snapshots__/SelectedThemeCard.test.ts.snap
@@ -42,7 +42,7 @@ exports[`SelectedThemeCard > should render 1`] = `
               class="mb-4 block text-xs text-neutral-500"
             >
               Added
-              a moment ago by testuser
+              &lt;FORMATTED_TIME_DELTA_TEXT&gt; ago by testuser
             </small>
              
             <footer

--- a/frontend/src/components/screens/FinalisingThemesDetail/FinalisingThemesDetail.test.ts
+++ b/frontend/src/components/screens/FinalisingThemesDetail/FinalisingThemesDetail.test.ts
@@ -42,7 +42,7 @@ function clearMocks() {
   resetMocks();
 }
 
-describe("EditUser", () => {
+describe("FinalisingThemesDetail", () => {
   beforeEach(() => {
     clearMocks();
   });

--- a/frontend/src/components/screens/FinalisingThemesDetail/__snapshots__/FinalisingThemesDetail.test.ts.snap
+++ b/frontend/src/components/screens/FinalisingThemesDetail/__snapshots__/FinalisingThemesDetail.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`EditUser > should match snapshot after loading 1`] = `
+exports[`FinalisingThemesDetail > should match snapshot after loading 1`] = `
 <div>
   <!---->
   <!---->
@@ -276,7 +276,7 @@ exports[`EditUser > should match snapshot after loading 1`] = `
                     class="mb-4 block text-xs text-neutral-500"
                   >
                     Added
-              5 months ago by admin@example.com
+              &lt;FORMATTED_TIME_DELTA_TEXT&gt; ago by admin@example.com
                   </small>
                    
                   <footer
@@ -532,7 +532,7 @@ exports[`EditUser > should match snapshot after loading 1`] = `
 </div>
 `;
 
-exports[`EditUser > should match snapshot initially 1`] = `
+exports[`FinalisingThemesDetail > should match snapshot initially 1`] = `
 <div>
   <!---->
   <!---->

--- a/frontend/src/global/utils.test.ts
+++ b/frontend/src/global/utils.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatDate,
   formatTimeDeltaText,
@@ -9,6 +9,8 @@ import {
   getTimeDeltaInMinutes,
   toTitleCase,
 } from "./utils";
+
+vi.unmock("./utils");
 
 describe("getPercentage", () => {
   it("correctly calculates percentages", () => {

--- a/frontend/vitest-setup.ts
+++ b/frontend/vitest-setup.ts
@@ -10,9 +10,9 @@ process.env.BACKEND_URL = "http://localhost:8000";
 vi.mock("svelte/transition");
 
 vi.mock(import("./src/global/utils"), async (importOriginal) => {
-  const actual = await importOriginal<typeof import('./src/global/utils')>();
+  const actual = await importOriginal<typeof import("./src/global/utils")>();
   return {
     ...actual,
-    formatTimeDeltaText: vi.fn(() => "<FORMATTED_TIME_DELTA_TEXT>")
-  }
+    formatTimeDeltaText: vi.fn(() => "<FORMATTED_TIME_DELTA_TEXT>"),
+  };
 });

--- a/frontend/vitest-setup.ts
+++ b/frontend/vitest-setup.ts
@@ -8,3 +8,11 @@ process.env.BACKEND_URL = "http://localhost:8000";
 // Mock svelte/transition to avoid Web Animations API issues in jsdom
 // See: https://github.com/testing-library/svelte-testing-library/issues/416
 vi.mock("svelte/transition");
+
+vi.mock(import("./src/global/utils"), async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./src/global/utils')>();
+  return {
+    ...actual,
+    formatTimeDeltaText: vi.fn(() => "<FORMATTED_TIME_DELTA_TEXT>")
+  }
+});


### PR DESCRIPTION
## Context
Snapshot tests were breaking every month due to this text relying on current time.

## Changes proposed in this pull request
This PR mocks the formattedTimeDeltaText function in the utils to replace the output with a fixed text so that it no longer breaks every month. Also fixes an incorrect describe name.

## Guidance to review
Confirm snapshot output is fixed text and not something along the lines of "x months ago" or "a moment ago".

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
