### PR TITLE
Elliotmoore/pro 582 consolidateremove duplicate sentry sdkcapture exception

### DIFF
--- a/backend/consultations/api/views/consultation.py
+++ b/backend/consultations/api/views/consultation.py
@@ -45,7 +45,6 @@ from hosting_environment import HostingEnvironment
 from ingest.jobs import (
     delete_consultation_job,
 )
-from sentry_context import capture_handled_sentry_exception
 
 logger = settings.LOGGER
 
@@ -261,14 +260,12 @@ class ConsultationViewSet(ModelViewSet):
             logger.warning(
                 "Consultation setup request failed validation: {detail}", detail=e.detail
             )
-            capture_handled_sentry_exception(e)
             return Response(
                 {"message": "An error occurred while starting the import"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to start consultation setup import job")
-            capture_handled_sentry_exception(e)
             return Response(
                 {"message": "An error occurred while starting the import"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -349,7 +346,6 @@ class ConsultationViewSet(ModelViewSet):
             logger.exception(
                 f"Error starting Find Themes job for consultation {consultation.title}"
             )
-            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to start Find Themes job",
@@ -414,7 +410,6 @@ class ConsultationViewSet(ModelViewSet):
                 "Failed to export selected themes to S3 for consultation {consultation_code}",
                 consultation_code=consultation.code,
             )
-            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to export themes to S3",
@@ -436,7 +431,6 @@ class ConsultationViewSet(ModelViewSet):
                 "Failed to submit ASSIGN_THEMES batch job for consultation {consultation_code}",
                 consultation_code=consultation.code,
             )
-            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to submit job to assign themes",
@@ -484,7 +478,6 @@ class ConsultationViewSet(ModelViewSet):
             s3_codes = s3.get_consultation_folders()
         except (ClientError, BotoCoreError) as e:
             logger.exception("Failed to list consultation folders from S3")
-            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": "Failed to list consultation folders",
@@ -571,12 +564,11 @@ class ConsultationViewSet(ModelViewSet):
                 },
                 status=status.HTTP_201_CREATED,
             )
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "Failed to add users to consultation {consultation_id}",
                 consultation_id=str(consultation.id),
             )
-            capture_handled_sentry_exception(e)
             return Response(
                 {"error": "Failed to add users to consultation"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -848,14 +840,13 @@ class ConsultationViewSet(ModelViewSet):
         # Export to S3
         try:
             export_selected_themes_to_s3(target)
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "S3 export failed after theme import for consultation {consultation_id} "
                 "({imported} themes saved to the database)",
                 consultation_id=str(target.id),
                 imported=imported_themes,
             )
-            capture_handled_sentry_exception(e)
             return Response(
                 {
                     "error": (

--- a/backend/sentry_context.py
+++ b/backend/sentry_context.py
@@ -1,7 +1,3 @@
-import sentry_sdk
-
-MANUAL_CAPTURE_TAG = "consult.manual_capture"
-
 # Error capture is independent of these rates: before_send runs regardless, so
 # lowering them doesn't drop errors.
 PROD_PERF_SAMPLE_RATE = 0.1
@@ -17,24 +13,8 @@ def default_perf_sample_rate(environment):
     return NON_PROD_PERF_SAMPLE_RATE
 
 
-def capture_handled_sentry_exception(error=None, **kwargs):
-    """Drop-in replacement for sentry_sdk.capture_exception for exceptions the
-    application already caught and is handling (e.g. converting to a 4xx/5xx
-    response). Tags the event so sentry_before_send always forwards it, regardless
-    of the handled/unhandled mechanism Sentry infers for manual captures.
-    """
-    new_kwargs = kwargs.copy()
-    new_kwargs["tags"] = {**kwargs.get("tags", {}), MANUAL_CAPTURE_TAG: "true"}
-    return sentry_sdk.capture_exception(error, **new_kwargs)
-
-
 def sentry_before_send(event, hint):
-    """Drops integration-captured handled exceptions. Manual captures also default to
-    handled=True, so capture_handled_sentry_exception tags them to bypass this.
-    """
-    if MANUAL_CAPTURE_TAG in event.get("tags", {}):
-        return event
-
+    """Drops handled exceptions — only uncaught exceptions reach Sentry."""
     try:
         mechanism = event["exception"]["values"][-1]["mechanism"]
         if mechanism and mechanism.get("handled") is True:

--- a/backend/tests/commands/test_prepare_environment.py
+++ b/backend/tests/commands/test_prepare_environment.py
@@ -11,7 +11,9 @@ from consultations.models import Consultation
 
 class TestPrepareEnvironment:
     @pytest.mark.django_db
-    @pytest.mark.parametrize("environment", ["prod", "preprod", "test", "", "unknown", "staging", "local"])
+    @pytest.mark.parametrize(
+        "environment", ["prod", "preprod", "test", "", "unknown", "staging", "local"]
+    )
     def test_does_not_reset_on_non_dev(self, settings, environment):
         settings.ENVIRONMENT = environment
 

--- a/backend/tests/unit/api/views/test_healthcheck_view.py
+++ b/backend/tests/unit/api/views/test_healthcheck_view.py
@@ -83,7 +83,9 @@ class TestHealthCheckView:
         for name in ALL_CHECK_NAMES:
             assert data["checks"][name] == OK
 
-    @pytest.mark.parametrize("failing_check,patch_target,apply_failure,exception", CRITICAL_FAILURE_CASES)
+    @pytest.mark.parametrize(
+        "failing_check,patch_target,apply_failure,exception", CRITICAL_FAILURE_CASES
+    )
     def test_critical_dependency_failure_returns_503(
         self, client, failing_check, patch_target, apply_failure, exception
     ):

--- a/backend/tests/unit/test_sentry_context.py
+++ b/backend/tests/unit/test_sentry_context.py
@@ -1,42 +1,11 @@
-from unittest.mock import patch
-
 import pytest
 
 from sentry_context import (
-    MANUAL_CAPTURE_TAG,
     NON_PROD_PERF_SAMPLE_RATE,
     PROD_PERF_SAMPLE_RATE,
-    capture_handled_sentry_exception,
     default_perf_sample_rate,
     sentry_before_send,
 )
-
-
-class TestCaptureHandledSentryException:
-    def test_tags_the_capture_as_manual(self):
-        error = ValueError("boom")
-
-        with patch("sentry_context.sentry_sdk.capture_exception") as mock_capture:
-            capture_handled_sentry_exception(error)
-
-        mock_capture.assert_called_once_with(error, tags={MANUAL_CAPTURE_TAG: "true"})
-
-    def test_preserves_caller_supplied_tags(self):
-        error = ValueError("boom")
-
-        with patch("sentry_context.sentry_sdk.capture_exception") as mock_capture:
-            capture_handled_sentry_exception(error, tags={"consultation_code": "ABC123"})
-
-        mock_capture.assert_called_once_with(
-            error,
-            tags={"consultation_code": "ABC123", MANUAL_CAPTURE_TAG: "true"},
-        )
-
-    def test_returns_the_underlying_capture_result(self):
-        with patch("sentry_context.sentry_sdk.capture_exception", return_value="event-id"):
-            result = capture_handled_sentry_exception(ValueError("boom"))
-
-        assert result == "event-id"
 
 
 def _event(mechanism=None, tags=None):
@@ -47,28 +16,15 @@ def _event(mechanism=None, tags=None):
 
 
 class TestSentryBeforeSend:
-    """capture_handled_sentry_exception tags manual captures so they always survive
-    filtering; only exceptions Sentry's own integrations marked handled=True (i.e.
-    already caught elsewhere) get dropped here."""
+    """Only uncaught exceptions reach Sentry; handled exceptions are dropped."""
 
-    def test_manually_tagged_capture_is_always_sent(self):
-        event = _event(
-            mechanism={"type": "generic", "handled": True},
-            tags={MANUAL_CAPTURE_TAG: "true"},
-        )
-
-        assert sentry_before_send(event, {}) is event
-
-    def test_drops_untagged_handled_exception(self):
-        """The core case: a plain sentry_sdk.capture_exception() call, with no
-        manual-capture tag, defaults to handled=True and must be dropped."""
+    def test_drops_handled_exception(self):
         event = _event(mechanism={"type": "generic", "handled": True})
 
         assert sentry_before_send(event, {}) is None
 
-    def test_still_drops_handled_exception_alongside_unrelated_tags(self):
-        """Only MANUAL_CAPTURE_TAG bypasses the filter - other tags on the event
-        don't count."""
+    def test_drops_handled_exception_with_tags(self):
+        """Tags on an event do not affect the handled filter."""
         event = _event(
             mechanism={"type": "generic", "handled": True},
             tags={"other_tag": "value"},
@@ -76,10 +32,16 @@ class TestSentryBeforeSend:
 
         assert sentry_before_send(event, {}) is None
 
-    def test_keeps_untagged_unhandled_exception(self):
+    def test_keeps_unhandled_exception(self):
         """e.g. mechanism={"type": "django", "handled": False} - an exception that
         escaped uncaught and was only caught by the Django integration."""
         event = _event(mechanism={"type": "django", "handled": False})
+
+        assert sentry_before_send(event, {}) is event
+
+    def test_keeps_event_with_no_mechanism(self):
+        """Events with no mechanism field pass through."""
+        event = _event()
 
         assert sentry_before_send(event, {}) is event
 

--- a/docs/architecture/decisions/0014-sentry-vs-logging-for-exceptions.md
+++ b/docs/architecture/decisions/0014-sentry-vs-logging-for-exceptions.md
@@ -1,0 +1,26 @@
+# 14. Sentry vs Logging for Exceptions
+
+Date: 2026-09-09
+
+## Status
+
+In Review
+
+## Context
+
+Sentry captures any uncaught exception in the system, but there are ways to include custom events into sentry exceptions
+with function calls. Following a discussion with the team we have reached a consensus on what to do with exceptions.
+
+## Decision
+
+Following a conversation in slack, it was decided that the observability stack will be able to surface excessive caught exceptions
+to the team, so pushing everything into sentry is duplicated traces, and extra noise.
+
+To achieve the desired outcome, we will remove the functions used to manually push events into sentry that bypass the sentry filter,
+and remove the calls to this function throughout the code.
+
+## Consequences
+
+- Sentry will only capture uncaught exceptions
+- Caught exceptions will continue to get logged into the observability stack
+- When the platform log collector is fully functional, this will enable us to build a dashboard and alerting for uncaught and caught exceptions

--- a/uv.lock
+++ b/uv.lock
@@ -328,7 +328,7 @@ requires-dist = [
     { name = "factory-boy", specifier = ">=3.3.3" },
     { name = "gunicorn", specifier = ">=26.1.0" },
     { name = "i-dot-ai-utilities", extras = ["auth", "otel-django"], specifier = ">=0.7.1rc1" },
-    { name = "openai", specifier = ">=2.52.0" },
+    { name = "openai", specifier = ">=3.3.1" },
     { name = "pgvector", specifier = ">=0.5.0" },
     { name = "psycopg", specifier = ">=3.3.4" },
     { name = "pydantic", specifier = ">=2.13.4" },
@@ -495,15 +495,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
-]
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -1032,28 +1023,28 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.15.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
-    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
-    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
-    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
-    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
-    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
-    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -1586,21 +1577,19 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "3.0.0"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/9c/ba0c292b4032ede74c249ca314ad64eb1bb5a03a843f6e01facb02f80cd8/openai-3.3.1.tar.gz", hash = "sha256:6f22807de1a976c932cecda620e8172a8c3fdbaeed29c7f21564e0c2410edf56", size = 1282113, upload-time = "2026-08-19T16:31:35.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/db/2b7a1b3de659bb82aef979116c74e809982b13e42c057759767552b5155f/openai-3.3.1-py3-none-any.whl", hash = "sha256:9652df7fdf8ee6f5bd58e0a12f2b1d414a18e0f06bb7a9a57c8643a5f5469bd3", size = 1690337, upload-time = "2026-08-19T16:31:32.812Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

Following conversations in the team, we found that manually pushing caught exceptions to sentry was probably creating more noise than it was worth. These will get flagged by the observability stack when that is in place.

## Changes proposed in this pull request

- Remove logic that manually captures caught exceptions in sentry
- Remove calls to manual capture function
- Update tests to match
- Ruff formatting in a couple files
