### PR TITLE
Temp disable OTel logging until platform is ready for us

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -9,7 +9,7 @@ locals {
     "AWS_ACCOUNT_ID" = data.aws_caller_identity.current.account_id
     # OTel PoC is dev only; other envs (prod included) stay Sentry-only.
     # Bootstraps read OTEL_ENABLED from the env directly; no Django setting.
-    "OTEL_ENABLED"                = var.env == "dev"
+    "OTEL_ENABLED"                = false
     "OTEL_EXPORTER_OTLP_ENDPOINT" = local.otel_exporter_otlp_endpoint
   }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -55,7 +55,7 @@ module "slack_notifier_lambda" {
     "AWS_BUCKET_NAME"             = module.app_bucket.id,
     "AWS_ACCOUNT_ID"              = data.aws_caller_identity.current.account_id,
     "EXECUTION_CONTEXT"           = "lambda",
-    "OTEL_ENABLED"                = var.env == "dev",
+    "OTEL_ENABLED"                = false,
     "OTEL_EXPORTER_OTLP_ENDPOINT" = local.otel_exporter_otlp_endpoint,
   }
 }
@@ -107,7 +107,7 @@ module "import_candidate_themes_lambda" {
     APP_NAME                    = "${var.project_name}-import-candidate-themes"
     REPO                        = var.project_name
     EXECUTION_CONTEXT           = "lambda"
-    OTEL_ENABLED                = var.env == "dev"
+    OTEL_ENABLED                = false
     OTEL_EXPORTER_OTLP_ENDPOINT = local.otel_exporter_otlp_endpoint
   }
 }
@@ -159,7 +159,7 @@ module "import_response_annotations_lambda" {
     APP_NAME                    = "${var.project_name}-import-response-annotations"
     REPO                        = var.project_name
     EXECUTION_CONTEXT           = "lambda"
-    OTEL_ENABLED                = var.env == "dev"
+    OTEL_ENABLED                = false
     OTEL_EXPORTER_OTLP_ENDPOINT = local.otel_exporter_otlp_endpoint
   }
 }


### PR DESCRIPTION
## Context

OTel is being initiated, but the collector can't be reached on dev.

## Changes proposed in this pull request

- Set the `OTEL_ENABLED` var in ecs.tf and lambda.tf to `false`

## Guidance to review

Deploy to dev and check that the sentry exceptions appear
