### PR TITLE
Elliotmoore/pro 302 implement deep frontend health checks

### DIFF
--- a/frontend/src/global/routes.ts
+++ b/frontend/src/global/routes.ts
@@ -39,6 +39,7 @@ export enum Routes {
   ApiUser = "/api/user/",
   ApiUsers = "/api/users/",
   ApiAstroSignIn = "/api/astro/sign-in/",
+  ApiHealth = "/api/health/",
   Design = "/design",
   SupportDataPipeline = "/support/data-pipeline",
   SupportUsers = "/support/users",

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -32,7 +32,10 @@ const mainMiddleware = defineMiddleware(
       return next();
     }
 
-    if (/^\/health[/]?$/.test(url.pathname)) {
+    if (
+      /^\/health[/]?$/.test(url.pathname) ||
+      /^\/live[/]?$/.test(url.pathname)
+    ) {
       return next();
     }
 

--- a/frontend/src/pages/health.test.ts
+++ b/frontend/src/pages/health.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fetchMock from "fetch-mock";
+
+import { GET } from "./health";
+import { getBackendUrl } from "../global/utils";
+
+const HEALTH_ENDPOINT = `${getBackendUrl()}/api/health/`;
+
+describe("GET /health", () => {
+  beforeEach(() => {
+    fetchMock.mockGlobal();
+  });
+
+  afterEach(() => {
+    fetchMock.unmockGlobal();
+    fetchMock.removeRoutes();
+    fetchMock.callHistory.clear();
+  });
+
+  it("returns 200 with all checks passing when backend is healthy", async () => {
+    fetchMock.route(HEALTH_ENDPOINT, { status: 200, body: { status: "ok" } });
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.checks.backend.status).toBe("ok");
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it("returns 503 when backend returns a non-2xx response", async () => {
+    fetchMock.route(HEALTH_ENDPOINT, {
+      status: 503,
+      body: "Service Unavailable",
+    });
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("error");
+    expect(body.checks.backend.status).toBe("error");
+  });
+
+  it("returns 503 with unreachable status on network failure", async () => {
+    fetchMock.route(HEALTH_ENDPOINT, { throws: new Error("fetch failed") });
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("error");
+    expect(body.checks.backend.status).toBe("unreachable");
+    expect(body.checks.backend.detail).toBe("fetch failed");
+  });
+
+  it("returns 503 with unreachable status on timeout", async () => {
+    const abortError = new DOMException(
+      "The operation was aborted.",
+      "AbortError",
+    );
+    fetchMock.route(HEALTH_ENDPOINT, { throws: abortError });
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.status).toBe("error");
+    expect(body.checks.backend.status).toBe("unreachable");
+  });
+
+  it("calls the correct backend health endpoint", async () => {
+    fetchMock.route(HEALTH_ENDPOINT, { status: 200, body: { status: "ok" } });
+
+    await GET({} as Parameters<typeof GET>[0]);
+
+    expect(
+      fetchMock.callHistory.calls().filter((c) => c.url === HEALTH_ENDPOINT),
+    ).toHaveLength(1);
+  });
+});

--- a/frontend/src/pages/health.ts
+++ b/frontend/src/pages/health.ts
@@ -1,7 +1,10 @@
 import type { APIRoute } from "astro";
 import { getBackendUrl } from "../global/utils";
+import { Routes } from "../global/routes";
 
 type BackendHealthStatus = "ok" | "error" | "unreachable";
+
+const timeoutMs = 5000;
 
 interface HealthResponse {
   status: "ok" | "error";
@@ -22,9 +25,9 @@ export const GET: APIRoute = async () => {
   try {
     const backendUrl = getBackendUrl();
     const response = await fetch(
-      new URL("/api/health/", backendUrl).toString(),
+      new URL(Routes.ApiHealth, backendUrl).toString(),
       {
-        signal: AbortSignal.timeout(5000),
+        signal: AbortSignal.timeout(timeoutMs),
       },
     );
 

--- a/frontend/src/pages/health.ts
+++ b/frontend/src/pages/health.ts
@@ -1,13 +1,63 @@
 import type { APIRoute } from "astro";
+import { getBackendUrl } from "../global/utils";
 
-export const GET: APIRoute = () => {
-  return new Response(
-    JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }),
-    {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json",
+type BackendHealthStatus = "ok" | "error" | "unreachable";
+
+interface HealthResponse {
+  status: "ok" | "error";
+  timestamp: string;
+  checks: {
+    backend: {
+      status: BackendHealthStatus;
+      detail?: unknown;
+    };
+  };
+}
+
+export const GET: APIRoute = async () => {
+  const timestamp = new Date().toISOString();
+  let backendStatus: BackendHealthStatus = "unreachable";
+  let backendDetail: unknown = undefined;
+
+  try {
+    const backendUrl = getBackendUrl();
+    const response = await fetch(
+      new URL("/api/health/", backendUrl).toString(),
+      {
+        signal: AbortSignal.timeout(5000),
+      },
+    );
+
+    if (response.ok) {
+      backendStatus = "ok";
+    } else {
+      backendStatus = "error";
+      backendDetail = await response.text();
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      backendDetail = err.message;
+    }
+  }
+
+  const overall = backendStatus === "ok" ? "ok" : "error";
+  const httpStatus = overall === "ok" ? 200 : 503;
+
+  const body: HealthResponse = {
+    status: overall,
+    timestamp,
+    checks: {
+      backend: {
+        status: backendStatus,
+        ...(backendDetail !== undefined ? { detail: backendDetail } : {}),
       },
     },
-  );
+  };
+
+  return new Response(JSON.stringify(body), {
+    status: httpStatus,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
 };

--- a/frontend/src/pages/live.test.ts
+++ b/frontend/src/pages/live.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "./live";
+
+describe("GET /live", () => {
+  it("returns 200 regardless of any external state", async () => {
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns JSON with status ok", async () => {
+    const response = await GET({} as Parameters<typeof GET>[0]);
+    const body = await response.json();
+
+    expect(body.status).toBe("ok");
+    expect(body.timestamp).toBeDefined();
+  });
+});

--- a/frontend/src/pages/live.ts
+++ b/frontend/src/pages/live.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = () => {
+  return new Response(
+    JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+};

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -141,10 +141,10 @@ module "frontend" {
 
   health_check = {
     accepted_response   = 200
-    interval            = 60
-    timeout             = 70
+    interval            = 20
+    timeout             = 10
     healthy_threshold   = 2
-    unhealthy_threshold = 5
+    unhealthy_threshold = 4
     port                = local.frontend_port
     path                = "/health"
   }


### PR DESCRIPTION
## Context

The frontend currently only returns 200 as a simple ready check, rather than checking the services it relies on before returning.

## Changes proposed in this pull request

- Added `/live` endpoint that just returns a 200 if available
- Updated `/health` endpoint that checks the backend service availability before returning and bubbles up status
- Updated the middleware passthrough to allow `/live` to be hit without auth

## Guidance to review

- Deploy and test healthcheck works as intended
