### PR TITLE
Add sentry release to django

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -40,6 +40,7 @@ AWS_ACCOUNT_ID = env("AWS_ACCOUNT_ID", default=None)
 MINIO_ADDRESS = env.str("MINIO_ENDPOINT", default=None)
 AWS_ACCESS_KEY = env.str("MINIO_ACCESS_KEY", default=None)
 AWS_SECRET_KEY = env.str("MINIO_SECRET_KEY", default=None)
+SENTRY_RELEASE = env.str("SENTRY_RELEASE", default="")
 
 DOMAIN_NAME = env("DOMAIN_NAME", default="0.0.0.0")  # nosec
 

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -38,6 +38,7 @@ sentry_sdk.init(
         "SENTRY_PROFILE_SESSION_SAMPLE_RATE", default=_perf_sample_rate
     ),
     profile_lifecycle="trace",
+    release=SENTRY_RELEASE
 )
 
 

--- a/backend/settings/production.py
+++ b/backend/settings/production.py
@@ -38,7 +38,7 @@ sentry_sdk.init(
         "SENTRY_PROFILE_SESSION_SAMPLE_RATE", default=_perf_sample_rate
     ),
     profile_lifecycle="trace",
-    release=SENTRY_RELEASE
+    release=SENTRY_RELEASE,
 )
 
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -3,14 +3,15 @@ locals {
   frontend_port = 3000
 
   base_env_vars = {
-    "ENVIRONMENT"    = terraform.workspace
-    "DEBUG"          = var.env == "prod" ? false : true
-    "REPO"           = var.project_name
-    "AWS_ACCOUNT_ID" = data.aws_caller_identity.current.account_id
+    "ENVIRONMENT"                 = terraform.workspace
+    "DEBUG"                       = var.env == "prod" ? false : true
+    "REPO"                        = var.project_name
+    "AWS_ACCOUNT_ID"              = data.aws_caller_identity.current.account_id
     # OTel PoC is dev only; other envs (prod included) stay Sentry-only.
     # Bootstraps read OTEL_ENABLED from the env directly; no Django setting.
     "OTEL_ENABLED"                = false
     "OTEL_EXPORTER_OTLP_ENDPOINT" = local.otel_exporter_otlp_endpoint
+    "SENTRY_RELEASE"              = data.aws_ssm_parameter.image_tags["frontend"].value
   }
 
   django_env_vars = {
@@ -126,7 +127,6 @@ module "frontend" {
     "DOCKER_BUILDER_CONTAINER" = "${var.project_name}-frontend",
     "PUBLIC_LANGFUSE_URL"      = "https://core-langfuse.i.ai.gov.uk/",
     "PUBLIC_HOMEPAGE_URL"      = "https://${local.host}"
-    "SENTRY_RELEASE"           = data.aws_ssm_parameter.image_tags["frontend"].value
   })
 
   secrets = [

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -11,7 +11,6 @@ locals {
     # Bootstraps read OTEL_ENABLED from the env directly; no Django setting.
     "OTEL_ENABLED"                = false
     "OTEL_EXPORTER_OTLP_ENDPOINT" = local.otel_exporter_otlp_endpoint
-    "SENTRY_RELEASE"              = data.aws_ssm_parameter.image_tags["frontend"].value
   }
 
   django_env_vars = {
@@ -67,6 +66,7 @@ module "backend" {
     "EXECUTION_CONTEXT"        = "backend"
     "DOCKER_BUILDER_CONTAINER" = "${var.project_name}-backend"
     "SENTRY_DSN"               = var.backend_sentry_dsn
+    "SENTRY_RELEASE"           = data.aws_ssm_parameter.image_tags["backend"].value
   })
 
   secrets = [
@@ -126,7 +126,8 @@ module "frontend" {
     "EXECUTION_CONTEXT"        = "ecs"
     "DOCKER_BUILDER_CONTAINER" = "${var.project_name}-frontend",
     "PUBLIC_LANGFUSE_URL"      = "https://core-langfuse.i.ai.gov.uk/",
-    "PUBLIC_HOMEPAGE_URL"      = "https://${local.host}"
+    "PUBLIC_HOMEPAGE_URL"      = "https://${local.host}",
+    "SENTRY_RELEASE"           = data.aws_ssm_parameter.image_tags["frontend"].value
   })
 
   secrets = [
@@ -184,6 +185,7 @@ module "worker" {
     "EXECUTION_CONTEXT"        = "worker"
     "DOCKER_BUILDER_CONTAINER" = "${var.project_name}-worker"
     "SENTRY_DSN"               = var.backend_sentry_dsn
+    "SENTRY_RELEASE"           = data.aws_ssm_parameter.image_tags["worker"].value
   })
 
   secrets = [


### PR DESCRIPTION
## Context

Sentry allows a release attributed to traces.

## Changes proposed in this pull request

- Change release to be a base infra var
- Add release to the django settings modules
- Update sentry config to consume the release

## Guidance to review

- Force an error on dev
