### PR TITLE
Elliotmoore/pro 457 document engineering ways of working

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,12 @@ Always use the PR template at `.github/PULL_REQUEST_TEMPLATE.md` when writing PR
 
 ---
 
+## Engineering standards
+
+Our engineering standards can be found in `CONTRIBUTING.md` and the files/sites linked to from that file.
+
+---
+
 ## Architecture
 
 ### High-Level Structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ found [here](https://github.com/i-dot-ai/config/tree/main/ways-of-working).
 
 ## Reviewers
 
-- **Always add one reviewer from the team.** PRs don't auto-request the whole team - a sinle person
+- **Always add one reviewer from the team.** PRs don't auto-request the whole team - a single person
   from the team will be automatically assigned when a PR is opened. (See
   [`CODEOWNERS`](.github/CODEOWNERS).)
 - **One approval is required to merge** (enforced by branch protection). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,14 @@ re-review. Reserve "request changes" for **blocking** issues.
   reviewer can then see just what changed since they last looked. Rebase on merge.
 - **Out-of-scope suggestions become a follow-up**, not scope creep in this PR. Open a
   Linear issue and link it.
+- Make commit messages concise and clear
+  - What problem are they solving?
+  - What files are affected?
+  - e.g. Corrected comment related to auth function header `AWS_HEADER_ID` in middleware.ts
 
 ## Merging
 
+- Only rebase a PR when the go-ahead has been given for the PR to be merged, to preserve history during reviews.
 - Rebase-merge to keep `main` history clean.
 - CI (build, tests, pre-commit, and the Claude auto-review) must be green. Don't merge
   around a red check without understanding why it's red.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ re-review. Reserve "request changes" for **blocking** issues.
 - **Reply, don't just resolve.** Push the fix, then reply (even briefly - "done",
   "fixed in `abc123`") so the reviewer knows what happened. If you disagree, say why
   rather than silently closing the thread.
+- If it is helpful to you, reply to the user with a checklist of actions to take from their comment,
+  so they know what you are working on.
 - **The commenter resolves the thread**, not the author - it signals they're satisfied.
   For plain **nit**s the author may resolve their own.
 - **Re-request review after non-trivial changes** (the 🔄 icon by the reviewer's name)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing
+
+How we work on this repo: raising pull requests, reviewing them, and the small
+conventions that keep review fast and low-friction. These are norms, not
+bureaucracy - the goal is smaller changes, clearer intent, and reviews that move
+quickly. If a rule is getting in the way of shipping something obvious, say so in
+the PR rather than working around it silently.
+
+For the optional tooling (Claude Code/OpenCode, GitHub CLI, Linear, Context7), see
+[docs/devex.md](docs/devex.md).
+
+## Coding standards
+
+We follow the GDS engineering standards found [here](https://gds-way.digital.cabinet-office.gov.uk/). We also have our
+own engineering standards that build on-top of this that can be
+found [here](https://github.com/i-dot-ai/config/tree/main/ways-of-working).
+
+## Pull requests
+
+- CICD will only run on the relevant changes, e.g. if only the frontend has been changed
+  then only the frontend tests will run. It is your responsibility to make sure no unintended
+  changes happen in a location that isn't tested automatically
+- **Branch off `main`.** Name branches should follow
+  Linear patterns, but if not possible then follow a `feat/...`, `fix/...`, `docs/...`, or `chore/...` pattern.
+- **Keep PRs small and focused** - one logical change. A reviewer should be able to
+  hold the whole diff in their head. If a change is genuinely large (a migration, a
+  refactor that touches many files), split it where you can and explain the shape in
+  the PR description.
+- **Fill in the template.** GitHub loads
+  [`.github/pull_request_template.md`](.github/pull_request_template.md) automatically:
+  say what changed and why, link the Linear issue (`PRO-*` if not done automatically by branch name),
+  point reviewers at where to start, and flag the PR size.
+- **Self-review first.** Read your own diff before requesting review - it catches
+  leftover debug code, stray files, and unclear naming, and respects reviewers' time.
+- **Keep the Linear issue up to date** as the PR moves through review - see the Linear
+  conventions in [docs/devex.md](docs/devex.md#linear).
+- **Double-check for AI leftovers** before requesting a review - excessive comments, imports out of place
+  or code that is needlessly complex are all mental fatigue for reviewers to look through.
+
+## Reviewers
+
+- **Always add one reviewer from the team.** PRs don't auto-request the whole team - a sinle person
+  from the team will be automatically assigned when a PR is opened. (See
+  [`CODEOWNERS`](.github/CODEOWNERS).)
+- **One approval is required to merge** (enforced by branch protection). 
+- **Be pragmatic about trivial PRs.** If the author flags a PR as *trivial* (a one-liner,
+  a typo, a comment), a single approval is enough - don't wait for only the assigned person to review it.
+- **Tag beyond the two where it helps.** Add other stakeholders as reviewers for
+  awareness, and if a change warrants a specific person's sign-off, tag or message them
+  explicitly asking for approval - and don't merge until they've approved.
+
+A reviewer can approve with open **nit**/**consider** comments - trust the author to
+handle them. Reserve "request changes" for **blocking** issues.
+
+## Addressing review comments
+
+- **Reply, don't just resolve.** Push the fix, then reply (even briefly - "done",
+  "fixed in `abc123`") so the reviewer knows what happened. If you disagree, say why
+  rather than silently closing the thread.
+- **The commenter resolves the thread**, not the author - it signals they're satisfied.
+  For plain **nit**s the author may resolve their own.
+- **Re-request review after non-trivial changes** (the 🔄 icon by the reviewer's name)
+  so it re-enters their queue - remember this is what gets your PR over the line once
+  you've addressed the comments; a reviewer won't necessarily come back on their own.
+- **Prefer follow-up commits over force-pushes** while a review is in progress - a
+  reviewer can then see just what changed since they last looked. Rebase on merge.
+- **Out-of-scope suggestions become a follow-up**, not scope creep in this PR. Open a
+  Linear issue and link it.
+
+## Merging
+
+- Rebase-merge to keep `main` history clean.
+- CI (build, tests, pre-commit, and the Claude auto-review) must be green. Don't merge
+  around a red check without understanding why it's red.
+
+## Keeping the PR list healthy
+
+As a team we keep on top of stale PRs rather than letting them pile up. If a PR has gone
+quiet, don't just close it - **check with the author first**: it may be waiting on a
+re-review, blocked on something, or still wanted. Nudge it forward, hand it off, or close
+it by agreement.
+
+## Dependabot
+
+Dependabot will auto-merge minor and patch version bumps. If you see a dependabot PR that is stuck
+only because the branch is out of date, comment `@dependabot rebase` to force a rebase. This should
+merge the PR when the branch is up-to-date.
+
+Major dependabot PRs are opened in Linear as issues, with a person assigned to them. It is that persons
+responsibility to check with relevant people whether the changes in the PR are acceptable or breaking,
+and resolve any issues with failing CICD due to the package update.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,29 @@ re-review. Reserve "request changes" for **blocking** issues.
   the branch before merging.
 - **Out-of-scope suggestions become a follow-up**, not scope creep in this PR. Open a
   Linear issue and link it.
-- Make commit messages concise and clear
-  - What problem are they solving?
-  - What files are affected?
-  - e.g. Corrected comment related to auth function header `AWS_HEADER_ID` in middleware.ts
+- Make commit messages precise and clear
+  - What problem does the commit solve?
+  - What files/directories are affected?
+  - What Linear issue is the commit related to?
+
+Examples of a good commit for small changes, which includes the Linear issue number,
+the change intent and the file affected:
+
+```
+PRO-123: Corrected comment related to auth function header `AWS_HEADER_ID` in middleware.ts
+```
+
+or for larger changes, which includes the directories and what changed, the intent, 
+and the Linear issue number:
+
+```
+themefinder/evals: Add new get_settings and eval_settings singleton for loading env variables and settings for evaluation framework.
+                   Add new eval_types.py for defining types used in evaluation framework.
+                   Move util files into new directory and create module
+themefinder/evals/tests: Add new test_settings.py for testing settings and env variable loading. Update other tests to use new settings and util module.
+
+                         pro-615 Groundwork for refactor of evaluation framework to use new settings and util module and eval types.
+```
 
 ## Merging
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,8 @@ found [here](https://github.com/i-dot-ai/config/tree/main/ways-of-working).
   hold the whole diff in their head. If a change is genuinely large (a migration, a
   refactor that touches many files), split it where you can and explain the shape in
   the PR description.
-- **Fill in the template.** GitHub loads
-  [`.github/pull_request_template.md`](.github/pull_request_template.md) automatically:
+- **Fill in the template.** (or even better, get your coding agent to do it, but don't make it too verbose)
+  GitHub loads [`.github/pull_request_template.md`](.github/pull_request_template.md) automatically:
   say what changed and why, link the Linear issue (`PRO-*` if not done automatically by branch name),
   point reviewers at where to start, and flag the PR size.
 - **Self-review first.** Read your own diff before requesting review - it catches

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ found [here](https://github.com/i-dot-ai/config/tree/main/ways-of-working).
   point reviewers at where to start, and flag the PR size.
 - **Self-review first.** Read your own diff before requesting review - it catches
   leftover debug code, stray files, and unclear naming, and respects reviewers' time.
+- If you self-review and catch fixes that you are going to look at, raise them as a comment with a checkbox
+  yourself, so that reviewers know they don't need to review this part.
 - **Keep the Linear issue up to date** as the PR moves through review - see the Linear
   conventions in [docs/devex.md](docs/devex.md#linear).
 - **Double-check for AI leftovers** before requesting a review - excessive comments, imports out of place

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,10 @@ found [here](https://github.com/i-dot-ai/config/tree/main/ways-of-working).
 - CICD will only run on the relevant changes, e.g. if only the frontend has been changed
   then only the frontend tests will run. It is your responsibility to make sure no unintended
   changes happen in a location that isn't tested automatically
-- **Branch off `main`.** Name branches should follow
-  Linear patterns, but if not possible then follow a `feat/...`, `fix/...`, `docs/...`, or `chore/...` pattern.
+- **Branch off `main`.** Name branches should follow the Linear patterns, this can be done simply by copying the branch
+  name from the Linear work item.
+- GitHub now supports [stacked PRs](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests), make
+  use of these when doing large pieces of work to break down individual pieces of reviewable code.
 - **Keep PRs small and focused** - one logical change. A reviewer should be able to
   hold the whole diff in their head. If a change is genuinely large (a migration, a
   refactor that touches many files), split it where you can and explain the shape in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,8 @@ re-review. Reserve "request changes" for **blocking** issues.
   so it re-enters their queue - remember this is what gets your PR over the line once
   you've addressed the comments; a reviewer won't necessarily come back on their own.
 - **Prefer follow-up commits over force-pushes** while a review is in progress - a
-  reviewer can then see just what changed since they last looked. Rebase on merge.
+  reviewer can then see just what changed since they last looked. Manually rebase
+  the branch before merging.
 - **Out-of-scope suggestions become a follow-up**, not scope creep in this PR. Open a
   Linear issue and link it.
 - Make commit messages concise and clear

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,9 @@ found [here](https://github.com/i-dot-ai/config/tree/main/ways-of-working).
   awareness, and if a change warrants a specific person's sign-off, tag or message them
   explicitly asking for approval - and don't merge until they've approved.
 
-A reviewer can approve with open **nit**/**consider** comments - trust the author to
-handle them. Reserve "request changes" for **blocking** issues.
+A reviewer can approve with open **nit**/**consider** comments only when small **nit** comments are the
+only comments left on the PR that are unresolved - trust the author to handle the nit comments without a need for a
+re-review. Reserve "request changes" for **blocking** issues.
 
 ## Addressing review comments
 

--- a/docs/devex.md
+++ b/docs/devex.md
@@ -25,12 +25,10 @@ site has instructions on how to set up both claude code and OpenCode configs.
 MCP (Model Context Protocol) servers give the agent extra tools; plugins bundle skills
 and MCP servers together. The suggested set for this repo:
 
-### Suggested MCP servers / plugins
-
 | Tool                                                                      | Type       | What it's for                                         | Setup                                                                     |
 |---------------------------------------------------------------------------|------------|-------------------------------------------------------|---------------------------------------------------------------------------|
 | [GitHub CLI (`gh`)](https://cli.github.com/)                              | CLI        | Open PRs, check CI, read failed job logs              | `brew install gh` then `gh auth login`                                    |
-| [Linear MCP](https://linear.app/docs/mcp)                                 | MCP server | Read/update `EDU-*` issues, attach PRs, create issues | `claude mcp add --transport sse linear-server https://mcp.linear.app/sse` |
+| [Linear MCP](https://linear.app/docs/mcp)                                 | MCP server | Read/update `PRO-*` issues, attach PRs, create issues | `claude mcp add --transport sse linear-server https://mcp.linear.app/sse` |
 | [Context7](https://context7.com/) | MCP Server | Finds up-to-date docs for relevant tools/techniques   | `npx ctx7 setup`, then get API key from the site                          |
 
 ### GitHub CLI (`gh`)

--- a/docs/devex.md
+++ b/docs/devex.md
@@ -61,13 +61,15 @@ Conventions:
   PR on the issue. You can copy the branch name from the Linear item to link them from creation time.
 - If an issue is only partly delivered, note that in the description rather than closing
   it (e.g. "engineering done, content outstanding"). Raise the follow-up ticket.
+- Use a checkbox list in the PR description to list any follow-up actions that are needed, such as raising
+  a follow-up ticket, and check them as complete when they are done.
 - Sub-issues that ship in the same PR as their parent get closed together.
 - Respect the planned backlog: pick up prioritised work rather than starting something
   off-plan. Adding **sub-issues** under an existing ticket is fine, but avoid doing
   unplanned work and then raising a **top-level ticket** to describe what you already
   built - that bypasses prioritisation. If new work seems worth doing, raise it as an
   issue and let it be prioritised before picking it up.
-- Similar to above, follow the milestones and targets set out by the project tech-lead
+- Similar to above, follow the milestones and targets set out by the project tech-lead.
 
 
 ## Safety notes

--- a/docs/devex.md
+++ b/docs/devex.md
@@ -1,0 +1,78 @@
+# Developer experience
+
+Notes on tooling that speeds up work on this repo. Everything here is optional and
+per-developer - none of it is required to build or run the app, and no shared
+credentials or config are committed (auth is individual, via your own accounts).
+
+## Agentic coding
+
+We use [Claude Code](https://claude.com/claude-code) or [Opencode](https://opencode.ai/) for agentic coding on this repo.
+It's most useful here when paired with a few integrations: the **GitHub CLI** for PRs
+and CI, plus MCP servers/plugins for **Linear** (issues) and **Context7** (up-to-date docs).
+
+### Model access via the i.AI LiteLLM gateway
+
+Point your coding agent at the **i.AI LiteLLM gateway** rather than
+the native provider API. For repos handling Official-Sensitive information this keeps
+prompt and code context inside our managed gateway for security and privacy, gives us
+central control of model access and spend, and lets model versions be upgraded centrally.
+
+The [`ai gateway tooling docs`](https://llm-gateway-console.i.ai.gov.uk/tooling)
+site has instructions on how to set up both claude code and OpenCode configs.
+
+### Suggested MCP servers / plugins
+
+MCP (Model Context Protocol) servers give the agent extra tools; plugins bundle skills
+and MCP servers together. The suggested set for this repo:
+
+### Suggested MCP servers / plugins
+
+| Tool                                                                      | Type       | What it's for                                         | Setup                                                                     |
+|---------------------------------------------------------------------------|------------|-------------------------------------------------------|---------------------------------------------------------------------------|
+| [GitHub CLI (`gh`)](https://cli.github.com/)                              | CLI        | Open PRs, check CI, read failed job logs              | `brew install gh` then `gh auth login`                                    |
+| [Linear MCP](https://linear.app/docs/mcp)                                 | MCP server | Read/update `EDU-*` issues, attach PRs, create issues | `claude mcp add --transport sse linear-server https://mcp.linear.app/sse` |
+| [Context7](https://context7.com/) | MCP Server | Finds up-to-date docs for relevant tools/techniques   | `npx ctx7 setup`, then get API key from the site                          |
+
+### GitHub CLI (`gh`)
+
+Used for everything PR- and CI-related from the terminal.
+
+```bash
+gh pr create --base main --title "..." --body "..."   # open a PR
+gh pr checks <number>                                 # CI status for a PR
+gh run view --job <job-id> --log-failed               # logs for a failed job
+gh pr list --state merged --limit 20                  # recent merged PRs
+```
+
+Coding agents drive `gh` directly, so once authenticated it can open PRs and inspect CI
+on your behalf. Follow repo conventions: branch off `main`, and only commit or push when
+you intend to. For PR and review conventions, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+### Linear
+
+Our work is tracked in the **Consult** workspace, largely in the **Product** team (issue keys `PRO-*`). The Linear
+MCP lets the agent list what's in progress, move issues to Done as their PRs merge,
+attach PR links, and create issues for new work. First use opens a browser to authorise
+against your Linear account.
+
+Conventions:
+
+- Keep status honest: **In Review** when a PR is open, **Done** when it merges; link the
+  PR on the issue. You can copy the branch name from the Linear item to link them from creation time.
+- If an issue is only partly delivered, note that in the description rather than closing
+  it (e.g. "engineering done, content outstanding"). Raise the follow-up ticket.
+- Sub-issues that ship in the same PR as their parent get closed together.
+- Respect the planned backlog: pick up prioritised work rather than starting something
+  off-plan. Adding **sub-issues** under an existing ticket is fine, but avoid doing
+  unplanned work and then raising a **top-level ticket** to describe what you already
+  built - that bypasses prioritisation. If new work seems worth doing, raise it as an
+  issue and let it be prioritised before picking it up.
+- Similar to above, follow the milestones and targets set out by the project tech-lead
+
+
+## Safety notes
+
+- Coding agents should ask before hard-to-reverse or outward-facing actions (pushing, opening PRs,
+  posting comments). Approve deliberately.
+- Never commit secrets or personal agent state. `.claude/settings.local.json` is
+  per-developer and stays local; real env values live in SSM, not the repo.


### PR DESCRIPTION
## Context

We need to document our ways of working, and make them available to AI coding agents

## Changes proposed in this pull request

- Added devex.md that explains the tools and processes we use
- Added CONTRIBUTING.md that outlines more in-depth practices around PRs, issues, comments and engineering standards
- Linked to CONTRIBUTING.md from AGENTS.md so an AI agent looks at them by default



More relevant docs will come out of this PR https://github.com/i-dot-ai/config/pull/23 that will possibly supersede some of this
