### PR TITLE
Change the worker ECS in ecs.tf to use `backend` as the SSM key

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -185,7 +185,7 @@ module "worker" {
     "EXECUTION_CONTEXT"        = "worker"
     "DOCKER_BUILDER_CONTAINER" = "${var.project_name}-worker"
     "SENTRY_DSN"               = var.backend_sentry_dsn
-    "SENTRY_RELEASE"           = data.aws_ssm_parameter.image_tags["worker"].value
+    "SENTRY_RELEASE"           = data.aws_ssm_parameter.image_tags["backend"].value
   })
 
   secrets = [


### PR DESCRIPTION
## Context

The deployment is failing because the worker is looking for the wrong SSM key for its image tag value.

## Changes proposed in this pull request

- Change the worker container to use `backend` instead of `worker` for its SSM key
