### PR TITLE
Pro 710 dataset cards ADR

### DIFF
--- a/docs/architecture/decisions/0014-dvc-for-eval-pipeline-version-control.md
+++ b/docs/architecture/decisions/0014-dvc-for-eval-pipeline-version-control.md
@@ -1,4 +1,4 @@
-# 13. DVC for eval pipeline version control
+# 14. DVC for eval pipeline version control
 
 Date: 2026-08-21
 

--- a/docs/architecture/decisions/0015-dataset-cards.md
+++ b/docs/architecture/decisions/0015-dataset-cards.md
@@ -1,0 +1,63 @@
+# 15. Dataset cards
+
+Date: 2026-09-04
+
+## Status
+
+Accepted
+
+## Context
+
+We have numerous datasets from consultations, which are a mix of synthetic data generated
+for evaluation, and real data from live consultations. These datasets vary in when they were
+gathered, what they can be used for, and how long they can be retained. However, we don't have
+a standard set of metadata fields that each dataset should be tagged with, or a system to record
+and query this metadata.
+
+## Decision
+
+### Data Cards
+
+We should use a simple JSON template to specify a "data card" that defines the metadata that each
+dataset is required to be tagged with. The data card will have the following fields and hierarchy:
+
+* Identity
+    * dataset_id (stable unique ID)
+    * name
+    * description
+    * owner (person or team)
+    * created_at
+
+* Provenance
+    * source_type (user annotation / synthetic)
+    * labeling_method (single human labeling / double human labeling / model-assisted)
+    * transformations (normalization / dedupe / PII redaction / filtering)
+
+* Permissions
+    * contains_pii (yes / no)
+    * allowed_uses (evaluation / fine-tuning)
+    * sensitivity (public / internal)
+    * retention_end_date (date)
+
+* Usage boundaries
+    * split_role (training / fine-tuning / eval / red-teaming / monitoring)
+
+**NOTE**: we want to keep the balance between recording everything we need to use data in a compliant way,
+and making the data cards as quick as possible to complete so that people actually fill them out.
+
+### System of Record
+
+We will use Langfuse as our system of record, passing the metadata JSON into calls to `Langfuse.create_dataset()`
+via the `metadata` field. This will enable us to view and edit the metadata manually through the Langfuse portal,
+or programatically through the Langfuse SDK. As a back-up, we should consider storing the JSON files in S3 too.
+
+## Consequences
+
+### Positive
+
+1. We will remain compliant with our data usage agreements
+2. We will have clear records of what data is being used to fine-tune and evaluate, preventing leakage
+
+### Negative
+
+1. Additional admin burden when ingesting data (but this can be minimised by using a standard template)

--- a/docs/architecture/decisions/0015-dataset-cards.md
+++ b/docs/architecture/decisions/0015-dataset-cards.md
@@ -29,13 +29,13 @@ dataset is required to be tagged with. The data card will have the following fie
     * created_at
 
 * Provenance
-    * source_type (user annotation / synthetic)
-    * labeling_method (single human labeling / double human labeling / model-assisted)
-    * transformations (normalization / dedupe / PII redaction / filtering)
+    * source_type (human / synthetic)
+    * labelling_method (single human / double human / automatic)
+    * transformations (normalization / deduplication / PII redaction / filtering)
 
 * Permissions
     * contains_pii (yes / no)
-    * allowed_uses (evaluation / fine-tuning)
+    * permitted_for_optimisation (yes / no)
     * sensitivity (public / internal)
     * retention_end_date (date)
 
@@ -51,6 +51,13 @@ We will use Langfuse as our system of record, passing the metadata JSON into cal
 via the `metadata` field. This will enable us to view and edit the metadata manually through the Langfuse portal,
 or programatically through the Langfuse SDK. As a back-up, we should consider storing the JSON files in S3 too.
 
+### Dataset Upload Script
+
+We will write a script that makes it easy to comply with the data labelling and storage requirements, by:
+1. Connecting to Langfuse automatically (using env variables)
+2. Prompting the user for values for each field in the data card
+3. Uploading the dataset and its metadata to Langfuse
+
 ## Consequences
 
 ### Positive
@@ -60,4 +67,4 @@ or programatically through the Langfuse SDK. As a back-up, we should consider st
 
 ### Negative
 
-1. Additional admin burden when ingesting data (but this can be minimised by using a standard template)
+1. Additional admin burden when ingesting data (but this can be minimised by using the Dataset Upload Script detailed above)


### PR DESCRIPTION
## Context

This ADR details how we should approach management of our eval data: what metadata we record, and the process for making and retrieving records.

## Changes proposed in this pull request

I propose 2 main changes:
1. Define a Data Card for each dataset, with a standard set of fields which must be filled out
2. Use Langfuse as the system of record for Data Cards

## Guidance to review

As well as reading the ADR, consider navigating to one of our datasets in Langfuse and looking at the Metadata field - this is where the Data Card info will be displayed.

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
