### PR TITLE
PRO-702: Replace manage consultations table with DataTable

### DIFF
--- a/e2e_tests/tests/support-console-archive.e2e.ts
+++ b/e2e_tests/tests/support-console-archive.e2e.ts
@@ -148,29 +148,29 @@ test.describe("Support Console - Consultations", () => {
   });
 
   test("initially sorted by date", async ({ page }) => {
-    const sortByDateButton = page.getByRole("button", { name: "Created At" });
+    const sortByDateButton = page.getByRole("button", { name: "Date Created" });
     await expect(sortByDateButton).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByTestId("date-column")).toHaveAttribute("aria-sort", "descending");
+    await expect(page.getByTestId("header-createdAt")).toHaveAttribute("aria-sort", "descending");
   });
 
   test("toggles date sort state when date sort button is clicked", async ({ page }) => {
-    const sortByDateButton = page.getByRole("button", { name: "Created At" });
+    const sortByDateButton = page.getByRole("button", { name: "Date Created" });
 
     // Click once to unset sorting
     await sortByDateButton.click();
     await expect(sortByDateButton).toHaveAttribute("aria-pressed", "false");
-    await expect(page.getByTestId("date-column")).toHaveAttribute("aria-sort", "none");
+    await expect(page.getByTestId("header-createdAt")).toHaveAttribute("aria-sort", "none");
 
     // Click once more to apply ascending sorting
     await sortByDateButton.click();
     await expect(sortByDateButton).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByTestId("date-column")).toHaveAttribute("aria-sort", "ascending");
+    await expect(page.getByTestId("header-createdAt")).toHaveAttribute("aria-sort", "ascending");
   });
 
   test("initially does not sort by name", async ({ page }) => {
     const sortByNameButton = page.getByRole("button", { name: "Name" });
     await expect(sortByNameButton).toHaveAttribute("aria-pressed", "false");
-    await expect(page.getByTestId("name-column")).toHaveAttribute("aria-sort", "none");
+    await expect(page.getByTestId("header-name")).toHaveAttribute("aria-sort", "none");
   });
 
   test("toggles name sort state when name sort button is clicked", async ({ page }) => {
@@ -179,12 +179,12 @@ test.describe("Support Console - Consultations", () => {
     // Click once to apply sorting
     await sortByNameButton.click();
     await expect(sortByNameButton).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByTestId("name-column")).toHaveAttribute("aria-sort", "ascending");
+    await expect(page.getByTestId("header-name")).toHaveAttribute("aria-sort", "ascending");
 
     // Click once more to reverse sorting
     await sortByNameButton.click();
     await expect(sortByNameButton).toHaveAttribute("aria-pressed", "true");
-    await expect(page.getByTestId("name-column")).toHaveAttribute("aria-sort", "descending");
+    await expect(page.getByTestId("header-name")).toHaveAttribute("aria-sort", "descending");
   });
 
   test("consultations list shows creation dates", async ({ page }) => {

--- a/frontend/src/components/DataTable/DataTable.svelte
+++ b/frontend/src/components/DataTable/DataTable.svelte
@@ -330,7 +330,7 @@
                 column.align === "right" && "text-right",
               ])}
               aria-sort={getSortText(column, sort)}
-              data-testid="column-header"
+              data-testid={`header-${column.key}`}
             >
               {#if sortable && column.sortable !== false}
                 <Button
@@ -449,6 +449,7 @@
                     column.align === "center" && "text-center",
                     column.align === "right" && "text-right",
                   ])}
+                  data-testid={`cell-${column.key}`}
                 >
                   {#if cellContent}
                     {@render cellContent(content, row, column)}

--- a/frontend/src/components/DataTable/DataTable.test.ts
+++ b/frontend/src/components/DataTable/DataTable.test.ts
@@ -20,6 +20,19 @@ function isRowsSorted(rows: HTMLElement[], reverse?: boolean) {
   return true;
 }
 
+const compareRowDates = (nameA: HTMLElement, nameB: HTMLElement) => {
+  const rowA = TEST_DATA.rows.find((row) => row.name === nameA.textContent)!;
+  const rowB = TEST_DATA.rows.find((row) => row.name === nameB.textContent)!;
+
+  const dateA = new Date(rowA.createdAt).getTime();
+  const dateB = new Date(rowB.createdAt).getTime();
+
+  if (dateA === dateB) {
+    return 0;
+  }
+  return dateA < dateB ? -1 : 1;
+};
+
 describe("DataTable", () => {
   it.each(TEST_DATA.columns)("should render column label", (column) => {
     render(DataTable, TEST_DATA as Record<string, unknown>);
@@ -431,7 +444,7 @@ describe("DataTable", () => {
     const numExpectedVisibleColumnsAfter = TEST_DATA.columns.length - 1;
 
     // expect all columns to be visible initially
-    expect(screen.getAllByTestId("column-header")).toHaveLength(
+    expect(screen.getAllByTestId("header", { exact: false })).toHaveLength(
       numExpectedVisibleColumnsBefore,
     );
 
@@ -447,7 +460,7 @@ describe("DataTable", () => {
     await user.click(firstColumnOption!);
 
     // expect one column to be hidden at this point
-    expect(screen.getAllByTestId("column-header")).toHaveLength(
+    expect(screen.getAllByTestId("header", { exact: false })).toHaveLength(
       numExpectedVisibleColumnsAfter,
     );
 
@@ -458,7 +471,7 @@ describe("DataTable", () => {
     await user.click(screen.getAllByTestId("searchable-select-option").at(0)!);
 
     // expect that all columns are visible again
-    expect(screen.getAllByTestId("column-header")).toHaveLength(
+    expect(screen.getAllByTestId("header", { exact: false })).toHaveLength(
       numExpectedVisibleColumnsBefore,
     );
   });
@@ -507,6 +520,44 @@ describe("DataTable", () => {
         "Sorted ascending by Name. Click to sort descending.",
       ),
     ).not.toBeInTheDocument();
+  });
+
+  it("should correctly sort dates", async () => {
+    render(DataTable, TEST_DATA as Record<string, unknown>);
+
+    const dateSortButton = screen.getByRole("button", {
+      name: "Sort by Date Created",
+    });
+
+    const user = userEvent.setup();
+
+    // Click once to apply sort
+    await user.click(dateSortButton);
+
+    const names = screen.getAllByTestId("cell-name");
+    const namesSortedByDate = names.toSorted(compareRowDates);
+
+    expect(names).toEqual(namesSortedByDate);
+  });
+
+  it("should correctly sort dates reversed", async () => {
+    render(DataTable, TEST_DATA as Record<string, unknown>);
+
+    const dateSortButton = screen.getByRole("button", {
+      name: "Sort by Date Created",
+    });
+
+    const user = userEvent.setup();
+
+    // Click once to apply sort
+    await user.click(dateSortButton);
+    // Click once again to reverse sort
+    await user.click(dateSortButton);
+
+    const names = screen.getAllByTestId("cell-name");
+    const namesSortedByDate = names.toSorted(compareRowDates);
+
+    expect(names).toEqual(namesSortedByDate.toReversed());
   });
 
   it("should match snapshot", () => {

--- a/frontend/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
+++ b/frontend/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
@@ -165,7 +165,7 @@ exports[`DataTable > should match snapshot 1`] = `
             <th
               aria-sort="ascending"
               class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-              data-testid="column-header"
+              data-testid="header-name"
               scope="col"
             >
               <!---->
@@ -219,7 +219,7 @@ exports[`DataTable > should match snapshot 1`] = `
             <th
               aria-sort="none"
               class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-              data-testid="column-header"
+              data-testid="header-createdAt"
               scope="col"
             >
               <!---->
@@ -278,6 +278,7 @@ exports[`DataTable > should match snapshot 1`] = `
           >
             <td
               class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-name"
             >
               <!---->
               Test Item 1 - A
@@ -286,6 +287,7 @@ exports[`DataTable > should match snapshot 1`] = `
             </td>
             <td
               class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-createdAt"
             >
               <!---->
               2026-08-19
@@ -300,6 +302,7 @@ exports[`DataTable > should match snapshot 1`] = `
           >
             <td
               class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-name"
             >
               <!---->
               Test Item 2 - B
@@ -308,6 +311,7 @@ exports[`DataTable > should match snapshot 1`] = `
             </td>
             <td
               class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-createdAt"
             >
               <!---->
               2026-06-19
@@ -322,6 +326,7 @@ exports[`DataTable > should match snapshot 1`] = `
           >
             <td
               class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-name"
             >
               <!---->
               Test Item 3 - C
@@ -330,6 +335,7 @@ exports[`DataTable > should match snapshot 1`] = `
             </td>
             <td
               class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-createdAt"
             >
               <!---->
               2025-10-10

--- a/frontend/src/components/DataTable/testData.ts
+++ b/frontend/src/components/DataTable/testData.ts
@@ -33,7 +33,7 @@ export const COLUMNS = [
     label: "Date Created",
     sortable: true,
 
-    sortValue: (item: RowItem) => new Date(item.createdAt).getTime(),
+    sortValue: (item: RowItem) => new Date(item.createdAt),
   },
 ];
 

--- a/frontend/src/components/screens/ConsultationList/__snapshots__/ConsultationList.test.ts.snap
+++ b/frontend/src/components/screens/ConsultationList/__snapshots__/ConsultationList.test.ts.snap
@@ -89,7 +89,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-name"
                 scope="col"
               >
                 <!---->
@@ -138,7 +138,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-createdAt"
                 scope="col"
               >
                 <!---->
@@ -187,7 +187,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-evalLink"
                 scope="col"
               >
                 <span>
@@ -198,7 +198,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-themesLink"
                 scope="col"
               >
                 <span>
@@ -209,7 +209,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-dashboardLink"
                 scope="col"
               >
                 <span>
@@ -230,6 +230,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
             >
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-name"
               >
                 <!---->
                 <!---->
@@ -242,6 +243,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-createdAt"
               >
                 <!---->
                 <!---->
@@ -254,6 +256,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-evalLink"
               >
                 <!---->
                 <!---->
@@ -279,6 +282,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-themesLink"
               >
                 <!---->
                 <!---->
@@ -304,6 +308,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-dashboardLink"
               >
                 <!---->
                 <!---->
@@ -335,6 +340,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
             >
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-name"
               >
                 <!---->
                 <!---->
@@ -347,6 +353,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-createdAt"
               >
                 <!---->
                 <!---->
@@ -359,6 +366,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-evalLink"
               >
                 <!---->
                 <!---->
@@ -384,6 +392,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-themesLink"
               >
                 <!---->
                 <!---->
@@ -409,6 +418,7 @@ exports[`ConsultationList > should match snapshot after loading 1`] = `
               </td>
               <td
                 class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+                data-testid="cell-dashboardLink"
               >
                 <!---->
                 <!---->
@@ -682,7 +692,7 @@ exports[`ConsultationList > should match snapshot initially 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-name"
                 scope="col"
               >
                 <!---->
@@ -731,7 +741,7 @@ exports[`ConsultationList > should match snapshot initially 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-createdAt"
                 scope="col"
               >
                 <!---->
@@ -780,7 +790,7 @@ exports[`ConsultationList > should match snapshot initially 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-evalLink"
                 scope="col"
               >
                 <span>
@@ -791,7 +801,7 @@ exports[`ConsultationList > should match snapshot initially 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-themesLink"
                 scope="col"
               >
                 <span>
@@ -802,7 +812,7 @@ exports[`ConsultationList > should match snapshot initially 1`] = `
               <th
                 aria-sort="none"
                 class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
-                data-testid="column-header"
+                data-testid="header-dashboardLink"
                 scope="col"
               >
                 <span>

--- a/frontend/src/components/screens/ManageConsultationsArchive/ManageConsultationsArchive.svelte
+++ b/frontend/src/components/screens/ManageConsultationsArchive/ManageConsultationsArchive.svelte
@@ -1,204 +1,103 @@
+<script lang="ts" module>
+  export const buildDateTimeString = (date: Date) => {
+    const dateString = date.toLocaleString(navigator.language, {
+      month: "long",
+      day: "2-digit",
+      year: "numeric",
+    });
+    const timeString = date.toLocaleTimeString(navigator.language, {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+    return `${dateString} at ${timeString}`;
+  };
+</script>
+
 <script lang="ts">
-  import clsx from "clsx";
-
-  import { fade } from "svelte/transition";
-
   import { getSupportConsultationDetails } from "../../../global/routes";
-  import { formatDate } from "../../../global/utils";
 
   import Link from "../../Link.svelte";
   import Title from "../../Title.svelte";
-  import MaterialIcon from "../../MaterialIcon.svelte";
-  import ArrowForward from "../../svg/material/ArrowForward.svelte";
-  import Button from "../../inputs/Button/Button.svelte";
-  import TextInput from "../../inputs/TextInput/TextInput.svelte";
+  import DataTable from "../../DataTable/DataTable.svelte";
+
+  interface LinkData {
+    url: string;
+    text: string;
+    ariaLabel: string;
+  }
 
   interface Consultation {
     id: string;
     title: string;
     created_at: string;
   }
+
+  interface DisplayConsultation {
+    createdAt: string;
+    name: LinkData;
+  }
+
   interface Props {
     consultations: Consultation[];
   }
 
   let { consultations = [] }: Props = $props();
 
-  const SORT_DIRECTION = {
-    ASC: "ascending",
-    DESC: "descending",
-    NONE: "none",
-  } as const;
+  let displayConsultations = $derived(
+    consultations.map((consultation) => ({
+      name: {
+        url: getSupportConsultationDetails(consultation.id),
+        text: consultation.title,
+        ariaLabel: `View ${consultation.title}`,
+      },
+      createdAt: consultation.created_at,
+    })),
+  );
 
-  type SortDirection =
-    | typeof SORT_DIRECTION.ASC
-    | typeof SORT_DIRECTION.DESC
-    | typeof SORT_DIRECTION.NONE;
-
-  let nameSortDirection = $state<SortDirection>(SORT_DIRECTION.NONE);
-  let dateSortDirection = $state<SortDirection>(SORT_DIRECTION.DESC);
-  let searchValue = $state("");
-
-  let displayConsultations = $derived.by(() => {
-    let result = [...consultations];
-
-    if (dateSortDirection !== SORT_DIRECTION.NONE) {
-      result.sort((a, b) => {
-        const dateA = new Date(a.created_at).getTime();
-        const dateB = new Date(b.created_at).getTime();
-
-        if (dateA === dateB) {
-          return 0;
-        }
-
-        const dateDirectionMultiplier =
-          dateSortDirection === SORT_DIRECTION.ASC ? -1 : 1;
-
-        return (dateA < dateB ? 1 : -1) * dateDirectionMultiplier;
-      });
-    }
-
-    if (nameSortDirection !== SORT_DIRECTION.NONE) {
-      result.sort((a, b) => {
-        const nameA = a.title;
-        const nameB = b.title;
-
-        const nameDirectionMultiplier =
-          nameSortDirection === SORT_DIRECTION.ASC ? 1 : -1;
-
-        if (nameA < nameB) {
-          return -1 * nameDirectionMultiplier;
-        } else if (nameA > nameB) {
-          return 1 * nameDirectionMultiplier;
-        }
-        return 0;
-      });
-    }
-
-    if (searchValue) {
-      result = result.filter((consultation) => {
-        const textA = consultation.title.toLocaleLowerCase();
-        const textB = searchValue.toLocaleLowerCase();
-        return textA.includes(textB);
-      });
-    }
-
-    return result;
-  });
+  const getFormattedDateTime = (item: DisplayConsultation) => {
+    const dateObj = new Date(item.createdAt);
+    return buildDateTimeString(dateObj);
+  };
 </script>
-
-{#snippet sortButton(
-  text: string,
-  direction: SortDirection,
-  setDirection: (newDirection: SortDirection) => void,
-  resetDirections: () => void,
-)}
-  <Button
-    variant="ghost"
-    handleClick={() => {
-      resetDirections();
-
-      if (direction === SORT_DIRECTION.NONE) {
-        setDirection(SORT_DIRECTION.ASC);
-      } else if (direction === SORT_DIRECTION.ASC) {
-        setDirection(SORT_DIRECTION.DESC);
-      } else {
-        setDirection(SORT_DIRECTION.NONE);
-      }
-    }}
-    ariaLabel={`sort consultations by ${text}`}
-    ariaControls="consultations-list"
-    highlighted={direction !== SORT_DIRECTION.NONE}
-    highlightVariant="none"
-  >
-    {text}
-    {#if direction !== SORT_DIRECTION.NONE}
-      <div
-        class={clsx([
-          "transition-transform",
-          direction === SORT_DIRECTION.ASC ? "rotate-90" : "-rotate-90",
-        ])}
-      >
-        <MaterialIcon color="fill-neutral-500">
-          <ArrowForward />
-        </MaterialIcon>
-      </div>
-    {/if}
-  </Button>
-{/snippet}
 
 <Title level={1} text="Consultations" />
 
-<div class="mt-2 w-full md:w-1/3">
-  <TextInput
-    id="search-consultations"
-    label="Search consultations"
-    placeholder="Find consultation..."
-    hideLabel={true}
-    value={searchValue}
-    setValue={(newValue) => (searchValue = newValue.trim())}
-  />
-</div>
+<DataTable
+  columns={[
+    {
+      key: "name",
+      label: "Name",
+      sortable: true,
+      sortValue: (item) => item.name.text,
+      filterValue: (item) => item.name.text,
+    },
+    {
+      key: "createdAt",
+      label: "Date Created",
+      sortable: true,
+      sortValue: (item) => new Date(item.createdAt).getTime(),
+      displayValue: (item) => getFormattedDateTime(item),
+      filterValue: (item) => getFormattedDateTime(item),
+    },
+  ]}
+  rows={displayConsultations}
+  emptyText="No consultations found for the given query"
+  initialSort={{
+    key: "createdAt",
+    direction: "desc",
+  }}
+  searchPlaceholder="Search consultations"
+>
+  {#snippet cellContent(content, row, column)}
+    {#if column.key === "name"}
+      {@const linkData = row[column.key] as LinkData}
 
-<div class="overflow-x-auto">
-  <table class="w-full whitespace-nowrap text-left">
-    <thead class="font-bold">
-      <tr>
-        <th
-          class="py-2 pr-2"
-          aria-sort={nameSortDirection || "none"}
-          data-testid="name-column"
-        >
-          {@render sortButton(
-            "Name",
-            nameSortDirection,
-            (newSortDirection: SortDirection) => {
-              nameSortDirection = newSortDirection;
-            },
-            () => (dateSortDirection = SORT_DIRECTION.NONE),
-          )}
-        </th>
-        <th
-          class="py-2 pr-2"
-          aria-sort={dateSortDirection || "none"}
-          data-testid="date-column"
-        >
-          {@render sortButton(
-            "Created At",
-            dateSortDirection,
-            (newSortDirection: SortDirection) => {
-              dateSortDirection = newSortDirection;
-            },
-            () => (nameSortDirection = SORT_DIRECTION.NONE),
-          )}
-        </th>
-      </tr>
-    </thead>
-    <tbody id="consultations-list">
-      {#if displayConsultations.length === 0}
-        <tr in:fade={{ duration: 200 }} class="border-t hover:bg-gray-50">
-          <td colspan="2" class="text-neutral-500">
-            No consultation found for the given query
-          </td>
-        </tr>
-      {/if}
-
-      {#each displayConsultations as consultation (consultation.id)}
-        <tr
-          transition:fade={{ duration: 200 }}
-          class="border-t hover:bg-gray-50"
-          data-testid="consultation-item"
-        >
-          <td data-testid="title" class="py-2 pr-2">
-            <Link href={getSupportConsultationDetails(consultation.id)}>
-              {consultation.title}
-            </Link>
-          </td>
-          <td data-testid="created-at" class="py-2 pr-2"
-            >{formatDate(consultation.created_at)}</td
-          >
-        </tr>
-      {/each}
-    </tbody>
-  </table>
-</div>
+      <Link href={linkData.url} ariaLabel={linkData.ariaLabel}>
+        {linkData.text}
+      </Link>
+    {:else}
+      <span>{content}</span>
+    {/if}
+  {/snippet}
+</DataTable>

--- a/frontend/src/components/screens/ManageConsultationsArchive/ManageConsultationsArchive.test.ts
+++ b/frontend/src/components/screens/ManageConsultationsArchive/ManageConsultationsArchive.test.ts
@@ -1,35 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { render, screen, waitFor } from "@testing-library/svelte";
-import userEvent from "@testing-library/user-event";
 
-import ManageConsultationsArchive from "./ManageConsultationsArchive.svelte";
+import ManageConsultationsArchive, {
+  buildDateTimeString,
+} from "./ManageConsultationsArchive.svelte";
 import { CONSULTATIONS } from "./testData";
-
-function parseCreatedAt(createdAtText: string) {
-  const [dateStr, timeStr] = createdAtText.split(" at ");
-  const [hourStr, minStr] = timeStr.split(":");
-  const date = new Date(dateStr);
-
-  const HOUR_IN_MILLISECONDS = 60 * 60 * 1000;
-  const MIN_IN_MILLISECONDS = 60 * 1000;
-
-  date.setTime(
-    date.getTime() +
-      parseInt(hourStr) * HOUR_IN_MILLISECONDS +
-      parseInt(minStr) * MIN_IN_MILLISECONDS,
-  );
-  return date;
-}
-
-function buildCreatedAt(date: Date) {
-  const year = date.getFullYear();
-  const monthName = date.toLocaleString("default", { month: "long" });
-  const day = date.getDate();
-  const hour = date.getHours();
-  const minute = date.getMinutes();
-  return `${day} ${monthName} ${year} at ${hour}:${minute}`;
-}
 
 describe("ManageConsultationsArchive", () => {
   it.each(CONSULTATIONS)("should render consultation", async (consultation) => {
@@ -40,83 +16,8 @@ describe("ManageConsultationsArchive", () => {
     });
 
     const date = new Date(consultation.created_at);
-    const createdAtText = buildCreatedAt(date);
+    const createdAtText = buildDateTimeString(date);
     expect(screen.getAllByText(createdAtText).length).toBeGreaterThan(0);
-  });
-
-  it("should only show consultations matching search", async () => {
-    render(ManageConsultationsArchive, { consultations: CONSULTATIONS });
-
-    const user = userEvent.setup();
-    await user.type(screen.getByLabelText("Search consultations"), "1");
-
-    await waitFor(() => {
-      const visibleConsultations = screen.getAllByTestId("consultation-item");
-      expect(visibleConsultations).toHaveLength(1);
-    });
-  });
-
-  it("should sort by ascending if created at button is clicked twice", async () => {
-    render(ManageConsultationsArchive, { consultations: CONSULTATIONS });
-
-    const dateSortButton = screen.getByRole("button", {
-      name: "sort consultations by Created At",
-    });
-
-    const user = userEvent.setup();
-    // click to unset sort
-    await user.click(dateSortButton);
-    // click to apply ascending
-    await user.click(dateSortButton);
-
-    const createdAtCells = screen.getAllByTestId("created-at");
-
-    const timestamps = createdAtCells.map((el) => {
-      const date = parseCreatedAt(el.textContent);
-      return date.getTime();
-    });
-
-    const sortedTimestamps = [...timestamps].sort((a, b) => {
-      if (a === b) {
-        return 0;
-      }
-      return a < b ? 1 : -1;
-    });
-
-    expect(timestamps).toEqual(sortedTimestamps.toReversed());
-  });
-
-  it("should sort by ascending/descending if name button is clicked", async () => {
-    render(ManageConsultationsArchive, { consultations: CONSULTATIONS });
-
-    const nameSortButton = screen.getByRole("button", {
-      name: "sort consultations by Name",
-    });
-
-    const user = userEvent.setup();
-    await user.click(nameSortButton);
-
-    let createdAtCells = screen.getAllByTestId("title");
-    let titles = createdAtCells.map((el) => el.textContent);
-
-    const sortedTimestamps = [...titles].sort((a, b) => {
-      if (a === b) {
-        return 0;
-      }
-      return a < b ? -1 : 1;
-    });
-
-    await waitFor(() => {
-      expect(titles).toEqual(sortedTimestamps);
-    });
-
-    await user.click(nameSortButton);
-
-    await waitFor(() => {
-      createdAtCells = screen.getAllByTestId("title");
-      titles = createdAtCells.map((el) => el.textContent);
-      expect(titles).toEqual(sortedTimestamps.toReversed());
-    });
   });
 
   it("should match snapshot initially", () => {
@@ -126,7 +27,7 @@ describe("ManageConsultationsArchive", () => {
 
     // Remove created at because pipeline timezone and local timezone
     // won't always be the same, causing snapshot conflict
-    const allCreatedAtCells = screen.getAllByTestId("created-at");
+    const allCreatedAtCells = screen.getAllByTestId("cell-createdAt");
     allCreatedAtCells.forEach((cell) => (cell.textContent = ""));
 
     expect(container).toMatchSnapshot();

--- a/frontend/src/components/screens/ManageConsultationsArchive/__snapshots__/ManageConsultationsArchive.test.ts.snap
+++ b/frontend/src/components/screens/ManageConsultationsArchive/__snapshots__/ManageConsultationsArchive.test.ts.snap
@@ -17,248 +17,573 @@ exports[`ManageConsultationsArchive > should match snapshot initially 1`] = `
   <!---->
    
   <div
-    class="mt-2 w-full md:w-1/3"
+    class="w-full"
   >
     <div
-      class="relative"
+      aria-atomic="true"
+      aria-live="polite"
+      class="sr-only"
     >
-      <label
-        class="sr-only"
-        for="search-consultations"
+      
+    </div>
+     
+    <div
+      class="flex justify-between items-center gap-2 pb-4 pt-2 svelte-e9ladz"
+    >
+      <div
+        class="flex flex-col gap-1"
       >
-        Search consultations
-      </label>
-       
-      <input
-        class="h-9 w-full p-1 border border-gray-300 rounded-xs focus:outline-2 focus:outline-yellow-300 svelte-1auzwdn"
-        id="search-consultations"
-        placeholder="Find consultation..."
-        type="text"
-      />
+        <label
+          class="sr-only svelte-ekj0e2"
+          data-melt-combobox-label=""
+          for="data-table-visible-columns-select"
+          id="data-table-visible-columns-select-label"
+        >
+          <span
+            class="text-sm font-medium text-neutral-900"
+          >
+            Visible columns
+          </span>
+        </label>
+         
+        <div
+          class="relative"
+        >
+          <div
+            class="absolute left-2 top-1/2 -translate-y-1/2"
+          >
+            <svg
+              aria-hidden="true"
+              class="fill-neutral-400"
+              height="1rem"
+              viewBox="0 -960 960 960"
+              width="1rem"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <!---->
+              <path
+                d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <!---->
+            </svg>
+            <!---->
+          </div>
+           
+          <input
+            aria-autocomplete="list"
+            aria-controls="data-table-visible-columns-select-menu"
+            aria-expanded="false"
+            aria-labelledby="data-table-visible-columns-select-label"
+            autocomplete="off"
+            class="w-full leading-8 flex items-center justify-between rounded-sm bg-white px-3 pr-12 text-black border border-neutral-300 pl-8 svelte-ekj0e2"
+            data-melt-combobox-input=""
+            data-melt-combobox-trigger=""
+            data-state="closed"
+            id="data-table-visible-columns-select"
+            placeholder="2 columns visible"
+            role="combobox"
+          />
+           
+          <div
+            class="absolute right-2 top-1/2 z-10 -translate-y-1/2 text-neutral-900 transition-transform -rotate-90 pointer-events-none svelte-ekj0e2"
+          >
+            <svg
+              aria-hidden="true"
+              class="fill-neutral-700"
+              height="1rem"
+              viewBox="0 -960 960 960"
+              width="1rem"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <!---->
+              <path
+                d="M480-344 240-584l56-56 184 184 184-184 56 56-240 240Z"
+              />
+              <!---->
+            </svg>
+            <!---->
+          </div>
+          <!---->
+        </div>
+      </div>
        
       <!---->
+      <!---->
        
+      <div
+        class="w-1/3 ml-auto text-sm svelte-e9ladz"
+      >
+        <div
+          class="relative"
+        >
+          <label
+            class="sr-only"
+            for="data-table-search-input"
+          >
+            Search
+          </label>
+           
+          <input
+            class="h-9 w-full p-1 border border-gray-300 rounded-xs focus:outline-2 focus:outline-yellow-300 pl-8 pr-4 svelte-1auzwdn"
+            id="data-table-search-input"
+            placeholder="Search consultations"
+            type="text"
+          />
+           
+          <!---->
+           
+          <div
+            class="absolute left-2 top-1/2 mt-0.5 -translate-y-1/2 transform"
+          >
+            <svg
+              aria-hidden="true"
+              class="fill-neutral-400"
+              height="1.2rem"
+              viewBox="0 -960 960 960"
+              width="1.2rem"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <!---->
+              <path
+                d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <!---->
+            </svg>
+            <!---->
+          </div>
+          <!---->
+        </div>
+        <!---->
+      </div>
       <!---->
     </div>
-    <!---->
+     
+    <div
+      class="max-h-[50rem] overflow-x-auto rounded-lg border border-neutral-200 bg-white svelte-e9ladz"
+    >
+      <table
+        class="min-w-full divide-y divide-neutral-200 svelte-e9ladz"
+      >
+        <caption
+          class="sr-only"
+        >
+          Data table
+        </caption>
+        <!---->
+        <thead
+          class="bg-neutral-50"
+        >
+          <tr>
+            <th
+              aria-sort="none"
+              class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
+              data-testid="header-name"
+              scope="col"
+            >
+              <!---->
+              <button
+                aria-label="Sort by Name"
+                aria-pressed="false"
+                class="text-xs cursor-pointer rounded-md py-0.5 px-1 border text-start border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
+                data-variant="ghost"
+                role="button"
+                tabindex="0"
+              >
+                <!---->
+                <!---->
+                <span>
+                  Name
+                </span>
+                 
+                <span
+                  aria-hidden="true"
+                  class="text-neutral-400"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="fill-neutral-500"
+                    height="1rem"
+                    viewBox="0 -960 960 960"
+                    width="1rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <!---->
+                    <path
+                      d="M320-440v-287L217-624l-57-56 200-200 200 200-57 56-103-103v287h-80ZM600-80 400-280l57-56 103 103v-287h80v287l103-103 57 56L600-80Z"
+                      xmlns="http://www.w3.org/2000/svg"
+                    />
+                    <!---->
+                  </svg>
+                  <!---->
+                </span>
+                
+                
+                
+              </button>
+              
+              <!---->
+            </th>
+            <th
+              aria-sort="descending"
+              class="px-4 py-3 text-left text-xs font-[500] tracking-wide text-neutral-600 svelte-e9ladz"
+              data-testid="header-createdAt"
+              scope="col"
+            >
+              <!---->
+              <button
+                aria-label="Sorted descending by Date Created. Click to sort ascending."
+                aria-pressed="true"
+                class="text-xs cursor-pointer rounded-md py-0.5 px-1 border text-start border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
+                data-variant="ghost"
+                role="button"
+                tabindex="0"
+              >
+                <!---->
+                <!---->
+                <span>
+                  Date Created
+                </span>
+                 
+                <span
+                  aria-hidden="true"
+                  class="text-neutral-400"
+                >
+                  <div
+                    class="-rotate-90"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="fill-neutral-500"
+                      height="1rem"
+                      viewBox="0 -960 960 960"
+                      width="1rem"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <!---->
+                      <path
+                        d="M647-440H160v-80h487L423-744l57-56 320 320-320 320-57-56 224-224Z"
+                        xmlns="http://www.w3.org/2000/svg"
+                      />
+                      <!---->
+                    </svg>
+                    <!---->
+                  </div>
+                  <!---->
+                </span>
+                
+                
+                
+              </button>
+              
+              <!---->
+            </th>
+            
+          </tr>
+        </thead>
+        <tbody
+          class="divide-y divide-neutral-200"
+        >
+          <!---->
+          <tr
+            class="transition-colors hover:bg-neutral-50 svelte-e9ladz"
+            data-testid="datatable-row"
+          >
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-name"
+            >
+              <!---->
+              <!---->
+              <!---->
+              <a
+                aria-label="View Consultation 4"
+                class="transition-colors duration-300 text-primary hover:underline"
+                data-testid="View Consultation 4"
+                href="/support/consultations/c-four"
+                role="button"
+                tabindex="0"
+                title=""
+              >
+                <!---->
+                Consultation 4
+                
+                
+              </a>
+              
+              
+              
+              <!---->
+            </td>
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-createdAt"
+            />
+            
+          </tr>
+          <tr
+            class="transition-colors hover:bg-neutral-50 svelte-e9ladz"
+            data-testid="datatable-row"
+          >
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-name"
+            >
+              <!---->
+              <!---->
+              <!---->
+              <a
+                aria-label="View Consultation 1"
+                class="transition-colors duration-300 text-primary hover:underline"
+                data-testid="View Consultation 1"
+                href="/support/consultations/c-one"
+                role="button"
+                tabindex="0"
+                title=""
+              >
+                <!---->
+                Consultation 1
+                
+                
+              </a>
+              
+              
+              
+              <!---->
+            </td>
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-createdAt"
+            />
+            
+          </tr>
+          <tr
+            class="transition-colors hover:bg-neutral-50 svelte-e9ladz"
+            data-testid="datatable-row"
+          >
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-name"
+            >
+              <!---->
+              <!---->
+              <!---->
+              <a
+                aria-label="View Consultation 3"
+                class="transition-colors duration-300 text-primary hover:underline"
+                data-testid="View Consultation 3"
+                href="/support/consultations/c-three"
+                role="button"
+                tabindex="0"
+                title=""
+              >
+                <!---->
+                Consultation 3
+                
+                
+              </a>
+              
+              
+              
+              <!---->
+            </td>
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-createdAt"
+            />
+            
+          </tr>
+          <tr
+            class="transition-colors hover:bg-neutral-50 svelte-e9ladz"
+            data-testid="datatable-row"
+          >
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-name"
+            >
+              <!---->
+              <!---->
+              <!---->
+              <a
+                aria-label="View Consultation 2"
+                class="transition-colors duration-300 text-primary hover:underline"
+                data-testid="View Consultation 2"
+                href="/support/consultations/c-two"
+                role="button"
+                tabindex="0"
+                title=""
+              >
+                <!---->
+                Consultation 2
+                
+                
+              </a>
+              
+              
+              
+              <!---->
+            </td>
+            <td
+              class="whitespace-nowrap px-4 py-3 text-sm text-neutral-700 svelte-e9ladz"
+              data-testid="cell-createdAt"
+            />
+            
+          </tr>
+          
+          <!---->
+        </tbody>
+      </table>
+    </div>
   </div>
    
   <div
-    class="overflow-x-auto"
+    class="mt-4 flex flex-wrap items-center justify-between gap-4 svelte-e9ladz"
   >
-    <table
-      class="w-full whitespace-nowrap text-left"
+    <p
+      class="text-sm text-neutral-600 svelte-e9ladz"
+      data-testid="visible-items-text"
     >
-      <thead
-        class="font-bold"
+      Showing 
+      <span
+        class="font-medium text-neutral-900"
       >
-        <tr>
-          <th
-            aria-sort="none"
-            class="py-2 pr-2"
-            data-testid="name-column"
+        1
+      </span>
+       - 
+      <span
+        class="font-medium text-gray-900 svelte-e9ladz"
+      >
+        4
+      </span>
+       of 
+      <span
+        class="font-medium text-neutral-900"
+      >
+        4
+      </span>
+    </p>
+     
+    <div
+      class="text-xs page-size-container svelte-e9ladz"
+    >
+      <div
+        class="flex items-center gap-4"
+      >
+        <label
+          class="mb-1 block text-base leading-5 text-neutral-900 md:text-lg md:leading-6 min-w-max"
+          for="data-table-page-size-select"
+        >
+          Page Size
+        </label>
+        <!---->
+         
+        <!---->
+         
+        <!---->
+         
+        <select
+          class="h-9 w-full rounded-xs border border-gray-300 bg-white p-1 text-neutral-700 focus:outline-2 focus:outline-yellow-300 disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-600 disabled:opacity-50"
+          id="data-table-page-size-select"
+          name="data-table-page-size-select"
+        >
+          <option
+            class="bg-white text-neutral-900"
+            data-testid="data-table-page-size-select-option"
+            selected=""
+            value="10"
           >
-            <!---->
-            <button
-              aria-controls="consultations-list"
-              aria-label="sort consultations by Name"
-              aria-pressed="false"
-              class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
-              data-variant="ghost"
-              role="button"
-              tabindex="0"
-            >
-              <!---->
-              <!---->
-              Name 
-              <!---->
-              
-              
-              
-            </button>
-            
-            <!---->
-          </th>
-          <th
-            aria-sort="descending"
-            class="py-2 pr-2"
-            data-testid="date-column"
+            10
+          </option>
+          <option
+            class="bg-white text-neutral-900"
+            data-testid="data-table-page-size-select-option"
+            value="50"
           >
-            <!---->
-            <button
-              aria-controls="consultations-list"
-              aria-label="sort consultations by Created At"
-              aria-pressed="true"
-              class="text-md cursor-pointer rounded-md py-1 px-2 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 svelte-1d0mdzt"
-              data-variant="ghost"
-              role="button"
-              tabindex="0"
-            >
-              <!---->
-              <!---->
-              Created At 
-              <div
-                class="transition-transform -rotate-90"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="fill-neutral-500"
-                  height="1rem"
-                  viewBox="0 -960 960 960"
-                  width="1rem"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <!---->
-                  <path
-                    d="M647-440H160v-80h487L423-744l57-56 320 320-320 320-57-56 224-224Z"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
-                  <!---->
-                </svg>
-                <!---->
-              </div>
-              <!---->
-              
-              
-              
-            </button>
-            
-            <!---->
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        id="consultations-list"
+            50
+          </option>
+          <option
+            class="bg-white text-neutral-900"
+            data-testid="data-table-page-size-select-option"
+            value="100"
+          >
+            100
+          </option>
+          <option
+            class="bg-white text-neutral-900"
+            data-testid="data-table-page-size-select-option"
+            value="250"
+          >
+            250
+          </option>
+          <option
+            class="bg-white text-neutral-900"
+            data-testid="data-table-page-size-select-option"
+            value="500"
+          >
+            500
+          </option>
+          
+        </select>
+      </div>
+      <!---->
+    </div>
+     
+    <nav
+      aria-label="Pagination"
+      class="flex items-center gap-1"
+    >
+      <!---->
+      <button
+        aria-label="Previous Page"
+        aria-pressed="false"
+        class="text-xs cursor-pointer rounded-md py-0.5 px-1 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 disabled disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed disabled:hover:bg-gray-200 disabled:hover:border-gray-300 disabled:hover:text-gray-400 svelte-1d0mdzt"
+        data-variant="ghost"
+        disabled=""
+        role="button"
+        tabindex="0"
       >
         <!---->
-        <tr
-          class="border-t hover:bg-gray-50"
-          data-testid="consultation-item"
-        >
-          <td
-            class="py-2 pr-2"
-            data-testid="title"
-          >
-            <!---->
-            <a
-              aria-label=""
-              class="transition-colors duration-300 text-primary hover:underline"
-              data-testid=""
-              href="/support/consultations/c-four"
-              role="button"
-              tabindex="0"
-              title=""
-            >
-              <!---->
-              Consultation 4
-              
-              
-            </a>
-            
-            <!---->
-          </td>
-          <td
-            class="py-2 pr-2"
-            data-testid="created-at"
-          />
-        </tr>
-        <tr
-          class="border-t hover:bg-gray-50"
-          data-testid="consultation-item"
-        >
-          <td
-            class="py-2 pr-2"
-            data-testid="title"
-          >
-            <!---->
-            <a
-              aria-label=""
-              class="transition-colors duration-300 text-primary hover:underline"
-              data-testid=""
-              href="/support/consultations/c-one"
-              role="button"
-              tabindex="0"
-              title=""
-            >
-              <!---->
-              Consultation 1
-              
-              
-            </a>
-            
-            <!---->
-          </td>
-          <td
-            class="py-2 pr-2"
-            data-testid="created-at"
-          />
-        </tr>
-        <tr
-          class="border-t hover:bg-gray-50"
-          data-testid="consultation-item"
-        >
-          <td
-            class="py-2 pr-2"
-            data-testid="title"
-          >
-            <!---->
-            <a
-              aria-label=""
-              class="transition-colors duration-300 text-primary hover:underline"
-              data-testid=""
-              href="/support/consultations/c-three"
-              role="button"
-              tabindex="0"
-              title=""
-            >
-              <!---->
-              Consultation 3
-              
-              
-            </a>
-            
-            <!---->
-          </td>
-          <td
-            class="py-2 pr-2"
-            data-testid="created-at"
-          />
-        </tr>
-        <tr
-          class="border-t hover:bg-gray-50"
-          data-testid="consultation-item"
-        >
-          <td
-            class="py-2 pr-2"
-            data-testid="title"
-          >
-            <!---->
-            <a
-              aria-label=""
-              class="transition-colors duration-300 text-primary hover:underline"
-              data-testid=""
-              href="/support/consultations/c-two"
-              role="button"
-              tabindex="0"
-              title=""
-            >
-              <!---->
-              Consultation 2
-              
-              
-            </a>
-            
-            <!---->
-          </td>
-          <td
-            class="py-2 pr-2"
-            data-testid="created-at"
-          />
-        </tr>
         <!---->
-      </tbody>
-    </table>
+        Previous
+        
+        
+        
+      </button>
+      
+      <!---->
+       
+      <span
+        aria-current="page"
+        class="px-2 text-xs text-neutral-600"
+        data-testid="current-page"
+      >
+        Page 1 of 1
+      </span>
+       
+      <!---->
+      <button
+        aria-label="Next Page"
+        aria-pressed="false"
+        class="text-xs cursor-pointer rounded-md py-0.5 px-1 border border-transparent transition-colors duration-300 self-start inline-flex gap-1 items-center hover:bg-gray-100 disabled disabled:bg-gray-200 disabled:text-gray-400 disabled:cursor-not-allowed disabled:hover:bg-gray-200 disabled:hover:border-gray-300 disabled:hover:text-gray-400 svelte-1d0mdzt"
+        data-variant="ghost"
+        disabled=""
+        role="button"
+        tabindex="0"
+      >
+        <!---->
+        <!---->
+        Next
+        
+        
+        
+      </button>
+      
+      <!---->
+    </nav>
   </div>
+  <!---->
+  <!---->
   
 </div>
 `;


### PR DESCRIPTION
## Context
The table on manage consultations screen lacks the functionality of DataTable and has duplicate logic.

## Changes proposed in this pull request
This PR replaces the existing table with the more powerful DataTable component which also reduces code repeat.

Screenshot:
<img width="2266" height="764" alt="image" src="https://github.com/user-attachments/assets/fdf4c901-d95c-4851-b1bb-6d40e961c5e4" />


## Guidance to review
View ManageConsultationsArchive on stories.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.test` files in the repo
