### PR TITLE
Elliotmoore/pro 301 implement deep backend health checks

### DIFF
--- a/backend/consultations/api/views/health.py
+++ b/backend/consultations/api/views/health.py
@@ -68,20 +68,36 @@ def _check_s3() -> None:
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health_check(_request) -> Response:
-    """Check health of connected services"""
-    checks: dict[str, str] = {}
-    _run_check(checks, "database", _check_database)
-    _run_check(checks, "redis", _check_redis)
-    _run_check(checks, "s3", _check_s3)
+    """Check health of connected services.
 
-    app_status = OK if all(check == OK for check in checks.values()) else NOT_OK
+    S3 is treated as a non-critical dependency: its status is reported but does
+    not affect the overall health status or HTTP response code.
+    """
+    critical_checks: dict[str, str] = {}
+    non_critical_checks: dict[str, str] = {}
+
+    _run_check(critical_checks, "database", _check_database)
+    _run_check(critical_checks, "redis", _check_redis)
+    _run_check(non_critical_checks, "s3", _check_s3)
+
+    app_status = OK if all(v == OK for v in critical_checks.values()) else NOT_OK
     http_status = 200 if app_status == OK else 503
 
     return Response(
         {
             "status": app_status,
-            "checks": checks,
+            "checks": {**critical_checks, **non_critical_checks},
             "timestamp": datetime.now(UTC).isoformat(),
         },
         status=http_status,
+    )
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def live_check(_request) -> Response:
+    """Liveness probe — returns 200 whenever the process is running."""
+    return Response(
+        {"status": OK, "timestamp": datetime.now(UTC).isoformat()},
+        status=200,
     )

--- a/backend/consultations/api/views/health.py
+++ b/backend/consultations/api/views/health.py
@@ -68,11 +68,7 @@ def _check_s3() -> None:
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health_check(_request) -> Response:
-    """Check health of connected services.
-
-    S3 is treated as a non-critical dependency: its status is reported but does
-    not affect the overall health status or HTTP response code.
-    """
+    """Check health of connected services."""
     critical_checks: dict[str, str] = {}
     non_critical_checks: dict[str, str] = {}
 

--- a/backend/consultations/urls.py
+++ b/backend/consultations/urls.py
@@ -6,7 +6,7 @@ from rest_framework_nested.routers import NestedDefaultRouter
 from .api.views.auth import logout_view, validate_token
 from .api.views.candidate_theme import CandidateThemeViewSet
 from .api.views.consultation import ConsultationViewSet
-from .api.views.health import health_check
+from .api.views.health import health_check, live_check
 from .api.views.question import QuestionViewSet
 from .api.views.respondent import RespondentViewSet
 from .api.views.response import ResponseViewSet
@@ -33,6 +33,7 @@ questions_router.register("responses", ResponseViewSet, basename="question-respo
 urlpatterns = [
     # API endpoints
     path("api/health/", health_check, name="health"),
+    path("api/live/", live_check, name="live"),
     path("api/", include(router.urls)),
     path("api/", include(consultations_router.urls)),
     path("api/", include(questions_router.urls)),

--- a/backend/tests/unit/api/views/test_healthcheck_view.py
+++ b/backend/tests/unit/api/views/test_healthcheck_view.py
@@ -5,7 +5,8 @@ from django.urls import reverse
 
 from consultations.api.views.health import NOT_OK, OK
 
-CHECK_NAMES = ("database", "redis", "s3")
+CRITICAL_CHECK_NAMES = ("database", "redis")
+ALL_CHECK_NAMES = ("database", "redis", "s3")
 
 
 def _break_database(mock_connect, exception):
@@ -25,7 +26,7 @@ def _break_s3(mock_s3, exception):
 # * patch_target: the dependency used by the healthcheck
 # * apply_failure: where the exception is invoked
 # * exception: either ConnectionError or TimeoutError
-FAILURE_CASES = [
+CRITICAL_FAILURE_CASES = [
     pytest.param(
         "database",
         "consultations.api.views.health.psycopg.connect",
@@ -37,7 +38,7 @@ FAILURE_CASES = [
         "database",
         "consultations.api.views.health.psycopg.connect",
         _break_database,
-        TimeoutError("Connection refused"),
+        TimeoutError("Connection timed out"),
         id="db-timeout",
     ),
     pytest.param(
@@ -54,17 +55,14 @@ FAILURE_CASES = [
         TimeoutError("Redis TimeoutError"),
         id="redis-timeout",
     ),
+]
+
+S3_FAILURE_CASES = [
     pytest.param(
-        "s3",
-        "consultations.utils.s3.get_s3_client",
-        _break_s3,
         ConnectionError("S3 connection error"),
         id="s3-failure",
     ),
     pytest.param(
-        "s3",
-        "consultations.utils.s3.get_s3_client",
-        _break_s3,
         TimeoutError("S3 connection timeout"),
         id="s3-timeout",
     ),
@@ -74,21 +72,22 @@ FAILURE_CASES = [
 @pytest.mark.django_db
 class TestHealthCheckView:
     def test_healthy_response_returns_200(self, client):
-        """Test API endpoint returns expected successful response if system healthy"""
+        """Returns 200 with all checks passing when all dependencies are reachable."""
         url = reverse("health")
         response = client.get(url)
 
         assert response.status_code == 200
         data = response.json()
-
         assert data["status"] == OK
         assert data["timestamp"]
+        for name in ALL_CHECK_NAMES:
+            assert data["checks"][name] == OK
 
-    @pytest.mark.parametrize("failing_check,patch_target,apply_failure,exception", FAILURE_CASES)
-    def test_dependency_failure_returns_503(
+    @pytest.mark.parametrize("failing_check,patch_target,apply_failure,exception", CRITICAL_FAILURE_CASES)
+    def test_critical_dependency_failure_returns_503(
         self, client, failing_check, patch_target, apply_failure, exception
     ):
-        """Test API endpoint returns 503 and marks only the failing dependency as unhealthy"""
+        """Returns 503 and marks only the failing critical dependency as unhealthy."""
         url = reverse("health")
 
         with patch(patch_target) as mock_dependency:
@@ -98,5 +97,41 @@ class TestHealthCheckView:
         assert response.status_code == 503
         data = response.json()
         assert data["status"] == NOT_OK
-        for name in CHECK_NAMES:
+        for name in CRITICAL_CHECK_NAMES:
             assert data["checks"][name] == (NOT_OK if name == failing_check else OK)
+
+    @pytest.mark.parametrize("exception", S3_FAILURE_CASES)
+    def test_s3_failure_returns_200_with_degraded_s3_status(self, client, exception):
+        """S3 is non-critical: its failure is reported in checks but does not cause a 503."""
+        url = reverse("health")
+
+        with patch("consultations.utils.s3.get_s3_client") as mock_s3:
+            _break_s3(mock_s3, exception)
+            response = client.get(url)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == OK
+        assert data["checks"]["s3"] == NOT_OK
+        assert data["checks"]["database"] == OK
+        assert data["checks"]["redis"] == OK
+
+
+@pytest.mark.django_db
+class TestLiveCheckView:
+    def test_returns_200_when_process_is_running(self, client):
+        """Always returns 200 regardless of dependency state."""
+        url = reverse("live")
+        response = client.get(url)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == OK
+        assert data["timestamp"]
+
+    def test_requires_no_authentication(self, client):
+        """Liveness probe must be accessible without any credentials."""
+        url = reverse("live")
+        response = client.get(url)
+
+        assert response.status_code == 200

--- a/backend/tests/unit/api/views/test_healthcheck_view.py
+++ b/backend/tests/unit/api/views/test_healthcheck_view.py
@@ -117,7 +117,6 @@ class TestHealthCheckView:
         assert data["checks"]["redis"] == OK
 
 
-@pytest.mark.django_db
 class TestLiveCheckView:
     def test_returns_200_when_process_is_running(self, client):
         """Always returns 200 regardless of dependency state."""
@@ -128,10 +127,3 @@ class TestLiveCheckView:
         data = response.json()
         assert data["status"] == OK
         assert data["timestamp"]
-
-    def test_requires_no_authentication(self, client):
-        """Liveness probe must be accessible without any credentials."""
-        url = reverse("live")
-        response = client.get(url)
-
-        assert response.status_code == 200

--- a/frontend/src/pages/health.ts
+++ b/frontend/src/pages/health.ts
@@ -4,7 +4,7 @@ import { Routes } from "../global/routes";
 
 type BackendHealthStatus = "ok" | "error" | "unreachable";
 
-const timeoutMs = 5000;
+const timeoutMs = 12000;
 
 interface HealthResponse {
   status: "ok" | "error";

--- a/frontend/src/pages/health.ts
+++ b/frontend/src/pages/health.ts
@@ -4,7 +4,7 @@ import { Routes } from "../global/routes";
 
 type BackendHealthStatus = "ok" | "error" | "unreachable";
 
-const timeoutMs = 12000;
+const timeoutMs = 14000;
 
 interface HealthResponse {
   status: "ok" | "error";

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -142,7 +142,7 @@ module "frontend" {
   health_check = {
     accepted_response   = 200
     interval            = 20
-    timeout             = 15
+    timeout             = 17
     healthy_threshold   = 2
     unhealthy_threshold = 4
     port                = local.frontend_port

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -81,10 +81,10 @@ module "backend" {
   health_check = {
     accepted_response   = 200
     path                = "/api/health"
-    interval            = 60
-    timeout             = 50
+    interval            = 20
+    timeout             = 15
     healthy_threshold   = 2
-    unhealthy_threshold = 5
+    unhealthy_threshold = 4
     port                = local.backend_port
   }
 
@@ -203,9 +203,9 @@ module "worker" {
   http_healthcheck = false
   container_healthcheck = {
     command     = ["CMD-SHELL", "venv/bin/python3.12 manage.py healthcheck_worker"]
-    interval    = 60
-    timeout     = 20
-    retries     = 3
+    interval    = 20
+    timeout     = 10
+    retries     = 4
     startPeriod = 60
   }
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -82,7 +82,7 @@ module "backend" {
     accepted_response   = 200
     path                = "/api/health"
     interval            = 20
-    timeout             = 15
+    timeout             = 17
     healthy_threshold   = 2
     unhealthy_threshold = 4
     port                = local.backend_port

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -142,7 +142,7 @@ module "frontend" {
   health_check = {
     accepted_response   = 200
     interval            = 20
-    timeout             = 10
+    timeout             = 15
     healthy_threshold   = 2
     unhealthy_threshold = 4
     port                = local.frontend_port


### PR DESCRIPTION
## Context

The backend currently has some deep healthchecks, but s3 is non-critical and we don't have a simple liveness check

## Changes proposed in this pull request

- Updated `/health` just to make s3 non-critical
- Added `/live` to do a simple ping check
- Updated the tests to match the above
- Updated the interval/timeouts set in ecs.tf for worker and backend

## Guidance to review

- Deploy and check that the containers are alive and outlast the timeout check (80s)
